### PR TITLE
feat(core): add generic metadata support to ExecutionRecord

### DIFF
--- a/packages/core/src/factories/execution_factory.test.ts
+++ b/packages/core/src/factories/execution_factory.test.ts
@@ -1,6 +1,7 @@
 import { createExecutionRecord } from './execution_factory';
 import { generateExecutionId } from '../utils/id_generator';
 import { DetailedValidationError } from '../validation/common';
+import type { ExecutionRecord } from '../types';
 
 // Mock the validator
 jest.mock('../validation/execution_validator', () => ({
@@ -256,6 +257,211 @@ describe('ExecutionRecord Factory', () => {
           const execution = createExecutionRecord(payload);
           expect(execution.result).toBe(result);
         }
+      });
+    });
+
+    describe('Metadata Field Support (EARS 48-51)', () => {
+      it('[EARS-48] should preserve metadata field when provided', async () => {
+        const payload = {
+          taskId: '1752274500-task-test-task',
+          result: 'Successfully completed with metadata',
+          type: 'analysis' as const,
+          title: 'Test with Metadata',
+          metadata: {
+            scannedFiles: 245,
+            duration_ms: 1250
+          }
+        };
+
+        const result = createExecutionRecord(payload);
+
+        expect(result.metadata).toEqual({
+          scannedFiles: 245,
+          duration_ms: 1250
+        });
+      });
+
+      it('[EARS-49] should preserve complex metadata with nested structures', async () => {
+        const payload = {
+          taskId: '1752274500-task-test-task',
+          result: 'GDPR audit completed with findings',
+          type: 'analysis' as const,
+          title: 'GDPR Audit Scan',
+          metadata: {
+            scannedFiles: 245,
+            findings: [
+              { id: 'SEC-001', severity: 'critical', file: 'src/config.ts', line: 5 }
+            ],
+            summary: { critical: 1, high: 0, medium: 0, low: 0 }
+          }
+        };
+
+        const result = createExecutionRecord(payload);
+
+        expect(result.metadata).toEqual({
+          scannedFiles: 245,
+          findings: [
+            { id: 'SEC-001', severity: 'critical', file: 'src/config.ts', line: 5 }
+          ],
+          summary: { critical: 1, high: 0, medium: 0, low: 0 }
+        });
+      });
+
+      it('[EARS-50] should accept ExecutionRecord without metadata', async () => {
+        const payload = {
+          taskId: '1752274500-task-test-task',
+          result: 'Execution without metadata field'
+        };
+
+        const result = createExecutionRecord(payload);
+
+        expect(result.metadata).toBeUndefined();
+      });
+
+      it('[EARS-51] should accept empty metadata object', async () => {
+        const payload = {
+          taskId: '1752274500-task-test-task',
+          result: 'Execution with empty metadata',
+          metadata: {}
+        };
+
+        const result = createExecutionRecord(payload);
+
+        expect(result.metadata).toEqual({});
+      });
+    });
+
+    describe('Generic Metadata Type Support (EARS 52-56)', () => {
+      it('[EARS-52] should allow ExecutionRecord with typed audit metadata', () => {
+        // Define metadata type inline - each module can define its own
+        type AuditMetadata = {
+          scannedFiles: number;
+          findings: Array<{ id: string; severity: string; file: string }>;
+          summary: { critical: number; high: number };
+        };
+
+        const auditMetadata: AuditMetadata = {
+          scannedFiles: 245,
+          findings: [{ id: 'SEC-001', severity: 'critical', file: 'src/config.ts' }],
+          summary: { critical: 1, high: 0 }
+        };
+
+        // ExecutionRecord<T> provides compile-time checking for metadata structure
+        const typedRecord: ExecutionRecord<AuditMetadata> = {
+          id: '1752275500-exec-audit',
+          taskId: '1752274500-task-compliance',
+          type: 'analysis',
+          title: 'Audit Scan',
+          result: 'Scanned 245 files with 1 critical finding',
+          metadata: auditMetadata
+        };
+
+        // Pass directly to factory - no field-by-field copying needed
+        const result = createExecutionRecord(typedRecord);
+
+        expect(result.metadata).toEqual(auditMetadata);
+        expect(result.metadata?.scannedFiles).toBe(245);
+        expect(result.metadata?.findings).toHaveLength(1);
+      });
+
+      it('[EARS-53] should allow ExecutionRecord with typed metrics metadata', () => {
+        type TestMetrics = {
+          durationMs: number;
+          testsPassed: number;
+          coveragePercent: number;
+        };
+
+        const metrics: TestMetrics = {
+          durationMs: 5000,
+          testsPassed: 42,
+          coveragePercent: 95.5
+        };
+
+        const typedRecord: ExecutionRecord<TestMetrics> = {
+          id: '1752275500-exec-test-run',
+          taskId: '1752274500-task-run-tests',
+          type: 'progress',
+          title: 'Test Suite Execution',
+          result: 'All 42 tests passed with 95.5% coverage',
+          metadata: metrics
+        };
+
+        const result = createExecutionRecord(typedRecord);
+
+        expect(result.metadata).toEqual(metrics);
+        expect(result.metadata?.durationMs).toBe(5000);
+        expect(result.metadata?.testsPassed).toBe(42);
+      });
+
+      it('[EARS-54] should allow Partial<ExecutionRecord<T>> for factory input', () => {
+        type PerformanceMetrics = {
+          durationMs: number;
+          memoryMb?: number;
+        };
+
+        // Partial allows omitting non-required fields
+        const payload: Partial<ExecutionRecord<PerformanceMetrics>> = {
+          taskId: '1752274500-task-performance',
+          result: 'Performance test completed successfully',
+          metadata: { durationMs: 1500, memoryMb: 128 }
+        };
+
+        const result = createExecutionRecord(payload);
+
+        expect(result.metadata?.durationMs).toBe(1500);
+        expect(result.metadata?.memoryMb).toBe(128);
+      });
+
+      it('[EARS-55] should allow custom metadata types defined by consumers', () => {
+        // Consumers can define their own metadata types
+        type CustomAuditMetadata = {
+          auditor: string;
+          auditDate: string;
+          passRate: number;
+          issues: string[];
+        };
+
+        const customMetadata: CustomAuditMetadata = {
+          auditor: 'security-team',
+          auditDate: '2025-01-15',
+          passRate: 98.5,
+          issues: ['minor-issue-1', 'minor-issue-2']
+        };
+
+        const typedRecord: ExecutionRecord<CustomAuditMetadata> = {
+          id: '1752275500-exec-custom-audit',
+          taskId: '1752274500-task-security-audit',
+          type: 'analysis',
+          title: 'Security Audit',
+          result: 'Security audit completed with 98.5% pass rate',
+          metadata: customMetadata
+        };
+
+        const result = createExecutionRecord(typedRecord);
+
+        expect(result.metadata).toEqual(customMetadata);
+        expect(result.metadata?.auditor).toBe('security-team');
+        expect(result.metadata?.passRate).toBe(98.5);
+      });
+
+      it('[EARS-56] should allow ExecutionRecord<T> without metadata (optional)', () => {
+        type SomeMetadata = {
+          field: string;
+        };
+
+        // ExecutionRecord<T> works without metadata since it's optional
+        const typedRecord: ExecutionRecord<SomeMetadata> = {
+          id: '1752275500-exec-no-metadata',
+          taskId: '1752274500-task-simple',
+          type: 'progress',
+          title: 'Simple Progress',
+          result: 'Progress without metadata field'
+          // metadata is optional
+        };
+
+        const result = createExecutionRecord(typedRecord);
+
+        expect(result.metadata).toBeUndefined();
       });
     });
   });

