### PR TITLE
feat(cli,core): add cycle remove-task and move-task commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@gitgov/core": "^1.0.2",
+    "clipboardy": "^5.0.0",
     "commander": "^11.1.0"
   },
   "optionalDependencies": {

--- a/packages/cli/src/commands/cycle/cycle.ts
+++ b/packages/cli/src/commands/cycle/cycle.ts
@@ -7,6 +7,8 @@ import type {
   CycleActivateOptions,
   CycleCompleteOptions,
   CycleAddTaskOptions,
+  CycleRemoveTaskOptions,
+  CycleMoveTaskOptions,
   CycleEditOptions,
   CycleAddChildOptions
 } from './cycle-command';
@@ -114,6 +116,33 @@ export function registerCycleCommands(program: Command): void {
     .option('-q, --quiet', 'Minimal output for scripting')
     .action(async (cycleId: string, options: CycleAddTaskOptions) => {
       await cycleCommand.executeAddTask(cycleId, options);
+    });
+
+  // gitgov cycle remove-task
+  cycle
+    .command('remove-task <cycleId>')
+    .description('Remove TaskRecord from CycleRecord with bidirectional unlinking')
+    .alias('rt')
+    .requiredOption('-t, --task <taskIds>', 'Task IDs to remove from the cycle (comma-separated)')
+    .option('--json', 'Output in JSON format')
+    .option('-v, --verbose', 'Show unlinking process details')
+    .option('-q, --quiet', 'Minimal output for scripting')
+    .action(async (cycleId: string, options: CycleRemoveTaskOptions) => {
+      await cycleCommand.executeRemoveTask(cycleId, options);
+    });
+
+  // gitgov cycle move-task
+  cycle
+    .command('move-task <targetCycleId>')
+    .description('Move TaskRecord between CycleRecords atomically')
+    .alias('mt')
+    .requiredOption('-t, --task <taskIds>', 'Task IDs to move (comma-separated)')
+    .requiredOption('-f, --from <sourceCycleId>', 'Source cycle ID')
+    .option('--json', 'Output in JSON format')
+    .option('-v, --verbose', 'Show move process details')
+    .option('-q, --quiet', 'Minimal output for scripting')
+    .action(async (targetCycleId: string, options: CycleMoveTaskOptions) => {
+      await cycleCommand.executeMoveTask(targetCycleId, options);
     });
 
   // gitgov cycle edit


### PR DESCRIPTION
## Summary

Implements two essential cycle management commands for task reorganization workflows.

## Changes

### Core - BacklogAdapter (420 lines)
- **removeTasksFromCycle()**: Bidirectional unlinking of tasks from cycles
  - Validates task existence and cycle membership
  - Removes task ID from cycle's taskIds array
  - Removes cycle ID from task's cycleIds array
  - Maintains referential integrity
  - Supports batch processing

- **moveTasksBetweenCycles()**: Atomic task movement between cycles
  - Validates source and target cycles exist
  - Ensures tasks belong to source cycle
  - Atomically removes from source and adds to target
  - Rollback on partial failure
  - Transactional approach for consistency

### CLI - CycleCommand (315 lines)
- **cycle remove-task** (`rt` alias):
  ```bash
  gitgov cycle remove-task <cycleId> -t <taskIds>
  ```
  - Comma-separated task IDs for batch operations
  - JSON/verbose/quiet output modes
  - Cache invalidation after successful removal

- **cycle move-task** (`mt` alias):
  ```bash
  gitgov cycle move-task <targetCycleId> -f <sourceCycleId> -t <taskIds>
  ```
  - Atomic operation with rollback on failure
  - Better UX than manual remove + add
  - Prevents inconsistent intermediate states

### Tests (428 lines)
- BacklogAdapter unit tests (230 lines)
  - EARS-11: removeTasksFromCycle validation
  - EARS-12: moveTasksBetweenCycles validation
  - Edge cases: non-existent tasks/cycles, partial failures
  
- CycleCommand unit tests (198 lines)
  - CLI delegation to adapter
  - Error handling and user feedback
  - Cache invalidation behavior

### Documentation
- Updated `cycle_command.md` with new commands
- Updated `backlog_adapter.md` with new methods
- EARS requirements and traceability tables

## Use Cases

**Weekly Planning Reorganization:**
```bash
# Move tasks from Week 2 to Week 3
gitgov cycle move-task week-3-cycle -f week-2-cycle -t task1,task2,task3

# Remove completed tasks from active sprint
gitgov cycle remove-task sprint-5 -t completed-task-1,completed-task-2
```

**Batch Operations:**
```bash
# Clean up multiple misplaced tasks
gitgov cycle rt old-cycle -t task1,task2,task3,task4
```

## Task Reference
Refs: #1758521733-task-implement-gitgov-cycle-move-task-command

## Validation
- [x] Build OK (packages/cli and packages/core)
- [x] Unit tests passing (BacklogAdapter: EARS-11, EARS-12)
- [x] Unit tests passing (CycleCommand: EARS-11, EARS-12)
- [x] Help text complete and descriptive
- [x] Aliases working (rt, mt)
- [x] Batch processing tested
- [x] Bidirectional consistency maintained

## Release Impact
**Type**: feat → Will trigger **minor** version bump (1.4.0 → 1.5.0)
**Scope**: cli, core → Changes in @gitgov/cli and @gitgov/core packages
**Files**: 6 files changed, 736 insertions(+)

## Architecture
- ✅ Business logic in Core (BacklogAdapter) - reusable across clients
- ✅ CLI as thin layer - argument parsing and user feedback only
- ✅ Proper separation of concerns
- ✅ Comprehensive error handling and validation