### PR TITLE
fix(cli): avoid checkout conflict in e2e init tests

### DIFF
--- a/packages/cli/e2e/init_command_e2e.test.ts
+++ b/packages/cli/e2e/init_command_e2e.test.ts
@@ -176,18 +176,14 @@ describe('Init CLI Command - Edge Cases E2E Tests', () => {
       const remoteBranches = execSync('git ls-remote --heads origin gitgov-state', { cwd: testProjectRoot, encoding: 'utf8' });
       expect(remoteBranches.trim()).toContain('gitgov-state');
 
-      // 7. Checkout gitgov-state and verify it has files
+      // 7. Verify gitgov-state has files using git ls-tree (avoids checkout conflicts with untracked .gitgov/)
       execSync('git fetch origin gitgov-state', { cwd: testProjectRoot, stdio: 'pipe' });
-      execSync('git checkout gitgov-state', { cwd: testProjectRoot, stdio: 'pipe' });
+      const stateFiles = execSync('git ls-tree -r --name-only origin/gitgov-state', { cwd: testProjectRoot, encoding: 'utf8' });
 
-      // Verify .gitgov/ exists with expected structure
-      expect(fs.existsSync(path.join(testProjectRoot, '.gitgov'))).toBe(true);
-      expect(fs.existsSync(path.join(testProjectRoot, '.gitgov', 'config.json'))).toBe(true);
-      expect(fs.existsSync(path.join(testProjectRoot, '.gitgov', 'actors'))).toBe(true);
-      expect(fs.existsSync(path.join(testProjectRoot, '.gitgov', 'cycles'))).toBe(true);
-
-      // Return to main
-      execSync('git checkout main', { cwd: testProjectRoot, stdio: 'pipe' });
+      // Verify .gitgov/ exists with expected structure in gitgov-state branch
+      expect(stateFiles).toContain('.gitgov/config.json');
+      expect(stateFiles).toMatch(/\.gitgov\/actors\/.*\.json/);
+      expect(stateFiles).toMatch(/\.gitgov\/cycles\/.*\.json/);
     });
   });
 
@@ -246,22 +242,14 @@ describe('Init CLI Command - Edge Cases E2E Tests', () => {
       const pushResult = runCliCommand(['sync', 'push'], { cwd: testProjectRoot });
       expect(pushResult.success).toBe(true);
 
-      // Checkout gitgov-state and verify it has files
+      // Verify gitgov-state has files using git ls-tree (avoids checkout conflicts with untracked .gitgov/)
       execSync('git fetch origin gitgov-state', { cwd: testProjectRoot, stdio: 'pipe' });
-      execSync('git checkout gitgov-state', { cwd: testProjectRoot, stdio: 'pipe' });
+      const stateFiles = execSync('git ls-tree -r --name-only origin/gitgov-state', { cwd: testProjectRoot, encoding: 'utf8' });
 
-      // Verify .gitgov/ exists with expected structure
-      expect(fs.existsSync(path.join(testProjectRoot, '.gitgov'))).toBe(true);
-      expect(fs.existsSync(path.join(testProjectRoot, '.gitgov', 'config.json'))).toBe(true);
-      expect(fs.existsSync(path.join(testProjectRoot, '.gitgov', 'actors'))).toBe(true);
-      expect(fs.existsSync(path.join(testProjectRoot, '.gitgov', 'cycles'))).toBe(true);
-
-      // Verify at least one actor file exists
-      const actorFiles = fs.readdirSync(path.join(testProjectRoot, '.gitgov', 'actors'));
-      expect(actorFiles.length).toBeGreaterThan(0);
-
-      // Return to main
-      execSync('git checkout main', { cwd: testProjectRoot, stdio: 'pipe' });
+      // Verify .gitgov/ exists with expected structure in gitgov-state branch
+      expect(stateFiles).toContain('.gitgov/config.json');
+      expect(stateFiles).toMatch(/\.gitgov\/actors\/.*\.json/);
+      expect(stateFiles).toMatch(/\.gitgov\/cycles\/.*\.json/);
     });
   });
 


### PR DESCRIPTION
## Summary
- Use `git ls-tree` to verify gitgov-state content instead of `git checkout`
- Fixes test failures when untracked `.gitgov/` files exist in working directory after `gitgov push`

## Test plan
- [x] All e2e tests pass locally (334 tests)
- [x] `init_command_e2e.test.ts` CASE 1 and CASE 2A now pass without checkout conflicts