### PR TITLE
fix(core): add tasks to SDK description in README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,7 @@
 [![License: MPL-2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue.svg)](./tsconfig.json)
 
-`@gitgov/core` is the **SDK** for the GitGovernance ecosystem. It provides a type-safe, local-first, and schema-driven API to manage identities, agents, and workflows in software projects.
+`@gitgov/core` is the **SDK** for the GitGovernance ecosystem. It provides a type-safe, local-first, and schema-driven API to manage identities, agents, tasks, and workflows in software projects.
 
 ## 🚀 Quick Start
 


### PR DESCRIPTION
## Summary
- Add "tasks" to the SDK description in README for accuracy

## Test plan
- N/A (documentation only)