### PR TITLE
feat(cli): add task pause and resume commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@gitgov/core": "^1.0.2",
+    "@gitgov/core": "^1.1.0",
     "clipboardy": "^5.0.0",
     "commander": "^11.1.0"
   },

--- a/packages/cli/src/commands/task/task.ts
+++ b/packages/cli/src/commands/task/task.ts
@@ -7,6 +7,7 @@ import type {
   TaskSubmitOptions,
   TaskApproveOptions,
   TaskActivateOptions,
+  TaskPauseOptions,
   TaskResumeOptions,
   TaskCompleteOptions,
   TaskCancelOptions,
@@ -157,6 +158,19 @@ EXAMPLES:
     .option('-q, --quiet', 'Minimal output for scripting')
     .action(async (taskId: string, options: TaskActivateOptions) => {
       await taskCommand.executeActivate(taskId, options);
+    });
+
+  // gitgov task pause
+  task
+    .command('pause <taskId>')
+    .description('Pause active TaskRecord from active to paused with optional reason tracking')
+    .alias('p')
+    .option('-r, --reason <reason>', 'Reason for pausing (tracked in notes with [PAUSED] prefix)')
+    .option('--json', 'Output in JSON format')
+    .option('-v, --verbose', 'Show pause process details')
+    .option('-q, --quiet', 'Minimal output for scripting')
+    .action(async (taskId: string, options: TaskPauseOptions) => {
+      await taskCommand.executePause(taskId, options);
     });
 
   // gitgov task resume


### PR DESCRIPTION
## 🎯 Summary

This PR adds manual task control commands to the CLI, enabling users to pause and resume tasks from the command line.

## ✨ New Features

### Commands Added
```bash
# Pause an active task
gitgov task pause <id> [--reason "reason for pausing"]
gitgov task pause <id> -r "reason for pausing"

# Resume a paused task  
gitgov task resume <id>
```

### Implementation Details
- **TaskCommand.executePause()**: Orchestrates pause operation
- **TaskCommand.executeResume()**: Orchestrates resume operation
- **Command Registration**: Both commands registered in task.ts with aliases (`p`, `r`)
- **Core Dependency**: Updated to `@gitgov/core@^1.1.0` (provides pauseTask/resumeTask)

## 🧪 Testing

- ✅ 3 EARS tests for `executePause()` (EARS-18, 19, 23)
- ✅ 3 EARS tests for `executeResume()` (EARS-20, 21, 22)  
- ✅ All existing CLI tests passing

## 📦 Dependencies

**Updated:**
- `@gitgov/core`: `^1.0.2` → `^1.1.0`

This consumes the new `pauseTask()` and `resumeTask()` methods added to BacklogAdapter in [PR #31](https://github.com/gitgovernance/monorepo/pull/31).

## 🔗 Related PRs

- **PR #31**: `feat(core): add task pause/resume and fix init actor roles` ✅ Merged
  - Added `BacklogAdapter.pauseTask()`
  - Added workflow transitions for pause/resume
  - Published as `@gitgov/core@1.1.0`

## 📋 Task References

- Refs: #1758587001-task-implement-gitgov-task-pause-command
- Refs: #1758587002-task-implement-gitgov-task-resume-command

## 📦 Release Impact

**Type**: `feat` → Will trigger **MINOR** version bump  
**Scope**: `cli` → Changes in `@gitgov/cli` package  
**Expected**: `1.4.2 → 1.5.0`

## 🔄 After Merge

Once merged to main:
1. ✅ CI/CD will detect `feat(cli)` commit
2. ✅ Auto bump to `1.5.0` (minor)
3. ✅ Auto generate changelog
4. ✅ Auto publish `@gitgov/cli@1.5.0` to NPM with `latest` tag

## ✅ Pre-merge Checklist

- [x] Core dependency updated to latest version
- [x] All EARS tests implemented and passing
- [x] Commands registered with proper aliases
- [x] Conventional Commits format validated
- [x] Task references included

---

**Ready for review and merge!** 🚀