### PR TITLE
fix(cli): pin @gitgov/core dependency to ^2.0.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@gitgov/core": "workspace:*",
+    "@gitgov/core": "^2.0.0",
     "clipboardy": "^5.0.0",
     "commander": "^11.1.0"
   },


### PR DESCRIPTION
## Summary

- Update `@gitgov/core` dependency from `workspace:*` to `^2.0.0`
- Matches latest published core version after PR #85 (sync/prebuild separation)

## Test plan

- [ ] Release CLI workflow passes (builds core with new prebuild, publishes CLI)