### PR TITLE
feat(cli): implement lint command and update core dependency to 1.7.0

### DIFF
--- a/packages/cli/e2e/task_command_e2e.test.ts
+++ b/packages/cli/e2e/task_command_e2e.test.ts
@@ -122,13 +122,13 @@ describe('Task Delete CLI Command - E2E Tests', () => {
       header: {
         version: '1.0',
         type: 'task',
-        payloadChecksum: 'test-checksum',
+        payloadChecksum: 'a'.repeat(64), // Valid SHA-256 format (64 hex chars)
         signatures: [{
           keyId: 'human:test-user',
           role: 'creator',
           notes: 'E2E test task creation',
-          timestamp: new Date().toISOString(),
-          signature: 'test-signature'
+          timestamp: Date.now(), // Unix timestamp in ms
+          signature: 'A'.repeat(86) + '==' // Valid Ed25519 signature format (86 chars + ==)
         }]
       },
       payload: {
@@ -139,7 +139,6 @@ describe('Task Delete CLI Command - E2E Tests', () => {
         description: 'This task can be deleted',
         tags: ['test', 'draft'],
         cycleIds: [],
-        dependencies: [],
         references: [],
         notes: ''
       }
@@ -151,13 +150,13 @@ describe('Task Delete CLI Command - E2E Tests', () => {
       header: {
         version: '1.0',
         type: 'task',
-        payloadChecksum: 'test-checksum',
+        payloadChecksum: 'b'.repeat(64), // Valid SHA-256 format (64 hex chars)
         signatures: [{
           keyId: 'human:test-user',
           role: 'creator',
           notes: 'E2E test task creation',
-          timestamp: new Date().toISOString(),
-          signature: 'test-signature'
+          timestamp: Date.now(), // Unix timestamp in ms
+          signature: 'B'.repeat(86) + '==' // Valid Ed25519 signature format (86 chars + ==)
         }]
       },
       payload: {
@@ -168,7 +167,6 @@ describe('Task Delete CLI Command - E2E Tests', () => {
         description: 'This task cannot be deleted',
         tags: ['test', 'review'],
         cycleIds: [],
-        dependencies: [],
         references: [],
         notes: ''
       }
@@ -180,13 +178,13 @@ describe('Task Delete CLI Command - E2E Tests', () => {
       header: {
         version: '1.0',
         type: 'task',
-        payloadChecksum: 'test-checksum',
+        payloadChecksum: 'c'.repeat(64), // Valid SHA-256 format (64 hex chars)
         signatures: [{
           keyId: 'human:test-user',
           role: 'creator',
           notes: 'E2E test task creation',
-          timestamp: new Date().toISOString(),
-          signature: 'test-signature'
+          timestamp: Date.now(), // Unix timestamp in ms
+          signature: 'C'.repeat(86) + '==' // Valid Ed25519 signature format (86 chars + ==)
         }]
       },
       payload: {
@@ -197,7 +195,6 @@ describe('Task Delete CLI Command - E2E Tests', () => {
         description: 'This task cannot be deleted',
         tags: ['test', 'active'],
         cycleIds: [],
-        dependencies: [],
         references: [],
         notes: ''
       }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@gitgov/core": "1.6.4",
+    "@gitgov/core": "1.7.0",
     "clipboardy": "^5.0.0",
     "commander": "^11.1.0"
   },

--- a/packages/cli/src/base/base-command.ts
+++ b/packages/cli/src/base/base-command.ts
@@ -16,6 +16,8 @@ export abstract class BaseCommand<TOptions extends BaseCommandOptions = BaseComm
   implements ICompleteCommand<TOptions> {
 
   protected readonly dependencyService = DependencyInjectionService.getInstance();
+  protected readonly container = DependencyInjectionService.getInstance();
+  protected readonly logger = console;
 
   /**
    * Register the command with Commander.js

--- a/packages/cli/src/commands/init/init-command.test.ts
+++ b/packages/cli/src/commands/init/init-command.test.ts
@@ -75,7 +75,16 @@ jest.doMock('@gitgov/core', () => ({
       getRootCycle: jest.fn()
     }))
   },
-  Records: {}
+  Records: {},
+  Factories: {
+    loadTaskRecord: jest.fn((data) => data),
+    loadCycleRecord: jest.fn((data) => data),
+    loadActorRecord: jest.fn((data) => data),
+    loadAgentRecord: jest.fn((data) => data),
+    loadFeedbackRecord: jest.fn((data) => data),
+    loadExecutionRecord: jest.fn((data) => data),
+    loadChangelogRecord: jest.fn((data) => data)
+  }
 }));
 
 // Mock child_process for git config

--- a/packages/cli/src/commands/init/init-command.ts
+++ b/packages/cli/src/commands/init/init-command.ts
@@ -123,13 +123,15 @@ export class InitCommand {
       const projectRoot = process.env['GITGOV_ORIGINAL_DIR'] || process.cwd();
       const eventBus = new EventBus.EventBus();
 
-      const taskStore = new Store.RecordStore<Records.TaskRecord>('tasks', projectRoot);
-      const cycleStore = new Store.RecordStore<Records.CycleRecord>('cycles', projectRoot);
-      const actorStore = new Store.RecordStore<Records.ActorRecord>('actors', projectRoot);
-      const agentStore = new Store.RecordStore<Records.AgentRecord>('agents', projectRoot);
-      const feedbackStore = new Store.RecordStore<Records.FeedbackRecord>('feedback', projectRoot);
-      const executionStore = new Store.RecordStore<Records.ExecutionRecord>('executions', projectRoot);
-      const changelogStore = new Store.RecordStore<Records.ChangelogRecord>('changelogs', projectRoot);
+      const { Factories } = await import('@gitgov/core');
+
+      const taskStore = new Store.RecordStore<Records.TaskRecord>('tasks', Factories.loadTaskRecord, projectRoot);
+      const cycleStore = new Store.RecordStore<Records.CycleRecord>('cycles', Factories.loadCycleRecord, projectRoot);
+      const actorStore = new Store.RecordStore<Records.ActorRecord>('actors', Factories.loadActorRecord, projectRoot);
+      const agentStore = new Store.RecordStore<Records.AgentRecord>('agents', Factories.loadAgentRecord, projectRoot);
+      const feedbackStore = new Store.RecordStore<Records.FeedbackRecord>('feedback', Factories.loadFeedbackRecord, projectRoot);
+      const executionStore = new Store.RecordStore<Records.ExecutionRecord>('executions', Factories.loadExecutionRecord, projectRoot);
+      const changelogStore = new Store.RecordStore<Records.ChangelogRecord>('changelogs', Factories.loadChangelogRecord, projectRoot);
 
       // Create adapters
       const identityAdapter = new Adapters.IdentityAdapter({

--- a/packages/cli/src/commands/lint/lint-command.test.ts
+++ b/packages/cli/src/commands/lint/lint-command.test.ts
@@ -1,0 +1,711 @@
+// Mock @gitgov/core with complete adapter mocks
+jest.doMock('@gitgov/core', () => ({
+  Config: {
+    ConfigManager: {
+      findProjectRoot: jest.fn().mockReturnValue('/mock/project/root'),
+      findGitgovRoot: jest.fn().mockReturnValue('/mock/project/root/.gitgov'),
+      getGitgovPath: jest.fn().mockReturnValue('/mock/project/root/.gitgov'),
+      isGitgovProject: jest.fn().mockReturnValue(true)
+    }
+  },
+  Lint: {
+    LintModule: jest.fn(),
+    ValidatorType: {}
+  }
+}));
+
+// Mock DependencyInjectionService before importing
+jest.mock('../../services/dependency-injection', () => ({
+  DependencyInjectionService: {
+    getInstance: jest.fn()
+  }
+}));
+
+// Mock fs for file detection
+jest.mock('fs', () => ({
+  promises: {
+    stat: jest.fn(),
+    readFile: jest.fn()
+  }
+}));
+
+import { LintCommand } from './lint-command';
+import { DependencyInjectionService } from '../../services/dependency-injection';
+import { promises as fs } from 'fs';
+import type { Lint, Records, IdentityAdapter } from '@gitgov/core';
+
+// Mock console methods to capture output
+const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
+const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
+const mockProcessExit = jest.spyOn(process, 'exit').mockImplementation();
+
+// Get access to the mocked DependencyInjectionService
+const mockDI = jest.mocked(DependencyInjectionService);
+
+// Global references to the mock adapters for easy access in tests
+let mockLintModule: {
+  lint: jest.MockedFunction<(options?: Partial<Lint.LintOptions>) => Promise<Lint.LintReport>>;
+  lintFile: jest.MockedFunction<(filePath: string, options?: Partial<Lint.LintOptions>) => Promise<Lint.LintReport>>;
+  fix: jest.MockedFunction<(lintReport: Lint.LintReport, fixOptions?: Partial<Lint.FixOptions>) => Promise<Lint.FixReport>>;
+};
+
+let mockIdentityAdapter: {
+  getCurrentActor: jest.MockedFunction<() => Promise<Records.ActorRecord>>;
+};
+
+describe('LintCommand - Complete Unit Tests', () => {
+  let lintCommand: LintCommand;
+
+  const mockLintReport: Lint.LintReport = {
+    summary: {
+      filesChecked: 10,
+      errors: 2,
+      warnings: 3,
+      fixable: 2,
+      executionTime: 150
+    },
+    results: [
+      {
+        level: 'error',
+        filePath: '.gitgov/tasks/task1.json',
+        validator: 'SCHEMA_VALIDATION',
+        message: 'Missing required field: description',
+        entity: { type: 'task', id: 'task1' },
+        fixable: false
+      },
+      {
+        level: 'error',
+        filePath: '.gitgov/tasks/task2.json',
+        validator: 'SIGNATURE_STRUCTURE',
+        message: 'Invalid signature format',
+        entity: { type: 'task', id: 'task2' },
+        fixable: true
+      },
+      {
+        level: 'warning',
+        filePath: '.gitgov/tasks/task3.json',
+        validator: 'REFERENTIAL_INTEGRITY',
+        message: 'Reference to task:missing not found',
+        entity: { type: 'task', id: 'task3' },
+        fixable: false
+      }
+    ],
+    metadata: {
+      timestamp: new Date().toISOString(),
+      options: {} as Lint.LintOptions,
+      version: '1.0.0'
+    }
+  };
+
+  const mockFixReport: Lint.FixReport = {
+    summary: {
+      fixed: 2,
+      failed: 0,
+      backupsCreated: 2
+    },
+    fixes: [
+      {
+        success: true,
+        filePath: '.gitgov/tasks/task2.json',
+        validator: 'SIGNATURE_STRUCTURE',
+        action: 'Signature regenerated',
+        backupPath: '.gitgov/tasks/task2.json.backup-1234567890'
+      }
+    ]
+  };
+
+  const mockActor: Records.ActorRecord = {
+    id: 'human:test-user',
+    type: 'human',
+    displayName: 'Test User',
+    publicKey: 'test-public-key',
+    roles: ['author'],
+    status: 'active'
+  };
+
+  beforeEach(async () => {
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Create simple mock adapters
+    mockLintModule = {
+      lint: jest.fn(),
+      lintFile: jest.fn(),
+      fix: jest.fn()
+    };
+
+    mockIdentityAdapter = {
+      getCurrentActor: jest.fn()
+    };
+
+    // Create mock dependency service
+    const mockDependencyService = {
+      getLintModule: jest.fn().mockResolvedValue(mockLintModule),
+      getIdentityAdapter: jest.fn().mockResolvedValue(mockIdentityAdapter)
+    };
+
+    // Mock singleton getInstance
+    (DependencyInjectionService.getInstance as jest.MockedFunction<typeof DependencyInjectionService.getInstance>)
+      .mockReturnValue(mockDependencyService as never);
+
+    // Create fresh LintCommand instance
+    lintCommand = new LintCommand();
+
+    // Set up default successful responses
+    mockLintModule.lint.mockResolvedValue(mockLintReport);
+    mockLintModule.lintFile.mockResolvedValue(mockLintReport);
+    mockLintModule.fix.mockResolvedValue(mockFixReport);
+    mockIdentityAdapter.getCurrentActor.mockResolvedValue(mockActor);
+
+    // Mock fs.stat for file detection
+    (fs.stat as jest.Mock).mockRejectedValue(new Error('Not a file'));
+    (fs.readFile as jest.Mock).mockResolvedValue('mock-private-key');
+  });
+
+  afterEach(() => {
+    // Reset mocks after each test
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    mockProcessExit.mockClear();
+  });
+
+  // ==========================================================================
+  // EARS 1-3, 10-14: CLI Argument Parsing & Module Integration
+  // ==========================================================================
+
+  describe('CLI Argument Parsing & Module Integration (EARS 1-3, 10-14)', () => {
+    it('[EARS-1] should use default options when no args provided', async () => {
+      await lintCommand.execute({});
+
+      expect(mockLintModule.lint).toHaveBeenCalledWith({
+        path: '.gitgov/',
+        validateReferences: false,
+        validateActors: false,
+        validateConventions: true
+      });
+    });
+
+    it('[EARS-2] should map CLI flags to LintOptions correctly', async () => {
+      await lintCommand.execute({
+        path: '.gitgov/custom',
+        references: true,
+        actors: true,
+        format: 'text',
+        quiet: false
+      });
+
+      expect(mockLintModule.lint).toHaveBeenCalledWith({
+        path: '.gitgov/custom',
+        validateReferences: true,
+        validateActors: true,
+        validateConventions: true
+      });
+    });
+
+    it('[EARS-3] should handle module initialization errors', async () => {
+      const error = new Error('LintModule initialization failed');
+      const mockDependencyService = {
+        getLintModule: jest.fn().mockRejectedValue(error),
+        getIdentityAdapter: jest.fn().mockResolvedValue(mockIdentityAdapter)
+      };
+      (DependencyInjectionService.getInstance as jest.MockedFunction<typeof DependencyInjectionService.getInstance>)
+        .mockReturnValue(mockDependencyService as never);
+
+      // Create new command instance to use the new mock
+      const errorCommand = new LintCommand();
+      await errorCommand.execute({});
+
+      expect(mockConsoleError).toHaveBeenCalledWith('❌ Lint command failed:', error);
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it('[EARS-10] should detect file path and use lintFile for single files', async () => {
+      await lintCommand.execute({
+        path: '.gitgov/tasks/task1.json'
+      });
+
+      expect(mockLintModule.lintFile).toHaveBeenCalledWith(
+        '.gitgov/tasks/task1.json',
+        expect.objectContaining({
+          validateConventions: true
+        })
+      );
+      expect(mockLintModule.lint).not.toHaveBeenCalled();
+    });
+
+    it('[EARS-10] should detect file by checking filesystem when extension is not .json', async () => {
+      (fs.stat as jest.Mock).mockResolvedValueOnce({ isFile: () => true });
+
+      await lintCommand.execute({
+        path: '.gitgov/tasks/task1'
+      });
+
+      expect(mockLintModule.lintFile).toHaveBeenCalled();
+      expect(mockLintModule.lint).not.toHaveBeenCalled();
+    });
+
+    it('[EARS-11] should filter results by excluded validator types', async () => {
+      await lintCommand.execute({
+        excludeValidators: 'SCHEMA_VALIDATION,REFERENTIAL_INTEGRITY'
+      });
+
+      // Verify that the report was filtered
+      const filteredResults = mockLintReport.results.filter(
+        r => !['SCHEMA_VALIDATION', 'REFERENTIAL_INTEGRITY'].includes(r.validator)
+      );
+      expect(filteredResults.length).toBe(1); // Only SIGNATURE_STRUCTURE should remain
+    });
+
+    it('[EARS-12] should group output by validator (default)', async () => {
+      await lintCommand.execute({
+        groupBy: 'validator'
+      });
+
+      // Verify output was grouped by validator
+      const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n');
+      expect(output).toContain('SCHEMA_VALIDATION');
+      expect(output).toContain('SIGNATURE_STRUCTURE');
+    });
+
+    it('[EARS-12] should group output by file', async () => {
+      await lintCommand.execute({
+        groupBy: 'file'
+      });
+
+      // Verify output was grouped by file
+      const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n');
+      expect(output).toContain('.gitgov/tasks/task1.json');
+      expect(output).toContain('.gitgov/tasks/task2.json');
+    });
+
+    it('[EARS-12] should show output without grouping when groupBy is none', async () => {
+      await lintCommand.execute({
+        groupBy: 'none'
+      });
+
+      // Verify output was not grouped
+      expect(mockConsoleLog).toHaveBeenCalled();
+    });
+
+    it('[EARS-13] should fix only specified validator types when --fix-validators is provided', async () => {
+      await lintCommand.execute({
+        fix: true,
+        fixValidators: 'SIGNATURE_STRUCTURE'
+      });
+
+      expect(mockLintModule.fix).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          fixTypes: ['SIGNATURE_STRUCTURE']
+        })
+      );
+    });
+
+    it('[EARS-14] should fix all fixable problems when --fix-validators is not provided', async () => {
+      await lintCommand.execute({
+        fix: true
+      });
+
+      expect(mockLintModule.fix).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.not.objectContaining({
+          fixTypes: expect.anything()
+        })
+      );
+    });
+  });
+
+  // ==========================================================================
+  // EARS 4-5: Output Formatting - Text Mode
+  // ==========================================================================
+
+  describe('Output Formatting - Text Mode (EARS 4-5)', () => {
+    it('[EARS-4] should format text output with colors and structure', async () => {
+      await lintCommand.execute({
+        format: 'text'
+      });
+
+      // Verify summary is shown
+      const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n');
+      expect(output).toContain('Files checked:');
+      expect(output).toContain('Errors:');
+      expect(output).toContain('Warnings:');
+      expect(output).toContain('Fixable:');
+    });
+
+    it('[EARS-5] should suppress warnings in quiet mode', async () => {
+      const reportWithWarnings: Lint.LintReport = {
+        ...mockLintReport,
+        results: [
+          {
+            level: 'warning',
+            filePath: '.gitgov/tasks/task3.json',
+            validator: 'REFERENTIAL_INTEGRITY',
+            message: 'Reference not found',
+            entity: { type: 'task', id: 'task3' },
+            fixable: false
+          }
+        ]
+      };
+      mockLintModule.lint.mockResolvedValueOnce(reportWithWarnings);
+
+      await lintCommand.execute({
+        quiet: true
+      });
+
+      // In quiet mode, warnings should be suppressed
+      const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n');
+      // Should not show the validation message
+      expect(mockConsoleLog).toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // EARS-6: Migration Detection Mode
+  // ==========================================================================
+
+  describe('Migration Detection Mode (EARS-6)', () => {
+    it('[EARS-6] should list legacy records without applying fixes', async () => {
+      const legacyReport: Lint.LintReport = {
+        ...mockLintReport,
+        results: [
+          {
+            level: 'error',
+            filePath: '.gitgov/tasks/legacy1.json',
+            validator: 'EMBEDDED_METADATA_STRUCTURE',
+            message: 'Legacy format detected',
+            entity: { type: 'task', id: 'legacy1' },
+            fixable: true
+          },
+          {
+            level: 'warning',
+            filePath: '.gitgov/tasks/legacy2.json',
+            validator: 'SCHEMA_VERSION_MISMATCH',
+            message: 'Schema version mismatch',
+            entity: { type: 'task', id: 'legacy2' },
+            fixable: true
+          }
+        ]
+      };
+      mockLintModule.lint.mockResolvedValueOnce(legacyReport);
+
+      await lintCommand.execute({
+        checkMigrations: true
+      });
+
+      // Verify migration report is shown
+      const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n');
+      expect(output).toContain('Migration Detection Report');
+      expect(output).toContain('Legacy records found');
+      // Should not call fix
+      expect(mockLintModule.fix).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // EARS 7-9: Output Formatting - JSON Mode & Exit Codes
+  // ==========================================================================
+
+  describe('Output Formatting - JSON Mode & Exit Codes (EARS 7-9)', () => {
+    it('[EARS-7] should output JSON format without modifications', async () => {
+      await lintCommand.execute({
+        format: 'json'
+      });
+
+      // Verify JSON output
+      const jsonOutput = mockConsoleLog.mock.calls.find(call =>
+        typeof call[0] === 'string' && call[0].startsWith('{')
+      );
+      expect(jsonOutput).toBeDefined();
+      const parsed = JSON.parse(jsonOutput![0] as string);
+      expect(parsed.summary).toBeDefined();
+      expect(parsed.results).toBeDefined();
+    });
+
+    it('[EARS-8] should exit with code 1 when errors present', async () => {
+      const reportWithErrors: Lint.LintReport = {
+        ...mockLintReport,
+        summary: {
+          ...mockLintReport.summary,
+          errors: 2
+        }
+      };
+      mockLintModule.lint.mockResolvedValueOnce(reportWithErrors);
+
+      await lintCommand.execute({});
+
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it('[EARS-8] should exit with code 1 based on filtered report when exclude-validators is used', async () => {
+      const reportWithErrors: Lint.LintReport = {
+        ...mockLintReport,
+        summary: {
+          ...mockLintReport.summary,
+          errors: 2
+        },
+        results: [
+          {
+            level: 'error',
+            filePath: '.gitgov/tasks/task1.json',
+            validator: 'SCHEMA_VALIDATION',
+            message: 'Error 1',
+            entity: { type: 'task', id: 'task1' },
+            fixable: false
+          },
+          {
+            level: 'error',
+            filePath: '.gitgov/tasks/task2.json',
+            validator: 'SIGNATURE_STRUCTURE',
+            message: 'Error 2',
+            entity: { type: 'task', id: 'task2' },
+            fixable: false
+          }
+        ]
+      };
+      mockLintModule.lint.mockResolvedValueOnce(reportWithErrors);
+
+      await lintCommand.execute({
+        excludeValidators: 'SCHEMA_VALIDATION'
+      });
+
+      // After filtering, only SIGNATURE_STRUCTURE error remains
+      // Exit code should be based on filtered report
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it('[EARS-8] should exit with code 1 when fix fails', async () => {
+      const fixReportWithFailures: Lint.FixReport = {
+        ...mockFixReport,
+        summary: {
+          ...mockFixReport.summary,
+          failed: 1
+        }
+      };
+      mockLintModule.fix.mockResolvedValueOnce(fixReportWithFailures);
+
+      await lintCommand.execute({
+        fix: true
+      });
+
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it('[EARS-9] should exit with code 0 when no errors', async () => {
+      const reportNoErrors: Lint.LintReport = {
+        ...mockLintReport,
+        summary: {
+          ...mockLintReport.summary,
+          errors: 0,
+          warnings: 1
+        }
+      };
+      mockLintModule.lint.mockResolvedValueOnce(reportNoErrors);
+
+      await lintCommand.execute({});
+
+      expect(mockProcessExit).toHaveBeenCalledWith(0);
+    });
+
+    it('[EARS-9] should exit with code 0 when all fixes succeed', async () => {
+      const fixReportSuccess: Lint.FixReport = {
+        ...mockFixReport,
+        summary: {
+          ...mockFixReport.summary,
+          failed: 0
+        }
+      };
+      mockLintModule.fix.mockResolvedValueOnce(fixReportSuccess);
+
+      await lintCommand.execute({
+        fix: true
+      });
+
+      expect(mockProcessExit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  // ==========================================================================
+  // EARS 15-16: Output Summary & Limiting
+  // ==========================================================================
+
+  describe('Output Summary & Limiting (EARS 15-16)', () => {
+    it('[EARS-15] should show only summary when --summary flag is provided', async () => {
+      await lintCommand.execute({
+        summary: true
+      });
+
+      // Verify summary is shown
+      const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n');
+      expect(output).toContain('Files checked:');
+      expect(output).toContain('Errors:');
+      expect(output).toContain('Warnings:');
+      expect(output).toContain('Validator Types:');
+      // Should not show individual error details
+      expect(output).not.toContain('task1');
+    });
+
+    it('[EARS-15] should show Validator Types breakdown in summary mode', async () => {
+      await lintCommand.execute({
+        summary: true
+      });
+
+      const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n');
+      expect(output).toContain('Validator Types:');
+      expect(output).toContain('SCHEMA_VALIDATION');
+      expect(output).toContain('SIGNATURE_STRUCTURE');
+    });
+
+    it('[EARS-16] should limit displayed errors/warnings when --max-errors is set', async () => {
+      const reportWithManyErrors: Lint.LintReport = {
+        ...mockLintReport,
+        results: Array.from({ length: 10 }, (_, i): Lint.LintResult => ({
+          level: 'error',
+          filePath: `.gitgov/tasks/task${i}.json`,
+          validator: 'SCHEMA_VALIDATION',
+          message: `Error ${i}`,
+          entity: { type: 'task', id: `task${i}` },
+          fixable: false
+        }))
+      };
+      mockLintModule.lint.mockResolvedValueOnce(reportWithManyErrors);
+
+      await lintCommand.execute({
+        maxErrors: 3
+      });
+
+      // Verify only first 3 errors are shown
+      const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n');
+      expect(output).toContain('more issue');
+      expect(output).toContain('use --max-errors 0 to see all');
+    });
+
+    it('[EARS-16] should show all errors when --max-errors is 0', async () => {
+      const reportWithManyErrors: Lint.LintReport = {
+        ...mockLintReport,
+        results: Array.from({ length: 5 }, (_, i): Lint.LintResult => ({
+          level: 'error',
+          filePath: `.gitgov/tasks/task${i}.json`,
+          validator: 'SCHEMA_VALIDATION',
+          message: `Error ${i}`,
+          entity: { type: 'task', id: `task${i}` },
+          fixable: false
+        }))
+      };
+      mockLintModule.lint.mockResolvedValueOnce(reportWithManyErrors);
+
+      await lintCommand.execute({
+        maxErrors: 0
+      });
+
+      // Verify all errors are shown (no "more issues" message)
+      const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n');
+      expect(output).not.toContain('more issue');
+    });
+
+    it('[EARS-16] should show summary section when max-errors limits output', async () => {
+      const reportWithManyErrors: Lint.LintReport = {
+        ...mockLintReport,
+        summary: {
+          ...mockLintReport.summary,
+          errors: 10
+        },
+        results: Array.from({ length: 10 }, (_, i): Lint.LintResult => ({
+          level: 'error',
+          filePath: `.gitgov/tasks/task${i}.json`,
+          validator: 'SCHEMA_VALIDATION',
+          message: `Error ${i}`,
+          entity: { type: 'task', id: `task${i}` },
+          fixable: false
+        }))
+      };
+      mockLintModule.lint.mockResolvedValueOnce(reportWithManyErrors);
+
+      await lintCommand.execute({
+        maxErrors: 2
+      });
+
+      // Verify summary section is shown
+      const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n');
+      expect(output).toContain('Summary:');
+      expect(output).toContain('more issue');
+    });
+  });
+
+  // ==========================================================================
+  // Additional Integration Tests
+  // ==========================================================================
+
+  describe('Fix Mode Integration', () => {
+    it('should load private key from .gitgov/actors/{actorId}.key when fixing', async () => {
+      await lintCommand.execute({
+        fix: true
+      });
+
+      expect(fs.readFile).toHaveBeenCalledWith(
+        expect.stringContaining('.gitgov/actors/human:test-user.key'),
+        'utf-8'
+      );
+    });
+
+    it('should handle missing private key gracefully when fixing', async () => {
+      (fs.readFile as jest.Mock).mockRejectedValueOnce(new Error('File not found'));
+
+      await lintCommand.execute({
+        fix: true
+      });
+
+      // Should continue with fix even if private key is missing
+      expect(mockLintModule.fix).toHaveBeenCalled();
+    });
+
+    it('should show fix report after applying fixes', async () => {
+      await lintCommand.execute({
+        fix: true
+      });
+
+      const output = mockConsoleLog.mock.calls.map(call => call[0]).join('\n');
+      expect(output).toContain('Fix Report:');
+      expect(output).toContain('Fixed:');
+      expect(output).toContain('Failed:');
+      expect(output).toContain('Backups created:');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty lint report', async () => {
+      const emptyReport: Lint.LintReport = {
+        summary: {
+          filesChecked: 0,
+          errors: 0,
+          warnings: 0,
+          fixable: 0,
+          executionTime: 0
+        },
+        results: [],
+        metadata: {
+          timestamp: new Date().toISOString(),
+          options: {} as Lint.LintOptions,
+          version: '1.0.0'
+        }
+      };
+      mockLintModule.lint.mockResolvedValueOnce(emptyReport);
+
+      await lintCommand.execute({});
+
+      expect(mockProcessExit).toHaveBeenCalledWith(0);
+    });
+
+    it('should handle file path detection errors gracefully', async () => {
+      (fs.stat as jest.Mock).mockRejectedValueOnce(new Error('Permission denied'));
+
+      await lintCommand.execute({
+        path: '.gitgov/tasks/unknown'
+      });
+
+      // Should fall back to directory mode
+      expect(mockLintModule.lint).toHaveBeenCalled();
+    });
+  });
+});
+

--- a/packages/cli/src/commands/lint/lint-command.ts
+++ b/packages/cli/src/commands/lint/lint-command.ts
@@ -1,0 +1,563 @@
+import { Command } from 'commander';
+import { BaseCommand } from '../../base/base-command';
+import type { BaseCommandOptions } from '../../interfaces/command';
+import type { Lint } from '@gitgov/core';
+import * as path from 'path';
+import { promises as fs } from 'fs';
+import { Config } from '@gitgov/core';
+
+/**
+ * Lint Command Options
+ * Maps CLI flags to LintModule options
+ */
+export interface LintCommandOptions extends BaseCommandOptions {
+  /** Directorio o archivo a validar (default: '.gitgov/') */
+  path?: string;
+  /** Validar referencias tipadas (mapea a validateReferences) */
+  references?: boolean;
+  /** Validar resolución de actores (mapea a validateActors) */
+  actors?: boolean;
+  /** Intentar reparar errores automáticamente (default: false) */
+  fix?: boolean;
+  /** Lista de validadores específicos a arreglar con --fix (separados por comas, ej: SIGNATURE_STRUCTURE) */
+  fixValidators?: string;
+  /** Solo detectar y listar records obsoletos sin auto-fix (default: false) */
+  checkMigrations?: boolean;
+  /** Formato de salida (default: 'text') */
+  format?: 'text' | 'json';
+  /** Modo silencioso - solo errores (default: false) */
+  quiet?: boolean;
+  /** Lista de validadores a excluir (separados por comas) */
+  excludeValidators?: string;
+  /** Agrupar output por validator|file|none (default: 'validator') */
+  groupBy?: 'validator' | 'file' | 'none';
+  /** Mostrar solo resumen sin detalles (default: false) */
+  summary?: boolean;
+  /** Limitar cantidad de errores mostrados (0 = todos, default: 0) */
+  maxErrors?: number;
+}
+
+/**
+ * Lint Command - Thin wrapper for @gitgov/core/lint module
+ * 
+ * Implements Quality Model Layer 1 (Structural + Referential Integrity).
+ * All validation logic lives in LintModule.
+ * 
+ * This command is responsible for:
+ * - Parsing CLI arguments
+ * - Injecting dependencies
+ * - Formatting output (text/JSON)
+ * - Setting exit codes
+ */
+export class LintCommand extends BaseCommand {
+  protected commandName = 'lint';
+  protected description = 'Validate GitGovernance records (Quality Layer 1)';
+
+  constructor() {
+    super();
+  }
+
+  /**
+   * Register the lint command with Commander
+   */
+  register(program: Command): void {
+    const lintCmd = program
+      .command('lint [path]')
+      .description(this.description)
+      .option('-r, --references', 'Validate typed references', false)
+      .option('-a, --actors', 'Validate actor resolution', false)
+      .option('--fix', 'Auto-fix problems (creates backups)', false)
+      .option('--fix-validators <validators>', 'Comma-separated list of validator types to fix (e.g., SIGNATURE_STRUCTURE). If not specified, fixes all fixable problems.', '')
+      .option('--check-migrations', 'List legacy records without fixing', false)
+      .option('-f, --format <type>', 'Output format (text|json)', 'text')
+      .option('-q, --quiet', 'Quiet mode - only errors', false)
+      .option('--exclude-validators <validators>', 'Comma-separated list of validator types to exclude (e.g., SCHEMA_VALIDATION)', '')
+      .option('--group-by <type>', 'Group output by validator|file|none', 'validator')
+      .option('--summary', 'Show only summary without individual error details', false)
+      .option('--max-errors <n>', 'Limit the number of errors/warnings displayed (0 = all, default: 0)', '0')
+      .action(async (path: string | undefined, options: LintCommandOptions & { maxErrors?: string | number }) => {
+        // Parse maxErrors from string to number if provided
+        const parsedMaxErrors = options.maxErrors !== undefined
+          ? (typeof options.maxErrors === 'string' ? parseInt(options.maxErrors, 10) : options.maxErrors)
+          : undefined;
+
+        const parsedOptions: LintCommandOptions = {
+          ...options,
+          ...(parsedMaxErrors !== undefined && { maxErrors: parsedMaxErrors })
+        };
+        await this.execute({ path: path || '.gitgov/', ...parsedOptions });
+      });
+  }
+
+  /**
+   * Execute lint command
+   * [EARS-1, EARS-2, EARS-3]
+   */
+  async execute(options: LintCommandOptions): Promise<void> {
+    try {
+      const startTime = Date.now();
+
+      // [EARS-1] Parse and set defaults
+      const inputPath = options.path || '.gitgov/';
+      const format = options.format || 'text';
+      const quiet = options.quiet || false;
+
+      // [EARS-2] Initialize LintModule with DI
+      const lintModule = await this.container.getLintModule();
+
+      // Detect if path is a file or directory
+      let isFile = false;
+      let filePath = inputPath;
+
+      try {
+        // Check if it's a file by extension or by checking filesystem
+        if (inputPath.endsWith('.json')) {
+          isFile = true;
+        } else {
+          // Check if it's actually a file
+          const stats = await fs.stat(inputPath);
+          isFile = stats.isFile();
+        }
+      } catch {
+        // If stat fails, assume it's a directory or use extension check
+        isFile = inputPath.endsWith('.json');
+      }
+
+      // Map CLI options to LintModule options
+      const lintOptions: Partial<Lint.LintOptions> = {
+        path: isFile ? path.dirname(inputPath) : inputPath,
+        validateReferences: options.references || false,
+        validateActors: options.actors || false,
+        validateConventions: true // Always validate conventions
+      };
+
+      if (!quiet) {
+        if (isFile) {
+          this.logger.info(`🔍 Validating file: ${inputPath}...`);
+        } else {
+          this.logger.info(`🔍 Validating records in ${inputPath}...`);
+        }
+      }
+
+      // [EARS-3] Invoke core module - use lintFile for single files, lint for directories
+      const report = isFile
+        ? await lintModule.lintFile(filePath, lintOptions)
+        : await lintModule.lint(lintOptions);
+
+      // Filter results by excluded validators
+      let filteredReport = report;
+      if (options.excludeValidators && options.excludeValidators.length > 0) {
+        const excluded = options.excludeValidators.split(',').map(v => v.trim());
+        filteredReport = {
+          ...report,
+          results: report.results.filter(r => !excluded.includes(r.validator)),
+          summary: {
+            ...report.summary,
+            errors: report.results.filter(r => !excluded.includes(r.validator) && r.level === 'error').length,
+            warnings: report.results.filter(r => !excluded.includes(r.validator) && r.level === 'warning').length,
+            fixable: report.results.filter(r => !excluded.includes(r.validator) && r.fixable).length
+          }
+        };
+      }
+
+      const executionTime = Date.now() - startTime;
+
+      // [EARS-4, EARS-5] Format and display output
+      if (options.checkMigrations) {
+        // [EARS-6] Migration detection mode
+        this.formatMigrationReport(filteredReport, format, quiet);
+        // [EARS-8] Exit code based on filtered report
+        const exitCode = filteredReport.summary.errors > 0 ? 1 : 0;
+        process.exit(exitCode);
+      } else if (options.fix) {
+        // [EARS-7] Fix mode
+        const fixReport = await this.handleFixMode(lintModule, filteredReport, options, format, quiet);
+        // [EARS-8] Exit code based on remaining errors after fix
+        // If fix failed for some items, exit with code 1
+        const exitCode = (fixReport?.summary.failed ?? 0) > 0 ? 1 : 0;
+        process.exit(exitCode);
+      } else {
+        // [EARS-4, EARS-5, EARS-15, EARS-16] Normal lint mode
+        const maxErrors = options.maxErrors !== undefined ? parseInt(options.maxErrors.toString(), 10) : 0;
+        this.formatLintReport(
+          filteredReport,
+          format,
+          quiet,
+          executionTime,
+          options.groupBy || 'validator',
+          options.summary || false,
+          maxErrors
+        );
+        // [EARS-8] Exit code based on filtered report
+        const exitCode = filteredReport.summary.errors > 0 ? 1 : 0;
+        process.exit(exitCode);
+      }
+
+    } catch (error) {
+      this.logger.error('❌ Lint command failed:', error);
+      process.exit(1);
+    }
+  }
+
+  /**
+   * Handle fix mode
+   * [EARS-7]
+   * @returns FixReport for exit code calculation
+   */
+  private async handleFixMode(
+    lintModule: Lint.LintModule,
+    lintReport: Lint.LintReport,
+    options: LintCommandOptions,
+    format: string,
+    quiet: boolean
+  ): Promise<Lint.FixReport | undefined> {
+    const fixableCount = lintReport.summary.fixable;
+
+    if (fixableCount === 0) {
+      if (!quiet) {
+        this.logger.info('\x1b[32m✓ No fixable problems found\x1b[0m');
+      }
+      this.formatLintReport(lintReport, format, quiet, lintReport.summary.executionTime, 'validator', false, 0);
+      return undefined;
+    }
+
+    if (!quiet) {
+      this.logger.info(`\n🔧 Attempting to fix ${fixableCount} problem(s)...`);
+    }
+
+    // Get current actor for signing fixed records
+    const identityAdapter = await this.container.getIdentityAdapter();
+    const currentActor = await identityAdapter.getCurrentActor();
+
+    // Try to load private key from .gitgov/actors/{actorId}.key
+    // Note: This is optional - fix will only work for non-legacy records if key is missing
+    let privateKey: string | undefined;
+    try {
+      const projectRoot = Config.ConfigManager.findGitgovRoot() || process.cwd();
+      const keyPath = path.join(projectRoot, '.gitgov', 'actors', `${currentActor.id}.key`);
+      const keyContent = await fs.readFile(keyPath, 'utf-8');
+      privateKey = keyContent.trim();
+    } catch (error) {
+      // Private key file not found - this is okay for non-legacy fixes
+      // Legacy record fixes will fail with a clear error message
+      if (!quiet) {
+        this.logger.warn(`⚠️  Private key not found at .gitgov/actors/${currentActor.id}.key`);
+        this.logger.warn('   Legacy record fixes will not be available. Other fixes will still work.');
+      }
+    }
+
+    // Parse fix-validators option if provided
+    let fixTypes: Lint.ValidatorType[] | undefined;
+    if (options.fixValidators) {
+      const validators = options.fixValidators.split(',').map(v => v.trim() as Lint.ValidatorType);
+      fixTypes = validators.filter(v => v.length > 0);
+    }
+
+    const fixOptions: Partial<Lint.FixOptions> = {
+      createBackups: true,
+      keyId: currentActor.id,
+      ...(privateKey && { privateKey }),
+      ...(fixTypes && fixTypes.length > 0 && { fixTypes }),
+    };
+
+    const fixReport = await lintModule.fix(lintReport, fixOptions);
+
+    // Display fix results
+    if (format === 'json') {
+      console.log(JSON.stringify({ lintReport, fixReport }, null, 2));
+    } else {
+      this.formatFixReport(fixReport, quiet);
+
+      // Show remaining errors after fix
+      if (fixReport.summary.failed > 0) {
+        this.logger.warn(`\n\x1b[33m⚠️  ${fixReport.summary.failed} problem(s) could not be fixed\x1b[0m`);
+      }
+    }
+
+    return fixReport;
+  }
+
+  /**
+   * Format lint report for display
+   * [EARS-4, EARS-5, EARS-15, EARS-16]
+   */
+  private formatLintReport(
+    report: Lint.LintReport,
+    format: string,
+    quiet: boolean,
+    executionTime: number,
+    groupBy: 'validator' | 'file' | 'none' = 'validator',
+    summary: boolean = false,
+    maxErrors: number = 0
+  ): void {
+    if (format === 'json') {
+      // [EARS-7] JSON output - ignore summary and maxErrors flags
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+
+    // [EARS-4, EARS-15, EARS-16] Text output
+    const { summary: reportSummary, results } = report;
+
+    // [EARS-16] Limit results if maxErrors is set (calculate before showing summary)
+    let displayResults = results;
+    let remainingCount = 0;
+    if (maxErrors > 0 && results.length > maxErrors) {
+      displayResults = results.slice(0, maxErrors);
+      remainingCount = results.length - maxErrors;
+    }
+
+    // [EARS-15] If summary flag is set, show only summary and Validator Types
+    if (summary) {
+      // Show Lint Report summary only
+      if (!quiet) {
+        console.log('\n\x1b[1mLint Report:\x1b[0m');
+        console.log('─'.repeat(60));
+      }
+      const errorColor = reportSummary.errors > 0 ? '\x1b[31m' : '\x1b[32m'; // red : green
+      console.log(`${errorColor}Errors:\x1b[0m          `, reportSummary.errors);
+      console.log('\x1b[33mWarnings:\x1b[0m        ', reportSummary.warnings); // yellow
+      console.log('\x1b[36mFixable:\x1b[0m         ', reportSummary.fixable); // cyan
+      console.log('Files checked:   ', reportSummary.filesChecked);
+      if (!quiet) {
+        console.log('Execution time:  ', `${executionTime}ms`);
+      }
+
+      // Show Validator Types breakdown even in summary mode
+      if (!quiet && results.length > 0) {
+        const validatorGroups = results.reduce((acc, result) => {
+          if (!acc[result.validator]) {
+            acc[result.validator] = { errors: 0, warnings: 0 };
+          }
+          if (result.level === 'error') {
+            acc[result.validator]!.errors++;
+          } else {
+            acc[result.validator]!.warnings++;
+          }
+          return acc;
+        }, {} as Record<string, { errors: number; warnings: number }>);
+
+        console.log('\n\x1b[1mValidator Types:\x1b[0m');
+        console.log('─'.repeat(60));
+        Object.entries(validatorGroups).forEach(([validator, counts]) => {
+          if (counts.errors > 0) {
+            console.log(`❌ ${validator} (${counts.errors} ${counts.errors === 1 ? 'error' : 'errors'})`);
+          } else if (counts.warnings > 0) {
+            console.log(`⚠️  ${validator} (${counts.warnings} ${counts.warnings === 1 ? 'warning' : 'warnings'})`);
+          }
+        });
+      }
+
+      console.log('');
+      return;
+    }
+
+    // 1. Issues (show first)
+    if (displayResults.length > 0 && !quiet) {
+      console.log('\n\x1b[1mIssues:\x1b[0m');
+      console.log('─'.repeat(60));
+
+      if (groupBy === 'validator') {
+        // Group by validator type
+        const grouped = displayResults.reduce((acc, result) => {
+          if (!acc[result.validator]) {
+            acc[result.validator] = [];
+          }
+          acc[result.validator]!.push(result);
+          return acc;
+        }, {} as Record<string, Lint.LintResult[]>);
+
+        Object.entries(grouped).forEach(([validator, validatorResults]) => {
+          const errorCount = validatorResults.filter(r => r.level === 'error').length;
+          const warningCount = validatorResults.filter(r => r.level === 'warning').length;
+          const icon = errorCount > 0 ? '❌' : '⚠️ ';
+          const color = errorCount > 0 ? '\x1b[31m' : '\x1b[33m';
+
+          // Show only relevant count (errors or warnings, not both)
+          const countText = errorCount > 0
+            ? `(${errorCount} ${errorCount === 1 ? 'error' : 'errors'})`
+            : `(${warningCount} ${warningCount === 1 ? 'warning' : 'warnings'})`;
+
+          console.log(`\n${icon} ${color}${validator}\x1b[0m ${countText}`);
+          validatorResults.forEach(result => {
+            const levelColor = result.level === 'error' ? '\x1b[31m' : '\x1b[33m';
+            console.log(`  - ${levelColor}${result.entity.type}:${result.entity.id}\x1b[0m`);
+            console.log(`     File: ${result.filePath}`);
+            console.log(`     ${result.message}`);
+            if (result.fixable) {
+              console.log(`     \x1b[36m✓ Fixable with --fix\x1b[0m`);
+            }
+          });
+        });
+      } else if (groupBy === 'file') {
+        // Group by file
+        const grouped = displayResults.reduce((acc, result) => {
+          if (!acc[result.filePath]) {
+            acc[result.filePath] = [];
+          }
+          acc[result.filePath]!.push(result);
+          return acc;
+        }, {} as Record<string, Lint.LintResult[]>);
+
+        Object.entries(grouped).forEach(([filePath, fileResults]) => {
+          console.log(`\n📄 ${filePath}`);
+          fileResults.forEach(result => {
+            const color = result.level === 'error' ? '\x1b[31m' : '\x1b[33m';
+            console.log(`  ${color}${result.validator}\x1b[0m`);
+            console.log(`   Entity: ${result.entity.type}:${result.entity.id}`);
+            console.log(`   ${result.message}`);
+            if (result.fixable) {
+              console.log(`   \x1b[36m✓ Fixable with --fix\x1b[0m`);
+            }
+          });
+        });
+      } else {
+        // No grouping (original format)
+        displayResults.forEach((result, index) => {
+          const icon = result.level === 'error' ? '❌' : '⚠️ ';
+          const color = result.level === 'error' ? '\x1b[31m' : '\x1b[33m'; // red : yellow
+
+          console.log(`\n${icon} ${color}${result.validator}\x1b[0m`);
+          console.log(`   File: ${result.filePath}`);
+          console.log(`   Entity: ${result.entity.type}:${result.entity.id}`);
+          console.log(`   Message: ${result.message}`);
+
+          if (result.fixable) {
+            console.log(`   \x1b[36m✓ Fixable with --fix\x1b[0m`); // cyan
+          }
+        });
+      }
+    }
+
+    // 2. Summary (only if maxErrors is set AND there are more issues than displayed)
+    if (maxErrors > 0 && remainingCount > 0 && !quiet) {
+      console.log('\n\x1b[1mSummary:\x1b[0m');
+      console.log('─'.repeat(60));
+      console.log(`\x1b[33m⚠️  ${remainingCount} more issue${remainingCount === 1 ? '' : 's'} not shown (use --max-errors 0 to see all)\x1b[0m`);
+      const errorColor = reportSummary.errors > 0 ? '\x1b[31m' : '\x1b[32m';
+      const warningColor = reportSummary.warnings > 0 ? '\x1b[33m' : '';
+      const resetColor = '\x1b[0m';
+      const warningReset = warningColor ? resetColor : '';
+      const totalsLine = `${errorColor}${reportSummary.errors} error${reportSummary.errors === 1 ? '' : 's'}${resetColor}, ${warningColor}${reportSummary.warnings} warning${reportSummary.warnings === 1 ? '' : 's'}${warningReset}, \x1b[36m${reportSummary.fixable} fixable${resetColor}`;
+      console.log(totalsLine);
+    }
+
+    // 3. Lint Report (show at the end)
+    if (!quiet) {
+      console.log('\n\x1b[1mLint Report:\x1b[0m');
+      console.log('─'.repeat(60));
+    }
+    const errorColor = reportSummary.errors > 0 ? '\x1b[31m' : '\x1b[32m'; // red : green
+    console.log(`${errorColor}Errors:\x1b[0m          `, reportSummary.errors);
+    console.log('\x1b[33mWarnings:\x1b[0m        ', reportSummary.warnings); // yellow
+    console.log('\x1b[36mFixable:\x1b[0m         ', reportSummary.fixable); // cyan
+    console.log('Files checked:   ', reportSummary.filesChecked);
+    if (!quiet) {
+      console.log('Execution time:  ', `${executionTime}ms`);
+    }
+
+    // 4. Validator Types Breakdown (show after Lint Report)
+    if (!quiet && results.length > 0) {
+      const validatorGroups = results.reduce((acc, result) => {
+        if (!acc[result.validator]) {
+          acc[result.validator] = { errors: 0, warnings: 0 };
+        }
+        if (result.level === 'error') {
+          acc[result.validator]!.errors++;
+        } else {
+          acc[result.validator]!.warnings++;
+        }
+        return acc;
+      }, {} as Record<string, { errors: number; warnings: number }>);
+
+      console.log('\n\x1b[1mValidator Types:\x1b[0m');
+      console.log('─'.repeat(60));
+      Object.entries(validatorGroups).forEach(([validator, counts]) => {
+        if (counts.errors > 0) {
+          console.log(`❌ ${validator} (${counts.errors} ${counts.errors === 1 ? 'error' : 'errors'})`);
+        } else if (counts.warnings > 0) {
+          console.log(`⚠️  ${validator} (${counts.warnings} ${counts.warnings === 1 ? 'warning' : 'warnings'})`);
+        }
+      });
+    }
+
+    console.log('');
+  }
+
+  /**
+   * Format migration detection report
+   * [EARS-6]
+   */
+  private formatMigrationReport(
+    report: Lint.LintReport,
+    format: string,
+    quiet: boolean
+  ): void {
+    const legacyRecords = report.results.filter(
+      r => r.validator === 'EMBEDDED_METADATA_STRUCTURE' || r.validator === 'SCHEMA_VERSION_MISMATCH'
+    );
+
+    if (format === 'json') {
+      console.log(JSON.stringify({ legacyRecords }, null, 2));
+      return;
+    }
+
+    console.log('\n\x1b[1mMigration Detection Report:\x1b[0m');
+    console.log('─'.repeat(60));
+    console.log('\x1b[33mLegacy records found:\x1b[0m', legacyRecords.length);
+
+    if (legacyRecords.length > 0 && !quiet) {
+      console.log('\n\x1b[1mLegacy Records:\x1b[0m');
+      legacyRecords.forEach(record => {
+        console.log(`  - \x1b[36m${record.filePath}\x1b[0m`);
+        console.log(`    ${record.message}`);
+      });
+
+      console.log(`\n\x1b[36m💡 Tip:\x1b[0m Run with \x1b[1m--fix\x1b[0m to automatically migrate these records\n`);
+    } else if (legacyRecords.length === 0) {
+      console.log('\x1b[32m\n✓ All records are up to date!\n\x1b[0m');
+    }
+  }
+
+  /**
+   * Format fix report for display
+   * [EARS-7]
+   */
+  private formatFixReport(report: Lint.FixReport, quiet: boolean): void {
+    const { summary, fixes } = report;
+
+    if (!quiet) {
+      console.log('\n\x1b[1mFix Report:\x1b[0m');
+      console.log('─'.repeat(60));
+    }
+
+    console.log('\x1b[32mFixed:\x1b[0m           ', summary.fixed);
+    console.log('\x1b[31mFailed:\x1b[0m          ', summary.failed);
+    console.log('\x1b[36mBackups created:\x1b[0m ', summary.backupsCreated);
+
+    if (fixes.length > 0 && !quiet) {
+      console.log('\n\x1b[1mDetails:\x1b[0m');
+      console.log('─'.repeat(60));
+
+      fixes.forEach(fix => {
+        const icon = fix.success ? '✓' : '✗';
+        const color = fix.success ? '\x1b[32m' : '\x1b[31m'; // green : red
+
+        console.log(`${icon} ${color}${fix.validator}\x1b[0m - ${fix.filePath}`);
+        console.log(`  ${fix.action}`);
+
+
+        if (fix.backupPath) {
+          console.log(`  Backup: ${fix.backupPath}`);
+        }
+
+        if (fix.error) {
+          console.log(`  \x1b[31mError:\x1b[0m ${fix.error}`);
+        }
+      });
+    }
+
+    console.log('');
+  }
+}
+

--- a/packages/cli/src/commands/lint/lint.ts
+++ b/packages/cli/src/commands/lint/lint.ts
@@ -1,0 +1,13 @@
+import { Command } from 'commander';
+import { LintCommand } from './lint-command';
+
+/**
+ * Register the lint command
+ */
+export function registerLintCommand(program: Command): void {
+  const lintCommand = new LintCommand();
+  lintCommand.register(program);
+}
+
+
+

--- a/packages/cli/src/commands/task/task-command.ts
+++ b/packages/cli/src/commands/task/task-command.ts
@@ -501,7 +501,8 @@ export class TaskCommand extends BaseCommand<BaseCommandOptions> {
         // Use cache first
         const indexData = await indexerAdapter.getIndexData();
         if (indexData) {
-          task = indexData.tasks.find((t: Records.TaskRecord) => t.id === taskId) || null;
+          const foundTask = indexData.tasks.find((t) => t.payload.id === taskId);
+          task = foundTask ? foundTask.payload : null;
         }
       }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,14 +28,21 @@ importers:
   packages/cli:
     dependencies:
       '@gitgov/core':
-        specifier: 1.6.4
-        version: 1.6.4
+        specifier: 1.7.0
+        version: 1.7.0
       clipboardy:
         specifier: ^5.0.0
         version: 5.0.0
       commander:
         specifier: ^11.1.0
         version: 11.1.0
+    optionalDependencies:
+      ink:
+        specifier: ^4.4.1
+        version: 4.4.1(@types/react@18.3.24)(react-devtools-core@4.28.5)(react@18.3.1)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
     devDependencies:
       '@semantic-release/changelog':
         specifier: ^6.0.3
@@ -82,13 +89,6 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.9.2
-    optionalDependencies:
-      ink:
-        specifier: ^4.4.1
-        version: 4.4.1(@types/react@18.3.24)(react-devtools-core@4.28.5)(react@18.3.1)
-      react:
-        specifier: ^18.3.1
-        version: 18.3.1
 
   packages/core:
     dependencies:
@@ -616,8 +616,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@gitgov/core@1.6.4':
-    resolution: {integrity: sha512-0UrShZ7WFB0lXtjtnwzkSzEOUgggIKYBrJY1vr8e+s6WToGVdPCUZbhTa7Y0IEAXjv0G55KYehN1eKMHYrwkDg==}
+  '@gitgov/core@1.7.0':
+    resolution: {integrity: sha512-5b17SIRkMTucb/GzjYSrw/ixTeyw8v5KvDJUoUS4fSVqBylYkads85HkRIJF2e+s1w3lRquBBR6SNVkImL7E2A==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -3703,7 +3703,7 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
-  '@gitgov/core@1.6.4':
+  '@gitgov/core@1.7.0':
     dependencies:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)


### PR DESCRIPTION
## Summary

This PR implements the lint command for structural validation and updates the @gitgov/core dependency to version 1.7.0 to use the new lint module.

## Changes

- Add lint command module (`packages/cli/src/commands/lint/`)
- Implement lint command with structural validation
- Update @gitgov/core dependency from 1.6.4 to 1.7.0
- Add comprehensive tests for lint command
- Integrate lint module from @gitgov/core package

## Task Reference

Refs: #1762488681-task-implement-lint-module--command-for-structural-vali

## Validation

- [x] Build OK
- [x] Tests passing
- [x] Conventional Commits format validated
- [x] Core dependency updated to 1.7.0

## Release Impact

**Type**: feat → Will trigger **minor** version bump
**Scope**: cli → Changes in @gitgov/cli package