### PR TITLE
fix(core): update sync-prompts.ts path to private/packages/blueprints

### DIFF
--- a/packages/core/scripts/sync-prompts.ts
+++ b/packages/core/scripts/sync-prompts.ts
@@ -17,7 +17,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const MONOREPO_ROOT = path.resolve(__dirname, '../../..');
-const SOURCE_DIR = path.join(MONOREPO_ROOT, 'packages/blueprints/02_agents/design');
+const SOURCE_DIR = path.join(MONOREPO_ROOT, 'packages/private/packages/blueprints/02_agents/design');
 const TARGET_DIR = path.join(__dirname, '../src/docs/generated');
 
 // Agent prompts to sync (official prompts that ship with @gitgov/core)


### PR DESCRIPTION
## Summary

- Fixed `sync-prompts.ts` to resolve blueprints via `packages/private/packages/blueprints` instead of the old `packages/blueprints` path
- Same fix applied in #89 to `sync-schemas.ts` and `sync-workflow-configs.ts` — this one was missed

## Test plan

- [x] `pnpm sync:prompts` succeeds: 1 prompt synced, 0 errors