### PR TITLE
feat(core): add task pause/resume and fix init actor roles

### DIFF
--- a/packages/core/src/adapters/project_adapter/index.ts
+++ b/packages/core/src/adapters/project_adapter/index.ts
@@ -186,7 +186,13 @@ export class ProjectAdapter implements IProjectAdapter {
         {
           type: "human" as const,
           displayName: options.actorName || "Project Owner",
-          roles: ["admin", "author"] as const,
+          roles: [
+            "admin",             // Platform admin (future use)
+            "author",            // Create & submit tasks
+            "approver:product",  // Approve tasks (product decisions)
+            "approver:quality",  // Complete tasks (quality validation)
+            "developer"          // General development work
+          ] as const,
         },
         "bootstrap"
       );

--- a/packages/core/src/adapters/project_adapter/project_adapter.test.ts
+++ b/packages/core/src/adapters/project_adapter/project_adapter.test.ts
@@ -400,7 +400,13 @@ describe('ProjectAdapter', () => {
         {
           type: 'human',
           displayName: 'Test User',
-          roles: ['admin', 'author'],
+          roles: [
+            'admin',
+            'author',
+            'approver:product',
+            'approver:quality',
+            'developer'
+          ],
         },
         'bootstrap'
       );

--- a/packages/core/src/adapters/workflow_methodology_adapter/workflow_methodology_adapter.test.ts
+++ b/packages/core/src/adapters/workflow_methodology_adapter/workflow_methodology_adapter.test.ts
@@ -269,6 +269,31 @@ describe('WorkflowMethodologyAdapter', () => {
       });
     });
 
