### PR TITLE
fix(cli): update priority color high to orange

### DIFF
--- a/packages/cli/src/commands/dashboard/dashboard-command.ts
+++ b/packages/cli/src/commands/dashboard/dashboard-command.ts
@@ -408,7 +408,7 @@ export class DashboardCommand {
   private getPriorityFlag(priority: string): string {
     const flags: Record<string, string> = {
       'critical': '🔴',
-      'high': '🟡',
+      'high': '🟠',
       'medium': '🔵',
       'low': '⚪'
     };

--- a/packages/cli/src/commands/status/status-command.ts
+++ b/packages/cli/src/commands/status/status-command.ts
@@ -339,7 +339,7 @@ export class StatusCommand {
     if (personalWork.assignedTasks.length > 0) {
       personalWork.assignedTasks.forEach(task => {
         const statusIcon = this.getStatusIcon(task.status);
-        const priorityFlag = task.priority === 'critical' ? '🔴' : task.priority === 'high' ? '🟡' : '';
+        const priorityFlag = task.priority === 'critical' ? '🔴' : task.priority === 'high' ? '🟠' : '';
         console.log(`  ${statusIcon} [${task.status}] ${task.id} - ${task.title} ${priorityFlag}`);
         if (options.verbose) {
           console.log(`    Priority: ${task.priority}, Tags: ${task.tags?.join(', ') || 'none'}`);
@@ -377,7 +377,7 @@ export class StatusCommand {
     if (systemHealth.alerts.length > 0) {
       console.log('🚨 Alerts:');
       systemHealth.alerts.forEach(alert => {
-        const alertIcon = alert.severity === 'critical' ? '🔴' : alert.severity === 'high' ? '🟡' : '🔵';
+        const alertIcon = alert.severity === 'critical' ? '🔴' : alert.severity === 'high' ? '🟠' : '🔵';
         console.log(`  ${alertIcon} ${alert.message}`);
       });
     }
@@ -447,7 +447,7 @@ export class StatusCommand {
       console.log('');
       console.log('🚨 Alerts & Warnings');
       overview.alerts.forEach(alert => {
-        const alertIcon = alert.severity === 'critical' ? '🔴' : alert.severity === 'high' ? '🟡' : '🔵';
+        const alertIcon = alert.severity === 'critical' ? '🔴' : alert.severity === 'high' ? '🟠' : '🔵';
         console.log(`  ${alertIcon} ${alert.message}`);
       });
     }

--- a/packages/cli/src/components/dashboard/DashboardTUI.tsx
+++ b/packages/cli/src/components/dashboard/DashboardTUI.tsx
@@ -688,7 +688,7 @@ const RowView: React.FC<{
 
   const getPriorityFlag = (priority: string): string => {
     const flags: Record<string, string> = {
-      'critical': '🔴', 'high': '🟡', 'medium': '🔵', 'low': '⚪'
+      'critical': '🔴', 'high': '🟠', 'medium': '🔵', 'low': '⚪'
     };
     return flags[priority] || '⚪';
   };
@@ -1051,7 +1051,7 @@ const ScrumView: React.FC<{
 
   const getPriorityFlag = (priority: string): string => {
     const flags: Record<string, string> = {
-      'critical': '🔴', 'high': '🟡', 'medium': '🔵', 'low': '⚪'
+      'critical': '🔴', 'high': '🟠', 'medium': '🔵', 'low': '⚪'
     };
     return flags[priority] || '⚪';
   };


### PR DESCRIPTION
## Summary

Updates priority color mapping: high priority now uses orange (🟠) instead of yellow (🟡), while keeping medium as blue (🔵). This improves visual hierarchy and semantic clarity.

## Changes
- Update priority flag in dashboard-command.ts
- Update priority flag in status-command.ts  
- Update priority flag in DashboardTUI.tsx (2 locations)

## Task Reference
Refs: #1762699192-task-update-dashboard-priority-colors-high-to-orange

## Release Impact
**Type**: fix → Will trigger **patch** version bump
**Scope**: cli → Changes in @gitgov/cli package