### PR TITLE
chore(cli): bump version to 1.3.0 to skip failed release

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitgov/cli",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "🚀 AI-first governance CLI for intelligent work. Install with `npm install -g @gitgov/cli` and start governing your projects with interactive dashboards, task management, and workflow automation.",
   "type": "module",
   "main": "build/dist/gitgov.mjs",


### PR DESCRIPTION
## Problem

Previous automated release to **1.2.0** failed during NPM publish step:

```
npm error 400 Bad Request - Cannot publish over previously published version "1.2.0"
```

This left the repository in an inconsistent state:
- ✅ semantic-release created tag **v1.2.0**
- ✅ CHANGELOG updated
- ❌ NPM publish **failed** 
- 📦 NPM registry still at **1.1.1**
- 📦 Repo package.json at **1.2.0**

## Solution

Manually bump to **1.3.0** to:
- Skip the problematic 1.2.0 version
- Resolve repo/NPM version inconsistency  
- Allow future releases to proceed cleanly

## Changes

- Update `packages/cli/package.json` version: `1.2.0` → `1.3.0`

## Next Steps

After merge:
1. semantic-release will skip (chore commit = no release)
2. Manual publish: `cd packages/cli && npm publish`
3. Or wait for next feat/fix commit for automated release

## Release Impact

**Type**: `chore` → **No** automatic version bump  
**Scope**: `cli` → Manual version correction only