### PR TITLE
fix(cli): use --initial-branch=main in sync e2e tests

### DIFF
--- a/packages/cli/e2e/sync_command_e2e.test.ts
+++ b/packages/cli/e2e/sync_command_e2e.test.ts
@@ -70,7 +70,7 @@ describe('Sync CLI Commands - E2E Tests', () => {
   // Helper to create a fresh git repo
   const createGitRepo = (repoPath: string, withInitialCommit: boolean = true) => {
     fs.mkdirSync(repoPath, { recursive: true });
-    execSync('git init', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git init --initial-branch=main', { cwd: repoPath, stdio: 'pipe' });
     execSync('git config user.name "Test User"', { cwd: repoPath, stdio: 'pipe' });
     execSync('git config user.email "test@example.com"', { cwd: repoPath, stdio: 'pipe' });
 
@@ -84,7 +84,7 @@ describe('Sync CLI Commands - E2E Tests', () => {
   // Helper to create a bare remote repo
   const createBareRemote = (remotePath: string) => {
     fs.mkdirSync(remotePath, { recursive: true });
-    execSync(`git init --bare`, { cwd: remotePath, stdio: 'pipe' });
+    execSync(`git init --bare --initial-branch=main`, { cwd: remotePath, stdio: 'pipe' });
   };
 
   // Helper to add remote to repo


### PR DESCRIPTION
Fix sync e2e tests failing with 'src refspec main does not match any'