--- a/packages/core/src/schemas/generated/execution_record_schema.json
+++ b/packages/core/src/schemas/generated/execution_record_schema.json
@@ -77,6 +77,29 @@
       },
       "default": [],
       "description": "Optional list of typed references to relevant commits, files, PRs, or external documents.\nShould use typed prefixes for clarity and trazabilidad (see execution_protocol_appendix.md):\n- commit:     Git commit SHA\n- pr:         Pull Request number\n- file:       File path (relative to repo root)\n- url:        External URL\n- issue:      GitHub Issue number\n- task:       TaskRecord ID\n- exec:       ExecutionRecord ID (for corrections or dependencies)\n- changelog:  ChangelogRecord ID\n"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Optional structured data for machine consumption.\nUse this field for data that needs to be programmatically processed (e.g., audit findings,\nperformance metrics, scan results). This complements result (human-readable WHAT) and\nnotes (narrative HOW/WHY) by providing structured, queryable data.\nCommon use cases: audit findings arrays, performance metrics, tool outputs, scan summaries.\n",
+      "examples": [
+        {
+          "findings": [
+            {
+              "type": "PII",
+              "file": "src/user.ts",
+              "line": 42
+            }
+          ],
+          "scannedFiles": 245
+        },
+        {
+          "metrics": {
+            "duration_ms": 1250,
+            "memory_mb": 512
+          }
+        }
+      ]
     }
   },
   "examples": [
@@ -149,6 +172,52 @@
       "references": [
         "exec:1752275500-exec-refactor-queries"
       ]
+    },
+    {
+      "id": "1752276000-exec-gdpr-audit-scan",
+      "taskId": "1752274500-task-gdpr-compliance",
+      "type": "analysis",
+      "title": "GDPR Audit Scan - 2025-01-15",
+      "result": "Escaneados 245 archivos. Encontrados 10 findings (3 critical, 4 high, 3 medium). Ver metadata para detalles estructurados.",
+      "notes": "Scan ejecutado con RegexDetector + HeuristicDetector. LLM calls: 0 (tier free).",
+      "references": [
+        "file:src/config/db.ts",
+        "file:src/auth/keys.ts"
+      ],
+      "metadata": {
+        "scannedFiles": 245,
+        "scannedLines": 18420,
+        "duration_ms": 1250,
+        "findings": [
+          {
+            "id": "SEC-001",
+            "severity": "critical",
+            "file": "src/config/db.ts",
+            "line": 5,
+            "type": "api_key"
+          },
+          {
+            "id": "SEC-003",
+            "severity": "critical",
+            "file": "src/auth/keys.ts",
+            "line": 2,
+            "type": "private_key"
+          },
+          {
+            "id": "PII-003",
+            "severity": "critical",
+            "file": "src/payments/stripe.ts",
+            "line": 8,
+            "type": "credit_card"
+          }
+        ],
+        "summary": {
+          "critical": 3,
+          "high": 4,
+          "medium": 3,
+          "low": 0
+        }
+      }
     }
   ]
 }

