### PR TITLE
chore(cli): update @gitgov/core dependency to ^1.8.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@gitgov/core": "workspace:*",
+    "@gitgov/core": "^1.8.0",
     "clipboardy": "^5.0.0",
     "commander": "^11.1.0"
   },


### PR DESCRIPTION
Updates @gitgov/core dependency to use the newly published version 1.8.0