### PR TITLE
fix(cli): translate status command output to English

### DIFF
--- a/packages/cli/src/commands/status/status-command.test.ts
+++ b/packages/cli/src/commands/status/status-command.test.ts
@@ -213,7 +213,7 @@ describe('StatusCommand - Complete Unit Tests', () => {
       expect(mockIdentityAdapter.getCurrentActor).toHaveBeenCalled();
       expect(mockBacklogAdapter.getTasksAssignedToActor).toHaveBeenCalledWith('human:test-user');
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('👤 Actor: Test User'));
-      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('✅ Mi Trabajo (1 tasks)'));
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('✅ My Work (1 tasks)'));
     });
 
     it('[EARS-2] should execute global dashboard with --all flag', async () => {
@@ -342,7 +342,7 @@ describe('StatusCommand - Complete Unit Tests', () => {
       await statusCommand.execute({});
 
       expect(mockBacklogAdapter.getTasksAssignedToActor).toHaveBeenCalledWith('human:test-user');
-      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('✅ Mi Trabajo (1 tasks)'));
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('✅ My Work (1 tasks)'));
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Test Task'));
     });
 
@@ -350,14 +350,14 @@ describe('StatusCommand - Complete Unit Tests', () => {
       await statusCommand.execute({});
 
       expect(mockFeedbackAdapter.getAllFeedback).toHaveBeenCalled();
-      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('❗️ Feedback Pendiente (1)'));
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('❗️ Pending Feedback (1)'));
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Test blocking feedback'));
     });
 
     it('[EARS-14] should show active cycles with --cycles flag', async () => {
       await statusCommand.execute({ cycles: true });
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('🚀 Cycles Activos (1)'));
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('🚀 Active Cycles (1)'));
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Test Cycle'));
     });
   });
@@ -493,7 +493,7 @@ describe('StatusCommand - Complete Unit Tests', () => {
       expect(mockIdentityAdapter.getCurrentActor).toHaveBeenCalled();
       expect(mockBacklogAdapter.getTasksAssignedToActor).toHaveBeenCalled();
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('👤 Actor: Test User'));
-      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('✅ Mi Trabajo'));
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('✅ My Work'));
     });
 
     it('[EARS-27] should maintain data consistency across adapters', async () => {

--- a/packages/cli/src/commands/status/status-command.ts
+++ b/packages/cli/src/commands/status/status-command.ts
@@ -335,7 +335,7 @@ export class StatusCommand {
     console.log('');
 
     // My Work section
-    console.log(`✅ Mi Trabajo (${personalWork.assignedTasks.length} tasks)`);
+    console.log(`✅ My Work (${personalWork.assignedTasks.length} tasks)`);
     if (personalWork.assignedTasks.length > 0) {
       personalWork.assignedTasks.forEach(task => {
         const statusIcon = this.getStatusIcon(task.status);
@@ -352,7 +352,7 @@ export class StatusCommand {
 
     // Pending Feedback section
     if (personalWork.pendingFeedback.length > 0) {
-      console.log(`❗️ Feedback Pendiente (${personalWork.pendingFeedback.length})`);
+      console.log(`❗️ Pending Feedback (${personalWork.pendingFeedback.length})`);
       personalWork.pendingFeedback.forEach(feedback => {
         const typeIcon = feedback.type === 'blocking' ? '🔴' : feedback.type === 'question' ? '🟡' : '🔵';
         console.log(`  ${typeIcon} [${feedback.type}] ${feedback.id} - ${feedback.content}`);
@@ -362,7 +362,7 @@ export class StatusCommand {
 
     // Active Cycles section
     if (personalWork.activeCycles.length > 0 && (options.cycles || options.verbose)) {
-      console.log(`🚀 Cycles Activos (${personalWork.activeCycles.length})`);
+      console.log(`🚀 Active Cycles (${personalWork.activeCycles.length})`);
       personalWork.activeCycles.forEach(cycle => {
         const taskCount = cycle.taskIds?.length || 0;
         console.log(`  📊 ${cycle.title}: ${taskCount} tasks - Status: ${cycle.status}`);


### PR DESCRIPTION
## Summary

Translates Spanish user-facing messages in the status command to English, improving internationalization consistency.

## Changes
- Change 'Mi Trabajo' to 'My Work' in status command output
- Change 'Feedback Pendiente' to 'Pending Feedback'
- Change 'Cycles Activos' to 'Active Cycles'
- Update all test assertions to match English translations

## Task Reference
Refs: #1758572792-task-translate-status-command-implementation-from-spani

## Validation
- [x] All tests passing (27/27)
- [x] No linter errors
- [x] Conventional Commits format validated
- [x] Functionality preserved

## Release Impact
**Type**: `fix` → Will trigger **patch** version bump (e.g., 1.5.0 → 1.5.1)
**Scope**: `cli` → Changes in @gitgov/cli package
**Files**: 2 files changed, 8 insertions(+), 8 deletions(-)