### PR TITLE
feat(agents): add GDPR audit agent with formatted output

### DIFF
--- a/packages/agents/gdpr-audit/index.ts
+++ b/packages/agents/gdpr-audit/index.ts
@@ -1,0 +1,145 @@
+/**
+ * GDPR Audit Agent
+ *
+ * Executes GDPR/PII audit on source code using SourceAuditorModule.
+ * Detects sensitive data (emails, API keys, credit cards) in code.
+ */
+
+import {
+  SourceAuditor,
+  PiiDetector,
+  Config,
+} from '@gitgov/core';
+
+type AgentExecutionContext = {
+  agentId: string;
+  actorId: string;
+  taskId: string;
+  runId: string;
+  input?: unknown;
+};
+
+type AgentOutput = {
+  data?: unknown;
+  message?: string;
+  artifacts?: string[];
+  metadata?: Record<string, unknown>;
+};
+
+interface AuditInput {
+  /** Base directory to audit (default: process.cwd()) */
+  baseDir?: string;
+  /** Include patterns (glob patterns) */
+  include?: string[];
+  /** Exclude patterns (default: node_modules, .git, dist, build) */
+  exclude?: string[];
+  /** Minimum severity to report (default: 'low') */
+  minSeverity?: 'critical' | 'high' | 'medium' | 'low';
+}
+
+/**
+ * Main agent function.
+ * Called by the AgentRunnerModule when the agent is executed.
+ */
+export async function runAudit(ctx: AgentExecutionContext): Promise<AgentOutput> {
+  const startTime = Date.now();
+  const input = (ctx.input as AuditInput) || {};
+
+  // Use ConfigManager to find project root (like git works from any subfolder)
+  const projectRoot = Config.ConfigManager.findProjectRoot() || process.cwd();
+  const baseDir = input.baseDir || projectRoot;
+  const include = input.include || ['**/*'];
+  const exclude = input.exclude || [
+    '**/node_modules/**',
+    '**/.git/**',
+    '**/dist/**',
+    '**/build/**',
+    '**/*.min.js',
+    '**/package-lock.json',
+    '**/pnpm-lock.yaml',
+  ];
+
+  try {
+    // Create PII detector with default config (regex enabled by default)
+    const piiDetector = new PiiDetector.PiiDetectorModule({
+      regex: { enabled: true },
+    });
+
+    // Create a no-op waiver reader (waivers handled externally)
+    const waiverReader: SourceAuditor.IWaiverReader = {
+      loadActiveWaivers: async () => [],
+      hasActiveWaiver: async () => false,
+    };
+
+    // Create source auditor
+    const sourceAuditor = new SourceAuditor.SourceAuditorModule({
+      piiDetector,
+      waiverReader,
+    });
+
+    // Execute audit
+    const result = await sourceAuditor.audit({
+      baseDir,
+      scope: {
+        include,
+        exclude,
+      },
+    });
+
+    // Filter by minimum severity if specified
+    let findings = result.findings;
+    if (input.minSeverity) {
+      const severityOrder = { critical: 4, high: 3, medium: 2, low: 1 };
+      const minLevel = severityOrder[input.minSeverity];
+      findings = findings.filter(f => severityOrder[f.severity] >= minLevel);
+    }
+
+    const duration = Date.now() - startTime;
+    const { summary } = result;
+
+    // Build formatted message with table
+    const lines: string[] = [];
+    lines.push('');
+    lines.push('┌──────────┬───────┬──────────────────────────┐');
+    lines.push('│ Severity │ Count │ Status                   │');
+    lines.push('├──────────┼───────┼──────────────────────────┤');
+    lines.push(`│ Critical │ ${String(summary.bySeverity.critical).padStart(5)} │ ${summary.bySeverity.critical > 0 ? '🔴 Blocking' : '✅ None'}${' '.repeat(summary.bySeverity.critical > 0 ? 15 : 19)} │`);
+    lines.push(`│ High     │ ${String(summary.bySeverity.high).padStart(5)} │ ${summary.bySeverity.high > 0 ? '🟠 Attention' : '✅ None'}${' '.repeat(summary.bySeverity.high > 0 ? 14 : 19)} │`);
+    lines.push(`│ Medium   │ ${String(summary.bySeverity.medium).padStart(5)} │ ${summary.bySeverity.medium > 0 ? '🟡 Review' : '✅ None'}${' '.repeat(summary.bySeverity.medium > 0 ? 17 : 19)} │`);
+    lines.push(`│ Low      │ ${String(summary.bySeverity.low).padStart(5)} │ ${summary.bySeverity.low > 0 ? '🔵 Info' : '✅ None'}${' '.repeat(summary.bySeverity.low > 0 ? 18 : 19)} │`);
+    lines.push('└──────────┴───────┴──────────────────────────┘');
+    lines.push('');
+    lines.push(`Scanned: ${result.scannedFiles} files (${result.scannedLines.toLocaleString()} lines)`);
+    lines.push(`Total:   ${findings.length} findings`);
+    lines.push(`Time:    ${duration}ms`);
+
+    return {
+      message: lines.join('\n'),
+      metadata: {
+        executedAt: new Date().toISOString(),
+        duration,
+        baseDir,
+        version: '1.0.0',
+        summary: result.summary,
+        scannedFiles: result.scannedFiles,
+        scannedLines: result.scannedLines,
+        detectors: result.detectors,
+        waivers: result.waivers,
+        findingsCount: findings.length,
+        findings,
+      },
+    };
+  } catch (error) {
+    return {
+      message: `GDPR audit failed: ${(error as Error).message}`,
+      metadata: {
+        executedAt: new Date().toISOString(),
+        duration: Date.now() - startTime,
+        baseDir,
+        version: '1.0.0',
+        error: (error as Error).message,
+        stack: (error as Error).stack,
+      },
+    };
+  }
+}

