### PR TITLE
ci: migrate from NPM_TOKEN to OIDC trusted publishers

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -36,8 +36,6 @@ jobs:
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -57,17 +55,6 @@ jobs:
           cd packages/cli
           pnpm build
 
-      - name: Debug NPM Token
-        run: |
-          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
-            echo "❌ NPM_TOKEN is empty or not set"
-          else
-            echo "✅ NPM_TOKEN is set (length: ${#NPM_TOKEN})"
-            echo "✅ Token starts with: ${NPM_TOKEN:0:10}..."
-          fi
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Run Tests
         run: |
           cd packages/cli
@@ -76,7 +63,7 @@ jobs:
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: |
           cd packages/cli
           npx semantic-release

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -36,8 +36,6 @@ jobs:
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -55,7 +53,7 @@ jobs:
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: |
           cd packages/core
           npx semantic-release


### PR DESCRIPTION
## Summary
NPM revoked classic tokens. Migrating to OIDC with provenance for publishing.

## Changes
- Remove `NPM_TOKEN` references from workflows
- Add `NPM_CONFIG_PROVENANCE: true` for OIDC authentication
- Remove debug step for NPM token

## Requirements
Trusted Publishers must be configured in NPM for:
- `@gitgov/core` → workflow: `release-core.yml`
- `@gitgov/cli` → workflow: `release-cli.yml`