### PR TITLE
fix(core): use require.resolve for agent prompt copy

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,8 @@
     ".": {
       "import": "./dist/src/index.js",
       "types": "./dist/src/index.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "clean": "rm -rf dist",

--- a/packages/core/src/adapters/project_adapter/index.ts
+++ b/packages/core/src/adapters/project_adapter/index.ts
@@ -521,28 +521,6 @@ export class ProjectAdapter implements IProjectAdapter {
   }
 
   private async copyAgentPrompt(gitgovPath: string): Promise<void> {
-    // Copy the official @gitgov agent prompt to the project
-    // 
-    // Solution A: Use require.resolve() with multiple fallback strategies
-    // This works reliably in ALL environments:
-    // - Development (monorepo with pnpm)
-    // - npm global install
-    // - npm local install
-    // - Different package managers (npm, pnpm, yarn)
-    // - Jest tests
-    //
-    // Strategy:
-    // 1️⃣ Monorepo development: src/prompts/ relative to cwd
-    // 2️⃣ NPM installation: use require.resolve() to find @gitgov/core package
-    // 3️⃣ Build fallback: relative to __dirname (for compiled distributable)
-    //
-    // Why this approach?
-    // - ✅ Node.js knows EXACTLY where packages are installed (require.resolve)
-    // - ✅ Handles monorepo development workflow
-    // - ✅ Works with all package managers
-    // - ✅ Graceful degradation with fallbacks
-    // - ✅ Jest compatible (import.meta resolved dynamically at runtime)
-
     // Helper function to safely get import.meta.url without triggering Jest parse errors
     function getImportMetaUrl(): string | null {
       try {


### PR DESCRIPTION
## Summary

Fixes agent prompt copy to work in both development (monorepo) and production (npm install) environments.

## Changes
- Use require.resolve('@gitgov/core/package.json') to locate npm package
- Add ./package.json to exports field (required for Node.js module resolution)
- Update tests to verify fs.copyFile behavior
- Graceful degradation with multiple fallback strategies

## Technical Details
**Strategy (3 fallbacks):**
1. Development: `process.cwd() + prompts/` (package root)
2. NPM install: `require.resolve('@gitgov/core/package.json')` → find prompts/
3. Build fallback: `__dirname + ../../prompts/` (relative path)

**Key Fix:**
Added `"./package.json": "./package.json"` to package.json exports field.
Without this, require.resolve fails with "Package subpath not defined" error.

## Validation
- ✅ All 23 unit tests passing
- ✅ npm pack/install scenario tested and working
- ✅ require.resolve correctly locates prompts/ in node_modules
- ✅ Jest-compatible (dynamic import.meta.url resolution)

## Release Impact
**Type**: fix → Will trigger **patch** version bump (1.6.1 → 1.6.2)
**Scope**: core → Changes in @gitgov/core package