--- a/packages/agents/gdpr-audit/package.json
+++ b/packages/agents/gdpr-audit/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@gitgov/agent-gdpr-audit",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "dist/index.mjs",
+  "scripts": {
+    "build": "esbuild index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.mjs --external:@gitgov/core",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@gitgov/core": "workspace:*"
+  },
+  "devDependencies": {
+    "esbuild": "^0.19.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/cli/src/commands/agent/agent-command.test.ts
+++ b/packages/cli/src/commands/agent/agent-command.test.ts
@@ -102,16 +102,15 @@ describe('AgentCommand', () => {
     status: 'active',
     priority: 'medium',
     tags: ['agent', 'automated'],
-    createdAt: '2025-12-21T10:00:00.000Z',
-    updatedAt: '2025-12-21T10:00:00.000Z',
   };
 
   // Mock ActorRecord
   const mockActor: Records.ActorRecord = {
     id: 'human:developer',
     type: 'human',
-    name: 'Developer',
-    email: 'dev@example.com',
+    displayName: 'Developer',
+    publicKey: 'mock-public-key-base64-encoded-44chars==',
+    roles: ['developer'],
   };
 
   beforeEach(() => {

--- a/packages/core/src/runner/agent_runner_module.test.ts
+++ b/packages/core/src/runner/agent_runner_module.test.ts
@@ -483,10 +483,15 @@ describe("AgentRunnerModule", () => {
 
       expect(mockExecutionAdapter.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          agentId: "agent:success",
           taskId: "task:1",
-          status: "success",
-          output: expect.objectContaining({ data: "ok" }),
+          type: "completion",
+          title: "Agent execution: agent:success",
+          result: expect.stringContaining("completed successfully"),
+          metadata: expect.objectContaining({
+            agentId: "agent:success",
+            status: "success",
+            output: expect.objectContaining({ data: "ok" }),
+          }),
         }),
         expect.any(String)
       );
@@ -514,9 +519,16 @@ describe("AgentRunnerModule", () => {
 
       expect(mockExecutionAdapter.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: "error",
-          error: "fail",
-          output: undefined,
+          taskId: "task:1",
+          type: "blocker",
+          title: "Agent execution: agent:error",
+          result: expect.stringContaining("failed"),
+          metadata: expect.objectContaining({
+            agentId: "agent:error",
+            status: "error",
+            error: "fail",
+            output: undefined,
+          }),
         }),
         expect.any(String)
       );

--- a/packages/core/src/runner/backends/local_backend.ts
+++ b/packages/core/src/runner/backends/local_backend.ts
@@ -102,9 +102,12 @@ export class LocalBackend {
 
     if (typeof result === "object") {
       const obj = result as Record<string, unknown>;
-      const output: AgentOutput = {
-        data: obj["data"] ?? obj,
-      };
+      const output: AgentOutput = {};
+
+      // Only include data if explicitly returned
+      if (obj["data"] !== undefined) {
+        output.data = obj["data"];
+      }
 
       const message = obj["message"];
       if (typeof message === "string") {


### PR DESCRIPTION
## Summary
- Add new GDPR audit agent that analyzes code for GDPR compliance issues
- Fix TypeScript strict mode errors in agent-command CLI
- Fix AgentOutput to only include data field when explicitly returned by agents

## Changes
- `packages/agents/gdpr-audit/` - New GDPR audit agent implementation
- `packages/cli/src/commands/agent/` - TypeScript fixes for strict mode
- `packages/core/src/runner/` - AgentOutput data handling fix

## Test plan
- [ ] Run `gitgov agent run gdpr-audit` to verify agent works correctly
- [ ] Verify formatted output displays properly in CLI
- [ ] Run existing agent tests to ensure no regressions