### PR TITLE
chore(cli): update @gitgov/core dependency to v1.3.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@gitgov/core": "^1.2.0",
+    "@gitgov/core": "^1.3.0",
     "clipboardy": "^5.0.0",
     "commander": "^11.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
   packages/cli:
     dependencies:
       '@gitgov/core':
-        specifier: ^1.2.0
-        version: link:../core
+        specifier: ^1.3.0
+        version: 1.3.0
       clipboardy:
         specifier: ^5.0.0
         version: 5.0.0
@@ -615,6 +615,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@gitgov/core@1.3.0':
+    resolution: {integrity: sha512-gh0nZPAjw3p9pxs6ljegQfRh7z4QYoNpFbTy0brybZ6D0UsZBok1MdWH79fOU8AbzmCKGNs6yTf9bNXwvtQnOQ==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -3699,6 +3702,12 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.5':
     optional: true
+
+  '@gitgov/core@1.3.0':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      js-yaml: 4.1.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:


### PR DESCRIPTION
## Summary

Updates `@gitgov/core` dependency to v1.3.0 to include the deduplication fixes implemented in PR #37.

## Changes

- **Dependency Update**: `@gitgov/core` from ^1.2.0 to ^1.3.0
- **Includes from core v1.3.0**:
  - Deduplication logic in BacklogAdapter.getTasksAssignedToActor()
  - Duplicate assignment prevention in FeedbackAdapter.create()
  - +34 new tests in @gitgov/core

## Test Results

```
Tests:       204 passed, 12 skipped, 216 total
Test Suites: 10 passed, 10 total
Time:        3.921s
```

## Task Reference

Refs: #1758573347-task-fix-duplicate-task-display-in-personal-status-view

## Validation

- [x] Dependencies installed successfully
- [x] All CLI tests passing (204/204)
- [x] Conventional Commits format validated
- [x] Only dependency files updated (package.json + pnpm-lock.yaml)

## Release Impact

**Type**: `chore` → **No version bump** for CLI (dependency update only)  
**Scope**: `cli` → Changes in @gitgov/cli package  
**Note**: This brings the latest core fixes to CLI