### PR TITLE
fix(cli): add loader functions to RecordStore initialization

### DIFF
--- a/packages/cli/src/services/dependency-injection.test.ts
+++ b/packages/cli/src/services/dependency-injection.test.ts
@@ -58,6 +58,17 @@ jest.doMock('@gitgov/core', () => {
       }))
     },
 
+    // 🎭 MOCK FACTORIES: Mock record loaders
+    Factories: {
+      loadTaskRecord: jest.fn((data) => data),
+      loadCycleRecord: jest.fn((data) => data),
+      loadFeedbackRecord: jest.fn((data) => data),
+      loadExecutionRecord: jest.fn((data) => data),
+      loadChangelogRecord: jest.fn((data) => data),
+      loadActorRecord: jest.fn((data) => data),
+      loadAgentRecord: jest.fn((data) => data)
+    },
+
     // 🎭 MOCK ADAPTERS: Mock business logic behavior with valid data
     Adapters: {
       FileIndexerAdapter: jest.fn().mockImplementation(() => ({

--- a/packages/cli/src/services/dependency-injection.ts
+++ b/packages/cli/src/services/dependency-injection.ts
@@ -51,14 +51,16 @@ export class DependencyInjectionService {
       throw new Error("❌ GitGovernance not initialized. Run 'gitgov init' first.");
     }
 
+    const { Factories } = await import('@gitgov/core');
+
     this.stores = {
-      taskStore: new Store.RecordStore<Records.TaskRecord>('tasks', projectRoot),
-      cycleStore: new Store.RecordStore<Records.CycleRecord>('cycles', projectRoot),
-      feedbackStore: new Store.RecordStore<Records.FeedbackRecord>('feedback', projectRoot),
-      executionStore: new Store.RecordStore<Records.ExecutionRecord>('executions', projectRoot),
-      changelogStore: new Store.RecordStore<Records.ChangelogRecord>('changelogs', projectRoot),
-      actorStore: new Store.RecordStore<Records.ActorRecord>('actors', projectRoot),
-      agentStore: new Store.RecordStore<Records.AgentRecord>('agents', projectRoot),
+      taskStore: new Store.RecordStore<Records.TaskRecord>('tasks', Factories.loadTaskRecord, projectRoot),
+      cycleStore: new Store.RecordStore<Records.CycleRecord>('cycles', Factories.loadCycleRecord, projectRoot),
+      feedbackStore: new Store.RecordStore<Records.FeedbackRecord>('feedback', Factories.loadFeedbackRecord, projectRoot),
+      executionStore: new Store.RecordStore<Records.ExecutionRecord>('executions', Factories.loadExecutionRecord, projectRoot),
+      changelogStore: new Store.RecordStore<Records.ChangelogRecord>('changelogs', Factories.loadChangelogRecord, projectRoot),
+      actorStore: new Store.RecordStore<Records.ActorRecord>('actors', Factories.loadActorRecord, projectRoot),
+      agentStore: new Store.RecordStore<Records.AgentRecord>('agents', Factories.loadAgentRecord, projectRoot),
     };
   }
 


### PR DESCRIPTION
## Problem
The E2E tests were failing in CI with error: `this.loader is not a function`

This occurred because `RecordStore` requires a `loader` function as the second parameter to validate records when reading from the filesystem. However, in `dependency-injection.ts`, the `RecordStore` instances were being created without the loader parameter.

## Solution
- Added `Factories.load*Record` functions to all `RecordStore` instances in `dependency-injection.ts`
- This ensures records are properly validated when read from the filesystem

## Changes
- `packages/cli/src/services/dependency-injection.ts`: Added `Factories` import and loader functions to all RecordStore instances

## Testing
- E2E tests now pass (10 passed, 5 skipped)
- Fixes the error that was causing CI failures

## Related
Fixes the issue introduced in the merge of feature/1762488681-cli-lint-command