--- a/packages/core/src/types/generated/agent_record.ts
+++ b/packages/core/src/types/generated/agent_record.ts
@@ -7,7 +7,7 @@
 /**
  * Canonical schema for agent operational manifests.
  */
-export interface AgentRecord {
+export interface AgentRecord<TMetadata = object> {
   /**
    * Unique identifier for the agent, linking to an ActorRecord.
    */
@@ -40,9 +40,7 @@ export interface AgentRecord {
    * This field does NOT affect agent execution - it is purely informational.
    *
    */
-  metadata?: {
-    [k: string]: unknown | undefined;
-  };
+  metadata?: TMetadata;
   engine:
     | {
         type: 'local';

--- a/packages/core/src/types/generated/execution_record.ts
+++ b/packages/core/src/types/generated/execution_record.ts
@@ -7,7 +7,7 @@
 /**
  * Canonical schema for execution log records - the universal event stream
  */
-export interface ExecutionRecord {
+export interface ExecutionRecord<TMetadata = object> {
   /**
    * Unique identifier for the execution log entry (10 timestamp + 1 dash + 4 'exec' + 1 dash + max 50 slug = 66 max)
    */
@@ -50,4 +50,13 @@ export interface ExecutionRecord {
    *
    */
   references?: string[];
+  /**
+   * Optional structured data for machine consumption.
+   * Use this field for data that needs to be programmatically processed (e.g., audit findings,
+   * performance metrics, scan results). This complements result (human-readable WHAT) and
+   * notes (narrative HOW/WHY) by providing structured, queryable data.
+   * Common use cases: audit findings arrays, performance metrics, tool outputs, scan summaries.
+   *
+   */
+  metadata?: TMetadata;
 }


### PR DESCRIPTION
## Summary

- Post-process generated types in `compile-json-to-types.ts` to convert fields with `additionalProperties: true` to generic type parameters
- `ExecutionRecord<TMetadata = object>` now allows strongly-typed metadata for compile-time safety
- `createExecutionRecord` factory is now generic and preserves the metadata type
- `AgentRecord` also gains generic metadata support as a side effect

## Changes

### `compile-json-to-types.ts`
- Added `detectGenericFields()` to find properties with `type: object` + `additionalProperties: true`
- Added `addGenericParameters()` to post-process generated TypeScript and add generic parameters

### Generated Types
- `ExecutionRecord<TMetadata = object>` with `metadata?: TMetadata`
- `AgentRecord<TMetadata = object>` with `metadata?: TMetadata`

### Factory
- `createExecutionRecord<TMetadata extends object = object>()` preserves the metadata type

### Tests
- Added EARS 48-51: Metadata field support tests
- Added EARS 52-56: Generic metadata type support tests

## Usage Example

```typescript
type AuditMetadata = {
  scannedFiles: number;
  findings: Array<{ id: string; severity: string }>;
};

const record = createExecutionRecord<AuditMetadata>({
  taskId: '1752274500-task-audit',
  result: 'Audit complete',
  metadata: { scannedFiles: 245, findings: [] }
});
// record.metadata?.scannedFiles is typed as number
```

## Test plan
- [x] All 22 execution_factory tests pass
- [x] All 168 core tests pass
- [x] tsc compiles without errors