### PR TITLE
chore(core): sync package version with npm registry

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitgov/core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SDK for the GitGovernance ecosystem, providing a type-safe, local-first API to manage identities, agents, and workflows.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Problem

semantic-release tried to publish v1.0.1 but it already exists in npm, causing the release to fail.

## Solution

Update package.json version to 1.0.1 (matching npm) so semantic-release will calculate the next version as 1.0.2.

## Current State

- npm registry: 1.0.0, 1.0.1
- package.json (before): 1.0.0
- package.json (after): 1.0.1  
- Next release will be: 1.0.2