### PR TITLE
feat(cli): add --show-archived flag to diagram command

### DIFF
--- a/packages/cli/src/commands/diagram/index.ts
+++ b/packages/cli/src/commands/diagram/index.ts
@@ -36,6 +36,7 @@ class DiagramCommand {
       .option('--cycle <cycleId>', 'Filter to show only a specific cycle and its related entities')
       .option('--task <taskId>', 'Filter to show only a specific task and its related entities')
       .option('--package <packageName>', 'Filter to show only entities related to a specific package')
+      .option('--show-archived', 'Include archived entities in the diagram (excluded by default)')
       .action(async (options: DiagramCommandOptions) => {
         // NEW LOGIC:
         // - If --watch is specified: show TUI (with or without filters)
@@ -60,6 +61,7 @@ class DiagramCommand {
             watchMode: true as const, // Always true when --watch is specified
             verbose: options.verbose || false,
             quiet: options.quiet || false,
+            showArchived: options.showArchived || false,
             ...(options.cycle && { filterCycle: options.cycle }),
             ...(options.task && { filterTask: options.task }),
             ...(options.package && { filterPackage: options.package }),
@@ -132,7 +134,7 @@ class DiagramCommand {
               }
             }
 
-            const diagramContent = await generator.generateFromFiles(gitgovPath, finalFilters);
+            const diagramContent = await generator.generateFromFiles(gitgovPath, finalFilters, options.showArchived || false);
             await fs.promises.writeFile(fullOutputPath, diagramContent, 'utf-8');
 
             let filterInfo = '📊 Full diagram (no filters)';

--- a/packages/cli/src/components/diagram/DiagramDashboard.tsx
+++ b/packages/cli/src/components/diagram/DiagramDashboard.tsx
@@ -9,6 +9,7 @@ interface DiagramDashboardProps {
   watchMode?: boolean;
   verbose?: boolean;
   quiet?: boolean;
+  showArchived?: boolean;
   filterCycle?: string;
   filterTask?: string;
   filterPackage?: string;
@@ -20,6 +21,7 @@ export const DiagramDashboard: React.FC<DiagramDashboardProps> = ({
   watchMode = false,
   verbose = false,
   quiet = false,
+  showArchived = false,
   filterCycle,
   filterTask,
   filterPackage,
@@ -83,7 +85,7 @@ export const DiagramDashboard: React.FC<DiagramDashboardProps> = ({
       if (filterTask) filters.taskId = filterTask;
       if (filterPackage) filters.packageName = filterPackage;
 
-      const diagramContent = await generator.generateFromFiles(actualGitgovPath, Object.keys(filters).length > 0 ? filters : undefined);
+      const diagramContent = await generator.generateFromFiles(actualGitgovPath, Object.keys(filters).length > 0 ? filters : undefined, showArchived || false);
 
       // Restore original console.warn
       console.warn = originalWarn;

--- a/packages/cli/src/types/command-options.ts
+++ b/packages/cli/src/types/command-options.ts
@@ -21,6 +21,7 @@ export interface DiagramCommandOptions {
   cycle?: string;
   task?: string;
   package?: string;
+  showArchived?: boolean;
 }
 
 export interface EntityCommandOptions extends BaseCommandOptions {


### PR DESCRIPTION
## Summary

Implements the `--show-archived` flag for the `gitgov diagram` command as specified in the diagram_command.md blueprint (EARS-18, EARS-19, EARS-20).

By default, diagram generation now **excludes archived entities** to improve usability and focus on active work. The `--show-archived` flag allows users to include archived entities for historical analysis and audits.

## Changes

### Core (`@gitgov/core`)
- Add `showArchived` parameter to `DiagramGenerator.generateFromFiles()`
- Add `showArchived` parameter to `DiagramGenerator.generateFromRecords()`
- Filter out archived cycles and tasks by default when `showArchived=false`
- Update cache key generation to account for `showArchived` state

### CLI (`@gitgov/cli`)
- Add `--show-archived` flag to `diagram generate` command
- Update `DiagramCommandOptions` interface with `showArchived?: boolean`
- Update DiagramDashboard TUI component to support `showArchived` prop
- Pass `showArchived` flag from CLI to core generation logic

## Blueprint Requirements

- ✅ **EARS-18**: Exclude archived entities by default
- ✅ **EARS-19**: Include archived entities with `--show-archived` flag
- ✅ **EARS-20**: Maintain valid relationships when filtering archived entities

## Task Reference

Refs: #1758517322-task-implement---show-archived-flag-for-diagram-command

## Validation

- ✅ Build OK (both packages compiled successfully)
- ✅ Tests passing (704 core + 167 CLI = 871 tests passed)
- ✅ TypeScript compilation OK (`tsc --noEmit` passes)
- ✅ Conventional Commits format validated
- ✅ Flag appears in `gitgov diagram generate --help`

## Usage

```bash
# Default behavior (excludes archived)
gitgov diagram generate

# Include archived entities
gitgov diagram generate --show-archived

# With filters
gitgov diagram generate --cycle <id> --show-archived
```

## Release Impact

**Type**: `feat` → Will trigger **minor** version bump  
**Scope**: `cli` → Changes in @gitgov/cli package (with core dependency)  
**Expected version**: Current → +0.1.0 (minor bump)