### PR TITLE
fix(cli): update core dependency to use fixed v1.0.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitgov/cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "🚀 AI-first governance CLI for intelligent work. Install with `npm install -g @gitgov/cli` and start governing your projects with interactive dashboards, task management, and workflow automation.",
   "type": "module",
   "main": "build/dist/gitgov.mjs",
@@ -45,7 +45,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gitgovernance/monorepo.git",
+    "url": "git+https://github.com/gitgovernance/monorepo.git",
     "directory": "packages/cli"
   },
   "homepage": "https://github.com/gitgovernance/monorepo/tree/main/packages/cli#readme",
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@gitgov/core": "^1.0.1",
+    "@gitgov/core": "^1.0.2",
     "commander": "^11.1.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Summary

Updates CLI to use the fixed `@gitgov/core@1.0.2` which now properly supports ES modules.

## Changes

- **Version**: Bump from `1.0.0` to `1.1.0` (avoids burned versions 1.0.1-1.0.31, 1.2.0-1.2.1)
- **Core dependency**: Update from `^1.0.1` to `^1.0.2`
- **Architecture**: Keep core as external dependency (not bundled)
- **Repository URL**: Normalize format for npm

## Why External Core?

We fixed `@gitgov/core` specifically to work as an external library with proper ES modules support. Using it externally provides:

- ✅ Smaller CLI package (~182kb vs 824kb bundled)
- ✅ Clean architecture (separation of concerns)
- ✅ Core can be used by other packages
- ✅ Core updates don't require CLI republish

## Dependencies

- **Requires**: `@gitgov/core@1.0.2` (already published ✅)
- **Follows**: PR #22 (core tsup fix)

## Task Reference

Refs: #1759460529-task-fix-core-package-es-modules-resolution-error

## Testing

✅ Local build: `pnpm build` succeeds  
✅ Package size: ~182kb (external core)  
✅ CLI runs correctly with core@1.0.2

## Release Impact

**Type**: `fix` → Will trigger **PATCH** version bump  
**Expected Version**: `@gitgov/cli@1.1.1` (semantic-release from 1.1.0 base)  
**Scope**: CLI package only