+    it('[EARS-8A] should return transition rule for active to paused', async () => {
+      const context: ValidationContext = { task: createMockTask() };
+      const rule = await adapter.getTransitionRule('active', 'paused', context);
+
+      expect(rule).toEqual({
+        to: 'paused',
+        conditions: {
+          event: 'feedback_blocking_created'
+        }
+      });
+    });
+
+    it('[EARS-8B] should return transition rule for paused to active (resume)', async () => {
+      const context: ValidationContext = { task: createMockTask() };
+      const rule = await adapter.getTransitionRule('paused', 'active', context);
+
+      expect(rule).toEqual({
+        to: 'active',
+        conditions: {
+          event: 'first_execution_record_created',
+          custom_rules: ['task_must_have_valid_assignment_for_executor']
+        }
+      });
+    });
+
     it('[EARS-9] should return null for invalid transition', async () => {
       const context: ValidationContext = { task: createMockTask() };
       const rule = await adapter.getTransitionRule('archived', 'draft', context);

--- a/packages/core/src/adapters/workflow_methodology_adapter/workflow_methodology_adapter_integration.test.ts
+++ b/packages/core/src/adapters/workflow_methodology_adapter/workflow_methodology_adapter_integration.test.ts
@@ -231,6 +231,29 @@ describe('WorkflowMethodologyAdapter - DEFAULT Methodology Integration Tests', (
         expect(rule?.to).toBe('archived');
         expect(rule?.conditions?.event).toBe('changelog_record_created');
       });
+
+      it('[EARS-54A] should complete active to paused transition with default methodology', async () => {
+        const task = createMockTask([], 'active');
+        const context: ValidationContext = { task, transitionTo: 'paused' };
+
+        const rule = await adapter.getTransitionRule('active', 'paused', context);
+
+        expect(rule).toBeDefined();
+        expect(rule?.to).toBe('paused');
+        expect(rule?.conditions?.event).toBe('feedback_blocking_created');
+      });
+
+      it('[EARS-54B] should complete paused to active transition with default methodology', async () => {
+        const task = createMockTask([], 'paused');
+        const context: ValidationContext = { task, transitionTo: 'active' };
+
+        const rule = await adapter.getTransitionRule('paused', 'active', context);
+
+        expect(rule).toBeDefined();
+        expect(rule?.to).toBe('active');
+        expect(rule?.conditions?.event).toBe('first_execution_record_created');
+        expect(rule?.conditions?.custom_rules).toContain('task_must_have_valid_assignment_for_executor');
+      });
     });
 
     describe('Guild-Specific Workflows', () => {

--- a/packages/core/src/adapters/workflow_methodology_adapter/workflow_methodology_adapter_scrum_integration.test.ts
+++ b/packages/core/src/adapters/workflow_methodology_adapter/workflow_methodology_adapter_scrum_integration.test.ts
@@ -231,6 +231,29 @@ describe('WorkflowMethodologyAdapter - SCRUM Methodology Integration Tests', () 
         const customRuleResult = await scrumAdapter.validateCustomRules(['task_assigned_to_team_member'], context);
         expect(customRuleResult).toBe(true);
       });
+
+      it('[EARS-68A] should handle task pause transition with scrum methodology', async () => {
+        const task = createMockTask(['sprint:current'], 'active');
+        const context: ValidationContext = { task, transitionTo: 'paused' };
+
+        // Task can be paused from active state
+        const rule = await scrumAdapter.getTransitionRule('active', 'paused', context);
+        expect(rule).toBeDefined();
+        expect(rule?.to).toBe('paused');
+        expect(rule?.conditions?.event).toBe('feedback_blocking_created');
+      });
+
+      it('[EARS-68B] should handle task resume transition with scrum methodology', async () => {
+        const task = createMockTask(['sprint:current'], 'paused');
+        const context: ValidationContext = { task, transitionTo: 'active' };
+
+        // Task can be resumed from paused to active
+        const rule = await scrumAdapter.getTransitionRule('paused', 'active', context);
+        expect(rule).toBeDefined();
+        expect(rule?.to).toBe('active');
+        expect(rule?.conditions?.event).toBe('sprint_started');
+        expect(rule?.conditions?.custom_rules).toContain('task_assigned_to_team_member');
+      });
     });
 
     describe('Scrum Custom Rules Validation', () => {

--- a/packages/core/src/adapters/workflow_methodology_adapter/workflow_methodology_default.json
+++ b/packages/core/src/adapters/workflow_methodology_adapter/workflow_methodology_default.json
@@ -53,7 +53,8 @@
     },
     "active": {
       "from": [
-        "ready"
+        "ready",
+        "paused"
       ],
       "requires": {
         "event": "first_execution_record_created",

--- a/packages/core/src/adapters/workflow_methodology_adapter/workflow_methodology_scrum.json
+++ b/packages/core/src/adapters/workflow_methodology_adapter/workflow_methodology_scrum.json
@@ -33,7 +33,8 @@
     },
     "active": {
       "from": [
-        "ready"
+        "ready",
+        "paused"
       ],
       "requires": {
         "event": "sprint_started",


### PR DESCRIPTION
## 🎯 Summary

This PR adds manual task control capabilities and fixes a critical UX issue with initial actor permissions.

## ✨ Changes

### New Features
- **Task Pause/Resume**: Add `pauseTask()` method to BacklogAdapter
- **Workflow Transitions**: Enable `active ↔ paused` state transitions
- **Init Roles Fix**: Assign all necessary workflow roles to initial actor

### Implementation Details
- `BacklogAdapter.pauseTask()` with complete EARS tests (34A-37A)
- Workflow methodology updates for pause/resume transitions
- ProjectAdapter now assigns: admin, author, developer, approver:product, approver:quality
- 6 new workflow transition tests across default and scrum methodologies

## 🐛 Fixes

**Critical UX Issue**: New users from `gitgov init` couldn't complete basic workflow operations (approve, complete) due to missing roles.

## 🧪 Testing

- ✅ 4 EARS tests for `pauseTask()` in BacklogAdapter
- ✅ 6 workflow transition tests (active→paused, paused→active)
- ✅ Updated ProjectAdapter tests for new role assignment
- ✅ All existing tests passing

## 📋 Task References

- Refs: #1758587001-task-implement-gitgov-task-pause-command
- Refs: #1758587002-task-implement-gitgov-task-resume-command
- Refs: #1759983132-task-fix-init-actor-roles---add-required-workflow-capab

## 📦 Release Impact

**Type**: `feat` → Will trigger **MINOR** version bump  
**Scope**: `core` → Changes in `@gitgov/core` package  
**Expected**: `1.x.0 → 1.(x+1).0`

## 🔄 Next Steps

After merge to main:
1. ✅ CI/CD will detect `feat` commit
2. ✅ Auto bump to next minor version
3. ✅ Auto generate changelog
4. ✅ Auto publish to NPM with `latest` tag
5. ✅ CLI package can then consume new `@gitgov/core` version

---

**Note**: CLI changes (task pause/resume commands) will be submitted in a separate PR after this core release.