### PR TITLE
feat: interface completeness — exec, feedback, actor, workflow, identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 ![Tests](https://img.shields.io/badge/Core-2628%20tests-success)
 ![License: Apache-2.0](https://img.shields.io/badge/CLI-Apache--2.0-blue.svg)
 ![cli npm version](https://img.shields.io/npm/v/@gitgov/cli?color=orange&label=CLI%20npm)
-![Tests](https://img.shields.io/badge/CLI-403%20tests-success)
+![Tests](https://img.shields.io/badge/CLI-450%20tests-success)
+![License: Apache-2.0](https://img.shields.io/badge/MCP--Server-Apache--2.0-blue.svg)
+![Tests](https://img.shields.io/badge/MCP--Server-199%20tests-success)
 
 # GitGovernance
 
@@ -70,6 +72,7 @@ Agent:  "Sprint is 70% done, 3 tasks active, 1 blocked."
 | **Protocol** | Apache 2.0 | The **Standard** -- RFCs, schemas, and normative specifications. | [`protocol/`](packages/private/packages/blueprints/03_products/protocol/unified/) |
 | **`@gitgov/core`** | MPL-2.0 | The **Engine** -- Type-safe SDK for business logic, records, validation, storage, adapters. | [`README.md`](packages/core/README.md) |
 | **`@gitgov/cli`** | Apache 2.0 | The **Tool** -- Command-line interface for humans and AI agents. | [`README.md`](packages/cli/README.md) |
+| **`@gitgov/mcp-server`** | Apache 2.0 | The **Bridge** -- MCP server exposing 43 tools for AI agents (Claude Code, Cursor, Windsurf). | [`README.md`](packages/mcp-server/README.md) |
 
 ## Community
 
@@ -82,8 +85,9 @@ Agent:  "Sprint is 70% done, 3 tasks active, 1 blocked."
 - **Protocol Specs (RFCs, Schemas)**: [Apache License 2.0](https://opensource.org/licenses/Apache-2.0)
 - **`@gitgov/core`**: [Mozilla Public License 2.0 (MPL-2.0)](https://opensource.org/licenses/MPL-2.0)
 - **`@gitgov/cli`**: [Apache License 2.0](https://opensource.org/licenses/Apache-2.0)
+- **`@gitgov/mcp-server`**: [Apache License 2.0](https://opensource.org/licenses/Apache-2.0)
 
-The protocol specification is licensed permissively to maximize adoption as an open standard. The core SDK uses weak copyleft to protect shared improvements while allowing commercial integration.
+The protocol specification is licensed permissively to maximize adoption as an open standard. The core SDK uses weak copyleft to protect shared improvements while allowing commercial integration. The CLI and MCP server are permissively licensed to maximize distribution as adoption tools.
 
 ---
 

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024-2026 GitGovernance
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,6 +48,8 @@ Commands:
   init [options]         Initialize GitGovernance project
   task|t                 Create and manage TaskRecords
   cycle|c                Create and manage CycleRecords
+  exec|x                Record proof-of-work via ExecutionRecords
+  feedback|fb            Create structured, immutable FeedbackRecords
   status [options]       Show intelligent project status dashboard
   dashboard [options]    Launch interactive TUI dashboard
   indexer [options]      Control local cache system
@@ -55,6 +57,7 @@ Commands:
   lint [options] [path]  Validate GitGovernance records
   audit [options]        Audit source code (PII/secrets, GDPR)
   agent                  Manage and run GitGov agents
+  actor                  Manage project actors (identity)
   sync                   State synchronization (push/pull/resolve/audit)
   context [options]      Query working context for agents and automation
   push [options]         Alias for "gitgov sync push"
@@ -78,6 +81,30 @@ draft -> review -> ready -> active -> done -> archived
 ```
 
 15 subcommands: `new`, `list`, `show`, `submit`, `approve`, `activate`, `pause`, `resume`, `complete`, `cancel`, `reject`, `delete`, `assign`, `edit`, `promote`
+
+### Execution Tracking
+
+Record proof-of-work against tasks:
+
+```
+  Create:    gitgov exec new <taskId> --result "OAuth handler implemented"
+  List:      gitgov exec list <taskId>
+  Show:      gitgov exec show <executionId>
+```
+
+3 subcommands: `new`, `list`, `show`
+
+Execution types: `analysis`, `progress` (default), `blocker`, `completion`, `info`, `correction`
+
+### Feedback
+
+Create structured, immutable feedback linked to any entity:
+
+```
+  Create:    gitgov feedback --entity-type task --entity-id <id> --type approval --content "LGTM"
+```
+
+Feedback types: `blocking`, `suggestion`, `question`, `approval`, `clarification`, `assignment`
 
 ### Cycle Management
 
@@ -115,7 +142,7 @@ gitgov sync resolve --reason "..."      # Resolve conflicts
 ```mermaid
 graph TD
     subgraph "@gitgov/cli"
-        Commands["Commands (12)"]
+        Commands["Commands (16)"]
         Base["BaseCommand / SimpleCommand"]
         DI["DependencyInjectionService"]
         TUI["Ink/React TUI"]

--- a/packages/cli/src/commands/actor/actor-command.test.ts
+++ b/packages/cli/src/commands/actor/actor-command.test.ts
@@ -60,8 +60,8 @@ describe('ActorCommand', () => {
     mockProcessExit.mockClear();
   });
 
-  describe('4.1. Actor Creation (EARS-1)', () => {
-    it('[EARS-1] WHEN actor new is executed with valid flags THE SYSTEM SHALL create ActorRecord with keys', async () => {
+  describe('4.1. Actor Creation (ICOMP-C4 to ICOMP-C6)', () => {
+    it('[ICOMP-C4] WHEN actor new is executed with valid flags THE SYSTEM SHALL create ActorRecord with keys', async () => {
       mockIdentityAdapter.createActor.mockResolvedValue(sampleActor);
 
       await actorCommand.executeNew({
@@ -94,7 +94,7 @@ describe('ActorCommand', () => {
       expect(output.data.roles).toEqual(['developer']);
     });
 
-    it('[EARS-1b] WHEN actor new is executed with invalid type THE SYSTEM SHALL fail with error', async () => {
+    it('[ICOMP-C5] WHEN actor new is executed with invalid type THE SYSTEM SHALL fail with error', async () => {
       mockIdentityAdapter.createActor.mockRejectedValue(
         new Error('ActorRecord requires type and displayName')
       );
@@ -109,6 +109,30 @@ describe('ActorCommand', () => {
         expect.stringContaining('Failed to create actor')
       );
       expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it('[ICOMP-C6] WHEN --json flag is provided THE SYSTEM SHALL output JSON with success and data fields', async () => {
+      mockIdentityAdapter.createActor.mockResolvedValue(sampleActor);
+
+      await actorCommand.executeNew({
+        type: 'human',
+        name: 'Test User',
+        role: ['developer'],
+        json: true
+      });
+
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const outputCall = mockConsoleLog.mock.calls.find(call =>
+        typeof call[0] === 'string' && call[0].includes('"success"')
+      );
+      expect(outputCall).toBeDefined();
+      const output = JSON.parse(outputCall![0]);
+      expect(output.success).toBe(true);
+      expect(output.data).toBeDefined();
+      expect(output.data.actorId).toBeDefined();
+      expect(output.data.type).toBeDefined();
+      expect(output.data.displayName).toBeDefined();
+      expect(output.data.roles).toBeDefined();
     });
   });
 

--- a/packages/cli/src/commands/exec/exec_command.test.ts
+++ b/packages/cli/src/commands/exec/exec_command.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Exec Command tests — Block A (ICOMP-A1 to ICOMP-A9)
+ * Blueprint: exec_command.md §4
+ */
+
+// Mock @gitgov/core FIRST to avoid import.meta issues
+jest.mock('@gitgov/core', () => ({
+  Records: {},
+  Factories: {
+    createExecutionRecord: jest.fn((data) => data),
+    createTestSignature: jest.fn((keyId, role, notes) => ({
+      keyId, role, notes, timestamp: Date.now(), signature: 'A'.repeat(86) + '=='
+    })),
+  }
+}));
+
+// Mock DependencyInjectionService
+jest.mock('../../services/dependency-injection', () => ({
+  DependencyInjectionService: {
+    getInstance: jest.fn()
+  }
+}));
+
+import { ExecCommand } from './exec_command';
+import { DependencyInjectionService } from '../../services/dependency-injection';
+
+// Test fixtures
+const mockExecution = {
+  id: '1752361200-exec-oauth-callback',
+  taskId: '1752274500-task-oauth',
+  type: 'progress',
+  title: 'Implement OAuth callback',
+  result: 'OAuth2 callback handler completed with token validation.',
+  notes: 'Used NextAuth.js',
+  references: ['commit:abc123'],
+};
+
+const mockExecution2 = {
+  id: '1752361300-exec-api-blocker',
+  taskId: '1752274500-task-oauth',
+  type: 'blocker',
+  title: 'API down',
+  result: 'Cannot continue — payment API returns 503.',
+  references: [],
+};
+
+// Mock console and process.exit at module level (task-command pattern)
+const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
+const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
+const mockProcessExit = jest.spyOn(process, 'exit').mockImplementation();
+
+describe('ExecCommand', () => {
+  let execCommand: ExecCommand;
+  let mockExecutionAdapter: {
+    create: jest.MockedFunction<any>;
+    getExecution: jest.MockedFunction<any>;
+    getExecutionsByTask: jest.MockedFunction<any>;
+    getAllExecutions: jest.MockedFunction<any>;
+  };
+  let mockIdentityAdapter: {
+    getCurrentActor: jest.MockedFunction<any>;
+  };
+  let mockProjector: {
+    invalidateCache: jest.MockedFunction<any>;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockExecutionAdapter = {
+      create: jest.fn().mockResolvedValue(mockExecution),
+      getExecution: jest.fn().mockResolvedValue(null),
+      getExecutionsByTask: jest.fn().mockResolvedValue([]),
+      getAllExecutions: jest.fn().mockResolvedValue([]),
+    };
+
+    mockIdentityAdapter = {
+      getCurrentActor: jest.fn().mockResolvedValue({ id: 'human:dev', displayName: 'Dev', type: 'human' }),
+    };
+
+    mockProjector = {
+      invalidateCache: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const mockDependencyService = {
+      getExecutionAdapter: jest.fn().mockResolvedValue(mockExecutionAdapter),
+      getIdentityAdapter: jest.fn().mockResolvedValue(mockIdentityAdapter),
+      getRecordProjector: jest.fn().mockResolvedValue(mockProjector),
+    };
+
+    // Set up mock BEFORE constructing command (critical — BaseCommand reads DI in constructor)
+    (DependencyInjectionService.getInstance as jest.MockedFunction<typeof DependencyInjectionService.getInstance>)
+      .mockReturnValue(mockDependencyService as never);
+
+    execCommand = new ExecCommand();
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    mockProcessExit.mockClear();
+  });
+
+  describe('4.1. Subcommand new — Creation (ICOMP-A1 to ICOMP-A5)', () => {
+
+    it('[ICOMP-A1] should abort when --result is not provided', async () => {
+      await execCommand.executeNew('task-1', { result: '' } as any);
+
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('--result is required')
+      );
+    });
+
+    it('[ICOMP-A2] should abort when taskId does not exist', async () => {
+      mockExecutionAdapter.create.mockRejectedValue(new Error('Task not found: task-nonexistent'));
+
+      await execCommand.executeNew('task-nonexistent', { result: 'Some result' } as any);
+
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Task not found')
+      );
+    });
+
+    it('[ICOMP-A3] should create ExecutionRecord via adapter', async () => {
+      await execCommand.executeNew('1752274500-task-oauth', {
+        result: 'OAuth2 callback handler completed with token validation.',
+        type: 'progress',
+        title: 'Implement OAuth callback',
+      } as any);
+
+      expect(mockExecutionAdapter.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: '1752274500-task-oauth',
+          result: 'OAuth2 callback handler completed with token validation.',
+          type: 'progress',
+          title: 'Implement OAuth callback',
+        }),
+        'human:dev',
+      );
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Execution created')
+      );
+    });
+
+    it('[ICOMP-A4] should pass multiple references to adapter', async () => {
+      await execCommand.executeNew('1752274500-task-oauth', {
+        result: 'Done',
+        reference: ['commit:abc123', 'pr:456', 'file:src/auth.ts'],
+      } as any);
+
+      expect(mockExecutionAdapter.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          references: ['commit:abc123', 'pr:456', 'file:src/auth.ts'],
+        }),
+        'human:dev',
+      );
+    });
+
+    it('[ICOMP-A5] should default to type progress when not specified', async () => {
+      await execCommand.executeNew('1752274500-task-oauth', {
+        result: 'Some work done',
+      } as any);
+
+      expect(mockExecutionAdapter.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'progress',
+        }),
+        'human:dev',
+      );
+    });
+  });
+
+  describe('4.2. Subcommand list — Query (ICOMP-A6 to ICOMP-A7)', () => {
+
+    it('[ICOMP-A6] should list executions for a specific task', async () => {
+      mockExecutionAdapter.getExecutionsByTask.mockResolvedValue([mockExecution, mockExecution2]);
+
+      await execCommand.executeList('1752274500-task-oauth', { json: true } as any);
+
+      expect(mockExecutionAdapter.getExecutionsByTask).toHaveBeenCalledWith('1752274500-task-oauth');
+      const output = JSON.parse(mockConsoleLog.mock.calls[0]![0]);
+      expect(output.data.total).toBe(2);
+      expect(output.data.executions).toHaveLength(2);
+    });
+
+    it('[ICOMP-A7] should list all executions when no taskId given', async () => {
+      mockExecutionAdapter.getAllExecutions.mockResolvedValue([mockExecution]);
+
+      await execCommand.executeList(undefined, { json: true } as any);
+
+      expect(mockExecutionAdapter.getAllExecutions).toHaveBeenCalled();
+      const output = JSON.parse(mockConsoleLog.mock.calls[0]![0]);
+      expect(output.data.total).toBe(1);
+    });
+  });
+
+  describe('4.3. Subcommand show — Detail (ICOMP-A8 to ICOMP-A9)', () => {
+
+    it('[ICOMP-A8] should display full execution details', async () => {
+      mockExecutionAdapter.getExecution.mockResolvedValue(mockExecution);
+
+      await execCommand.executeShow('1752361200-exec-oauth-callback', { json: true } as any);
+
+      expect(mockExecutionAdapter.getExecution).toHaveBeenCalledWith('1752361200-exec-oauth-callback');
+      const output = JSON.parse(mockConsoleLog.mock.calls[0]![0]);
+      expect(output.data.id).toBe('1752361200-exec-oauth-callback');
+      expect(output.data.taskId).toBe('1752274500-task-oauth');
+      expect(output.data.type).toBe('progress');
+      expect(output.data.result).toBe('OAuth2 callback handler completed with token validation.');
+    });
+
+    it('[ICOMP-A9] should abort when executionId does not exist', async () => {
+      mockExecutionAdapter.getExecution.mockResolvedValue(null);
+
+      await execCommand.executeShow('exec-nonexistent', {} as any);
+
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Execution not found')
+      );
+    });
+  });
+});

--- a/packages/cli/src/commands/exec/exec_command.ts
+++ b/packages/cli/src/commands/exec/exec_command.ts
@@ -1,0 +1,215 @@
+import { Command } from 'commander';
+import { BaseCommand } from '../../base/base-command';
+import type { BaseCommandOptions } from '../../interfaces/command';
+import type { ExecNewOptions, ExecListOptions, ExecShowOptions } from './exec_command.types';
+
+/**
+ * ExecCommand — Registers proof-of-work via ExecutionRecords.
+ *
+ * Delegates all business logic to ExecutionAdapter.
+ * Blueprint: exec_command.md
+ */
+export class ExecCommand extends BaseCommand<BaseCommandOptions> {
+
+  register(program: Command): void {
+    // Not used — registration happens via registerExecCommands()
+  }
+
+  async execute(options: BaseCommandOptions): Promise<void> {
+    this.handleError('No action specified. Use --help for available options.', options);
+  }
+
+  /**
+   * gitgov exec new <taskId> — Create a new ExecutionRecord
+   * EARS: ICOMP-A1..A5
+   */
+  async executeNew(taskId: string, options: ExecNewOptions): Promise<void> {
+    try {
+      // [ICOMP-A1] Validate --result is provided
+      if (!options.result || options.result.trim().length === 0) {
+        this.handleError('--result is required', options);
+        return;
+      }
+
+      const executionAdapter = await this.dependencyService.getExecutionAdapter();
+      const projector = await this.dependencyService.getRecordProjector();
+      const { actorId } = await this.requireActor(options);
+
+      // Build payload
+      const payload: Record<string, unknown> = {
+        taskId,
+        result: options.result,
+        type: options.type || 'progress', // [ICOMP-A5] default progress
+        title: options.title || '',
+        notes: options.notes,
+        references: options.reference || [], // [ICOMP-A4] multiple references
+      };
+
+      // [ICOMP-A2] + [ICOMP-A3] Delegate to adapter (adapter validates taskId exists)
+      const execution = await executionAdapter.create(payload, actorId);
+
+      // Invalidate projector cache
+      await projector.invalidateCache();
+
+      // Output
+      if (options.json) {
+        console.log(JSON.stringify({
+          success: true,
+          data: {
+            id: execution.id,
+            taskId: execution.taskId,
+            type: execution.type,
+            title: execution.title,
+            result: execution.result,
+            references: execution.references || [],
+          }
+        }, null, 2));
+      } else if (!options.quiet) {
+        console.log(`✅ Execution created: ${execution.id}`);
+        console.log(`   Task:  ${execution.taskId}`);
+        console.log(`   Type:  ${execution.type}`);
+        if (execution.title) {
+          console.log(`   Title: ${execution.title}`);
+        }
+      }
+    } catch (error) {
+      this.handleExecError(error, options);
+    }
+  }
+
+  /**
+   * gitgov exec list [taskId] — List executions
+   * EARS: ICOMP-A6..A7
+   */
+  async executeList(taskId: string | undefined, options: ExecListOptions): Promise<void> {
+    try {
+      const executionAdapter = await this.dependencyService.getExecutionAdapter();
+
+      // [ICOMP-A6] + [ICOMP-A7]
+      let executions = taskId
+        ? await executionAdapter.getExecutionsByTask(taskId)
+        : await executionAdapter.getAllExecutions();
+
+      // Apply type filter
+      if (options.type) {
+        executions = executions.filter(e => e.type === options.type);
+      }
+
+      // Apply limit
+      const limit = options.limit || 50;
+      executions = executions.slice(0, limit);
+
+      if (options.json) {
+        console.log(JSON.stringify({
+          success: true,
+          data: {
+            total: executions.length,
+            executions: executions.map(e => ({
+              id: e.id,
+              taskId: e.taskId,
+              type: e.type,
+              title: e.title,
+              result: e.result,
+            })),
+          }
+        }, null, 2));
+      } else if (options.quiet) {
+        executions.forEach(e => console.log(e.id));
+      } else {
+        if (executions.length === 0) {
+          console.log(taskId
+            ? `No executions found for task: ${taskId}`
+            : 'No executions found.');
+          return;
+        }
+
+        const header = taskId
+          ? `EXECUTIONS (Task: ${taskId})`
+          : 'ALL EXECUTIONS';
+        console.log(header);
+        console.log(`${'ID'.padEnd(50)} ${'TYPE'.padEnd(12)} TITLE`);
+
+        for (const e of executions) {
+          console.log(`${e.id.padEnd(50)} ${e.type.padEnd(12)} ${e.title || '(untitled)'}`);
+        }
+      }
+    } catch (error) {
+      this.handleExecError(error, options);
+    }
+  }
+
+  /**
+   * gitgov exec show <executionId> — Show execution details
+   * EARS: ICOMP-A8..A9
+   */
+  async executeShow(executionId: string, options: ExecShowOptions): Promise<void> {
+    try {
+      const executionAdapter = await this.dependencyService.getExecutionAdapter();
+
+      // [ICOMP-A8] + [ICOMP-A9]
+      const execution = await executionAdapter.getExecution(executionId);
+
+      if (!execution) {
+        this.handleError(`Execution not found: ${executionId}`, options);
+        return;
+      }
+
+      if (options.json) {
+        console.log(JSON.stringify({
+          success: true,
+          data: {
+            id: execution.id,
+            taskId: execution.taskId,
+            type: execution.type,
+            title: execution.title,
+            result: execution.result,
+            notes: execution.notes || null,
+            references: execution.references || [],
+          }
+        }, null, 2));
+      } else if (!options.quiet) {
+        console.log(`Execution: ${execution.id}`);
+        console.log(`Task:      ${execution.taskId}`);
+        console.log(`Type:      ${execution.type}`);
+        console.log(`Title:     ${execution.title || '(untitled)'}`);
+        console.log(`Result:    ${execution.result}`);
+        if (execution.notes) {
+          console.log(`Notes:     ${execution.notes}`);
+        }
+        if (execution.references && execution.references.length > 0) {
+          console.log(`References:`);
+          for (const ref of execution.references) {
+            console.log(`  - ${ref}`);
+          }
+        }
+      }
+    } catch (error) {
+      this.handleExecError(error, options);
+    }
+  }
+
+  private handleExecError(error: unknown, options: BaseCommandOptions): void {
+    let message: string;
+
+    if (error instanceof Error) {
+      if (error.message.includes('not found') || error.message.includes('Not found')) {
+        message = `❌ ${error.message}`;
+      } else {
+        message = `❌ Execution operation failed: ${error.message}`;
+      }
+    } else {
+      message = `❌ Execution operation failed: ${String(error)}`;
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify({ success: false, error: message, exitCode: 1 }, null, 2));
+    } else {
+      console.error(message);
+      if (options.verbose && error instanceof Error) {
+        console.error(`🔍 Technical details: ${error.stack}`);
+      }
+    }
+
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/commands/exec/exec_command.types.ts
+++ b/packages/cli/src/commands/exec/exec_command.types.ts
@@ -1,0 +1,41 @@
+/**
+ * Types for the exec command.
+ * Based on exec_command.md §3.3.
+ */
+
+import type { BaseCommandOptions } from '../../interfaces/command';
+
+/** Options for `gitgov exec new <taskId>` */
+export interface ExecNewOptions extends BaseCommandOptions {
+  /** The tangible, verifiable output of the execution (required) */
+  result: string;
+  /** Semantic classification of the execution event */
+  type?: ExecutionType;
+  /** Human-readable title (used to generate executionId) */
+  title?: string;
+  /** Context, decisions, and rationale behind the result */
+  notes?: string;
+  /** Typed references (commit:abc, pr:123, file:path, url:https://...) */
+  reference?: string[];
+}
+
+/** Options for `gitgov exec list [taskId]` */
+export interface ExecListOptions extends BaseCommandOptions {
+  /** Filter by execution type */
+  type?: ExecutionType;
+  /** Max results to return */
+  limit?: number;
+}
+
+/** Options for `gitgov exec show <executionId>` */
+export interface ExecShowOptions extends BaseCommandOptions {
+  // Inherits json, verbose, quiet from BaseCommandOptions
+}
+
+/** Execution type enum values for validation */
+export type ExecutionType = 'analysis' | 'progress' | 'blocker' | 'completion' | 'info' | 'correction';
+
+/** Valid execution types array for validation */
+export const VALID_EXECUTION_TYPES: ExecutionType[] = [
+  'analysis', 'progress', 'blocker', 'completion', 'info', 'correction'
+];

--- a/packages/cli/src/commands/exec/index.ts
+++ b/packages/cli/src/commands/exec/index.ts
@@ -1,0 +1,78 @@
+import { Command } from 'commander';
+import { ExecCommand } from './exec_command';
+import type { ExecNewOptions, ExecListOptions, ExecShowOptions } from './exec_command.types';
+
+/**
+ * Register exec commands following GitGovernance CLI standard.
+ * Blueprint: exec_command.md
+ */
+export function registerExecCommands(program: Command): void {
+  const execCommand = new ExecCommand();
+
+  const exec = program
+    .command('exec')
+    .description('Record proof-of-work via ExecutionRecords')
+    .alias('x')
+    .addHelpText('after', `
+EXECUTION TYPES:
+  analysis   - Initial analysis, technical design, investigation
+  progress   - Incremental work progress (default)
+  blocker    - Impediment or blocker identified
+  completion - Work fully completed
+  info       - Contextual information without direct work
+  correction - Correction to a previous execution
+
+EXAMPLES:
+  gitgov exec new <taskId> --result "OAuth callback handler implemented"
+  gitgov exec new <taskId> --result "API down" --type blocker
+  gitgov exec list <taskId>
+  gitgov exec show <executionId>
+`);
+
+  // gitgov exec new <taskId>
+  exec
+    .command('new <taskId>')
+    .description('Create a new ExecutionRecord for a Task')
+    .alias('n')
+    .requiredOption('-r, --result <result>', 'The tangible, verifiable output (required)')
+    .option('-t, --type <type>', 'Execution type (analysis, progress, blocker, completion, info, correction)', 'progress')
+    .option('--title <title>', 'Human-readable title for the execution')
+    .option('-n, --notes <notes>', 'Context, decisions, and rationale')
+    .option('-ref, --reference <ref...>', 'Typed reference (commit:abc, pr:123, file:path, url:...)')
+    .option('--json', 'Output in JSON format')
+    .option('-v, --verbose', 'Show detailed output')
+    .option('-q, --quiet', 'Suppress output except errors')
+    .action(async (taskId: string, options: ExecNewOptions) => {
+      await execCommand.executeNew(taskId, options);
+    });
+
+  // gitgov exec list [taskId]
+  exec
+    .command('list [taskId]')
+    .description('List executions, optionally filtered by Task')
+    .alias('ls')
+    .option('-t, --type <type>', 'Filter by execution type')
+    .option('-l, --limit <limit>', 'Max number of results', '50')
+    .option('--json', 'Output in JSON format')
+    .option('-v, --verbose', 'Show detailed output')
+    .option('-q, --quiet', 'Only show IDs')
+    .action(async (taskId: string | undefined, options: ExecListOptions) => {
+      // Commander passes limit as string, convert to number
+      if (options.limit) {
+        options.limit = Number(options.limit);
+      }
+      await execCommand.executeList(taskId, options);
+    });
+
+  // gitgov exec show <executionId>
+  exec
+    .command('show <executionId>')
+    .description('Show full details of an ExecutionRecord')
+    .alias('s')
+    .option('--json', 'Output in JSON format')
+    .option('-v, --verbose', 'Show detailed output with metadata')
+    .option('-q, --quiet', 'Minimal output')
+    .action(async (executionId: string, options: ExecShowOptions) => {
+      await execCommand.executeShow(executionId, options);
+    });
+}

--- a/packages/cli/src/commands/feedback/feedback_command.test.ts
+++ b/packages/cli/src/commands/feedback/feedback_command.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Feedback Command tests — Block F (ICOMP-F1 to ICOMP-F3)
+ * Blueprint: feedback_command.md §4.1
+ *
+ * Only the create action is tested in this epic.
+ */
+
+// Mock @gitgov/core FIRST to avoid import.meta issues
+jest.mock('@gitgov/core', () => ({
+  Records: {},
+  Factories: {
+    createFeedbackRecord: jest.fn((data) => data),
+    createTestSignature: jest.fn((keyId, role, notes) => ({
+      keyId, role, notes, timestamp: Date.now(), signature: 'A'.repeat(86) + '=='
+    })),
+  }
+}));
+
+// Mock DependencyInjectionService
+jest.mock('../../services/dependency-injection', () => ({
+  DependencyInjectionService: {
+    getInstance: jest.fn()
+  }
+}));
+
+import { FeedbackCommand } from './feedback_command';
+import { DependencyInjectionService } from '../../services/dependency-injection';
+
+const mockFeedback = {
+  id: '1752642000-feedback-suggestion-refactor',
+  entityType: 'task',
+  entityId: '1752274500-task-auth',
+  type: 'suggestion',
+  status: 'open',
+  content: 'Consider refactoring the auth module',
+};
+
+// Mock console and process.exit at module level (task-command pattern)
+const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
+const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
+const mockProcessExit = jest.spyOn(process, 'exit').mockImplementation();
+
+describe('FeedbackCommand', () => {
+  let feedbackCommand: FeedbackCommand;
+  let mockFeedbackAdapter: {
+    create: jest.MockedFunction<any>;
+  };
+  let mockIdentityAdapter: {
+    getCurrentActor: jest.MockedFunction<any>;
+  };
+  let mockProjector: {
+    invalidateCache: jest.MockedFunction<any>;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockFeedbackAdapter = {
+      create: jest.fn().mockResolvedValue(mockFeedback),
+    };
+
+    mockIdentityAdapter = {
+      getCurrentActor: jest.fn().mockResolvedValue({ id: 'human:dev', displayName: 'Dev', type: 'human' }),
+    };
+
+    mockProjector = {
+      invalidateCache: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const mockDependencyService = {
+      getFeedbackAdapter: jest.fn().mockResolvedValue(mockFeedbackAdapter),
+      getIdentityAdapter: jest.fn().mockResolvedValue(mockIdentityAdapter),
+      getRecordProjector: jest.fn().mockResolvedValue(mockProjector),
+    };
+
+    // Set up mock BEFORE constructing command (critical — BaseCommand reads DI in constructor)
+    (DependencyInjectionService.getInstance as jest.MockedFunction<typeof DependencyInjectionService.getInstance>)
+      .mockReturnValue(mockDependencyService as never);
+
+    feedbackCommand = new FeedbackCommand();
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    mockProcessExit.mockClear();
+  });
+
+  describe('4.1. Create — Default Action (ICOMP-F1 to ICOMP-F3)', () => {
+
+    it('[ICOMP-F1] should abort when required fields are missing', async () => {
+      // Missing entityType, type, and content
+      await feedbackCommand.executeCreate({
+        entityId: 'task-1',
+      } as any);
+
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Missing required')
+      );
+    });
+
+    it('[ICOMP-F2] should create FeedbackRecord via adapter', async () => {
+      await feedbackCommand.executeCreate({
+        entityType: 'task',
+        entityId: '1752274500-task-auth',
+        type: 'suggestion',
+        content: 'Consider refactoring the auth module',
+      } as any);
+
+      expect(mockFeedbackAdapter.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityType: 'task',
+          entityId: '1752274500-task-auth',
+          type: 'suggestion',
+          content: 'Consider refactoring the auth module',
+        }),
+        'human:dev',
+      );
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Feedback created')
+      );
+    });
+
+    it('[ICOMP-F3] should output JSON when --json is provided', async () => {
+      await feedbackCommand.executeCreate({
+        entityType: 'task',
+        entityId: '1752274500-task-auth',
+        type: 'suggestion',
+        content: 'Consider refactoring',
+        json: true,
+      } as any);
+
+      const output = JSON.parse(mockConsoleLog.mock.calls[0]![0]);
+      expect(output.success).toBe(true);
+      expect(output.data.id).toBe('1752642000-feedback-suggestion-refactor');
+      expect(output.data.entityType).toBe('task');
+      expect(output.data.entityId).toBe('1752274500-task-auth');
+      expect(output.data.type).toBe('suggestion');
+      expect(output.data.status).toBe('open');
+    });
+  });
+});

--- a/packages/cli/src/commands/feedback/feedback_command.ts
+++ b/packages/cli/src/commands/feedback/feedback_command.ts
@@ -1,0 +1,91 @@
+import { Command } from 'commander';
+import { BaseCommand } from '../../base/base-command';
+import type { BaseCommandOptions } from '../../interfaces/command';
+import type { FeedbackCreateOptions } from './feedback_command.types';
+
+/**
+ * FeedbackCommand — Structured collaboration via FeedbackRecords.
+ *
+ * Only the default create action is implemented in this epic.
+ * Blueprint: feedback_command.md
+ */
+export class FeedbackCommand extends BaseCommand<BaseCommandOptions> {
+
+  register(program: Command): void {
+    // Not used — registration happens via registerFeedbackCommands()
+  }
+
+  async execute(options: BaseCommandOptions): Promise<void> {
+    this.handleError('No action specified. Use --help for available options.', options);
+  }
+
+  /**
+   * gitgov feedback (default action — create)
+   * EARS: ICOMP-F1..F3
+   */
+  async executeCreate(options: FeedbackCreateOptions): Promise<void> {
+    try {
+      // [ICOMP-F1] Validate all 4 required fields
+      const missing: string[] = [];
+      if (!options.entityType) missing.push('--entity-type');
+      if (!options.entityId) missing.push('--entity-id');
+      if (!options.type) missing.push('--type');
+      if (!options.content) missing.push('--content');
+
+      if (missing.length > 0) {
+        this.handleError(`Missing required: ${missing.join(', ')}`, options);
+        return;
+      }
+
+      const feedbackAdapter = await this.dependencyService.getFeedbackAdapter();
+      const projector = await this.dependencyService.getRecordProjector();
+      const { actorId } = await this.requireActor(options);
+
+      // [ICOMP-F2] Delegate to adapter
+      const feedback = await feedbackAdapter.create(
+        {
+          entityType: options.entityType,
+          entityId: options.entityId,
+          type: options.type,
+          content: options.content,
+        },
+        actorId,
+      );
+
+      // Invalidate projector cache
+      await projector.invalidateCache();
+
+      // [ICOMP-F3] Output
+      if (options.json) {
+        console.log(JSON.stringify({
+          success: true,
+          data: {
+            id: feedback.id,
+            entityType: feedback.entityType,
+            entityId: feedback.entityId,
+            type: feedback.type,
+            status: feedback.status,
+          }
+        }, null, 2));
+      } else if (!options.quiet) {
+        console.log(`✅ Feedback created: ${feedback.id}`);
+        console.log(`   Entity: ${feedback.entityType}/${feedback.entityId}`);
+        console.log(`   Type:   ${feedback.type}`);
+        console.log(`   Status: ${feedback.status}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (options.json) {
+        console.log(JSON.stringify({ success: false, error: `❌ Feedback creation failed: ${message}`, exitCode: 1 }, null, 2));
+      } else {
+        console.error(`❌ Feedback creation failed: ${message}`);
+        if (options.verbose && error instanceof Error) {
+          console.error(`🔍 Technical details: ${error.stack}`);
+        }
+      }
+
+      process.exit(1);
+    }
+  }
+}

--- a/packages/cli/src/commands/feedback/feedback_command.types.ts
+++ b/packages/cli/src/commands/feedback/feedback_command.types.ts
@@ -1,0 +1,34 @@
+/**
+ * Types for the feedback command.
+ * Based on feedback_command.md §3.3.
+ */
+
+import type { BaseCommandOptions } from '../../interfaces/command';
+
+/** Options for `gitgov feedback` (create — default action) */
+export interface FeedbackCreateOptions extends BaseCommandOptions {
+  /** Type of entity this feedback targets */
+  entityType: FeedbackEntityType;
+  /** ID of the entity this feedback is about */
+  entityId: string;
+  /** Semantic type of feedback */
+  type: FeedbackType;
+  /** Content/message of the feedback */
+  content: string;
+}
+
+/** Entity type enum for validation */
+export type FeedbackEntityType = 'task' | 'execution' | 'changelog' | 'feedback' | 'cycle';
+
+/** Feedback type enum for validation */
+export type FeedbackType = 'blocking' | 'suggestion' | 'question' | 'approval' | 'clarification' | 'assignment';
+
+/** Valid entity types for validation */
+export const VALID_ENTITY_TYPES: FeedbackEntityType[] = [
+  'task', 'execution', 'changelog', 'feedback', 'cycle'
+];
+
+/** Valid feedback types for validation */
+export const VALID_FEEDBACK_TYPES: FeedbackType[] = [
+  'blocking', 'suggestion', 'question', 'approval', 'clarification', 'assignment'
+];

--- a/packages/cli/src/commands/feedback/index.ts
+++ b/packages/cli/src/commands/feedback/index.ts
@@ -1,0 +1,30 @@
+import { Command } from 'commander';
+import { FeedbackCommand } from './feedback_command';
+import type { FeedbackCreateOptions } from './feedback_command.types';
+
+/**
+ * Register feedback commands following GitGovernance CLI standard.
+ * Blueprint: feedback_command.md
+ *
+ * Note: Only the default create action is implemented in this epic.
+ * list, show, reply, thread remain 🔴.
+ */
+export function registerFeedbackCommands(program: Command): void {
+  const feedbackCommand = new FeedbackCommand();
+
+  // gitgov feedback (default action = create, no subcommand needed)
+  program
+    .command('feedback')
+    .description('Create structured, immutable FeedbackRecords')
+    .alias('fb')
+    .requiredOption('-e, --entity-type <entityType>', 'Type of entity (task, execution, changelog, feedback, cycle)')
+    .requiredOption('-i, --entity-id <entityId>', 'ID of the entity')
+    .requiredOption('-t, --type <type>', 'Feedback type (blocking, suggestion, question, approval, clarification, assignment)')
+    .requiredOption('-c, --content <content>', 'Feedback content')
+    .option('--json', 'Output in JSON format')
+    .option('-v, --verbose', 'Show detailed output')
+    .option('-q, --quiet', 'Suppress output except errors')
+    .action(async (options: FeedbackCreateOptions) => {
+      await feedbackCommand.executeCreate(options);
+    });
+}

--- a/packages/cli/src/commands/init/init-command.test.ts
+++ b/packages/cli/src/commands/init/init-command.test.ts
@@ -194,6 +194,34 @@ describe('InitCommand', () => {
         })
       );
     });
+
+    it('[EARS-A6] should create actor with type=\'agent\' when --type agent', async () => {
+      await initCommand.execute({
+        name: 'Agent Project',
+        type: 'agent',
+        actorName: 'CI Bot',
+      });
+
+      expect(mockProjectAdapter.initializeProject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'agent',
+          name: 'Agent Project',
+          actorName: 'CI Bot',
+        })
+      );
+    });
+
+    it('[EARS-A7] should create actor with type=\'human\' by default', async () => {
+      await initCommand.execute({
+        name: 'Human Project',
+        actorName: 'Camilo',
+      });
+
+      // type should NOT be set (undefined) — ProjectAdapter defaults to 'human'
+      const callArgs = mockProjectAdapter.initializeProject.mock.calls[0]?.[0];
+      expect(callArgs?.type).toBeUndefined();
+      expect(callArgs?.name).toBe('Human Project');
+    });
   });
 
   // ============================================================================

--- a/packages/cli/src/commands/init/init-command.ts
+++ b/packages/cli/src/commands/init/init-command.ts
@@ -11,6 +11,7 @@ import { existsSync, promises as fsPromises } from 'fs';
  */
 export interface InitCommandOptions {
   name?: string;
+  type?: 'human' | 'agent';
   template?: string;
   methodology?: 'default' | 'scrum' | 'kanban';
   actorName?: string;
@@ -60,6 +61,8 @@ export class InitCommand {
         name: completeOptions.name!,
       };
 
+      // [EARS-A6, EARS-A7] Pass actor type to ProjectAdapter
+      if (completeOptions.type) projectInitOptions.type = completeOptions.type;
       // [EARS-A3] Process template when specified
       if (completeOptions.template) projectInitOptions.template = completeOptions.template;
       if (completeOptions.actorName) projectInitOptions.actorName = completeOptions.actorName;

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -12,6 +12,7 @@ export function registerInitCommands(program: Command): void {
     .command('init')
     .description('Initialize GitGovernance project with complete bootstrap')
     .option('-n, --name <name>', 'Project name (default: directory name)')
+    .option('--type <type>', 'Actor type: human (default) or agent', 'human')
     .option('-t, --template <name>', 'Project template (basic, saas-mvp, ai-product, enterprise) - optional')
     .option('-m, --methodology <method>', 'Workflow methodology (default, scrum, kanban)', 'default')
     .option('-a, --actor-name <name>', 'Actor display name (default: git user.name)')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,8 @@ import { registerAuditCommand } from './commands/audit/audit';
 import { registerAgentCommand } from './commands/agent/agent';
 import { registerSyncCommands } from './commands/sync/sync';
 import { registerActorCommands } from './commands/actor';
+import { registerExecCommands } from './commands/exec';
+import { registerFeedbackCommands } from './commands/feedback';
 import { DependencyInjectionService } from './services/dependency-injection';
 import packageJson from '../package.json' assert { type: 'json' };
 
@@ -71,6 +73,12 @@ async function setupCommands() {
 
     // Register agent commands
     registerAgentCommand(program);
+
+    // Register exec commands (execution proof-of-work)
+    registerExecCommands(program);
+
+    // Register feedback commands (structured collaboration)
+    registerFeedbackCommands(program);
   } catch (error) {
     // Handle initialization errors gracefully
     if (error instanceof Error) {

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,374 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under the name "LEGAL", and included in all Covered Software
+distributed in Source Code Form. Except to the extent prohibited by
+statute or regulation, such description must be sufficiently detailed
+for a recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/packages/core/src/adapters/project_adapter/project_adapter.test.ts
+++ b/packages/core/src/adapters/project_adapter/project_adapter.test.ts
@@ -342,6 +342,49 @@ describe('ProjectAdapter', () => {
       expect(mockProjectInitializer.validateEnvironment).toHaveBeenCalled();
     });
 
+    it('should pass type to IdentityAdapter when --type agent specified', async () => {
+      const mockAgentActor = createMockActorRecord({ id: 'agent:ci-bot', type: 'agent' });
+      const mockCycle = createMockCycleRecord();
+
+      mockIdentityAdapter.createActor.mockResolvedValueOnce(mockAgentActor);
+      mockBacklogAdapter.createCycle.mockResolvedValueOnce(mockCycle);
+
+      const result = await projectAdapter.initializeProject({
+        name: 'Agent Project',
+        type: 'agent',
+        actorName: 'CI Bot',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockIdentityAdapter.createActor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'agent',
+          displayName: 'CI Bot',
+        }),
+        'bootstrap'
+      );
+    });
+
+    it('should default to type human when type not specified', async () => {
+      const mockActor = createMockActorRecord();
+      const mockCycle = createMockCycleRecord();
+
+      mockIdentityAdapter.createActor.mockResolvedValueOnce(mockActor);
+      mockBacklogAdapter.createCycle.mockResolvedValueOnce(mockCycle);
+
+      await projectAdapter.initializeProject({
+        name: 'Human Project',
+        actorName: 'Test User',
+      });
+
+      expect(mockIdentityAdapter.createActor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'human',
+        }),
+        'bootstrap'
+      );
+    });
+
     it('[EARS-A6] should return ProjectInitResult with complete metadata', async () => {
       const mockActor = createMockActorRecord();
       const mockCycle = createMockCycleRecord();

--- a/packages/core/src/adapters/project_adapter/project_adapter.ts
+++ b/packages/core/src/adapters/project_adapter/project_adapter.ts
@@ -79,7 +79,7 @@ export class ProjectAdapter implements IProjectAdapter {
       // 3. Trust Root Creation via IdentityAdapter [EARS-B1]
       const actor = await this.identityAdapter.createActor(
         {
-          type: 'human' as const,
+          type: (options.type ?? 'human') as 'human' | 'agent',
           displayName: options.actorName || 'Project Owner',
           roles: [
             'admin',

--- a/packages/core/src/adapters/project_adapter/project_adapter.types.ts
+++ b/packages/core/src/adapters/project_adapter/project_adapter.types.ts
@@ -52,6 +52,8 @@ export interface ProjectAdapterDependencies {
 export type ProjectInitOptions = {
   /** Project name (will be slugified for projectId) */
   name: string;
+  /** Actor type for bootstrap trust root. Default: 'human' */
+  type?: 'human' | 'agent';
   /** Path to JSON template file for initial cycles/tasks */
   template?: string;
   /** Display name for bootstrap actor */

--- a/packages/core/src/adapters/workflow_adapter/index.ts
+++ b/packages/core/src/adapters/workflow_adapter/index.ts
@@ -23,7 +23,7 @@ export type ValidationContext = {
   transitionTo?: TaskStatus;
 }
 
-type TransitionRule = {
+export type TransitionRule = {
   to: TaskStatus;
   conditions: NonNullable<NonNullable<WorkflowRecord['state_transitions']>[string]>['requires'] | undefined;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,7 @@ export type { IIdentityAdapter } from "./adapters/identity_adapter";
 export type { IBacklogAdapter } from "./adapters/backlog_adapter";
 export type { IFeedbackAdapter } from "./adapters/feedback_adapter";
 export type { IExecutionAdapter } from "./adapters/execution_adapter";
+export type { IAgentAdapter } from "./adapters/agent_adapter";
 
 // SyncState type exports
 export type { ISyncStateModule, SyncStatePushResult, SyncStatePullResult, SyncStateResolveResult, AuditStateReport } from "./sync_state";

--- a/packages/mcp-server/LICENSE
+++ b/packages/mcp-server/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024-2026 GitGovernance
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,5 +1,7 @@
 # @gitgov/mcp-server
 
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 MCP server that exposes [GitGovernance](https://github.com/gitgovernance) operations as tools for AI agents. Works with Claude Code, Cursor, Windsurf, and any MCP-compatible client.
 
 43 tools, 3 prompts, dynamic `gitgov://` resources. Stdio and HTTP transports.
@@ -212,4 +214,4 @@ src/
 
 ## License
 
-Apache-2.0
+This package is licensed under the [Apache License 2.0](https://opensource.org/licenses/Apache-2.0).

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP server that exposes [GitGovernance](https://github.com/gitgovernance) operations as tools for AI agents. Works with Claude Code, Cursor, Windsurf, and any MCP-compatible client.
 
-36 tools, 3 prompts, dynamic `gitgov://` resources. Stdio and HTTP transports.
+43 tools, 3 prompts, dynamic `gitgov://` resources. Stdio and HTTP transports.
 
 ## Requirements
 
@@ -60,7 +60,7 @@ gitgov-mcp --port 3100
 # Listens on http://localhost:3100/mcp (StreamableHTTP transport)
 ```
 
-## Tools (36)
+## Tools (43)
 
 ### Read-Only (9)
 
@@ -118,7 +118,30 @@ gitgov-mcp --port 3100
 | `gitgov_sync_resolve` | Resolve sync conflicts |
 | `gitgov_sync_audit` | Audit state consistency |
 
-### Audit & Identity (5)
+### Execution (3)
+
+| Tool | Description |
+|---|---|
+| `gitgov_execution_create` | Create an execution record linked to a task (proof of work) |
+| `gitgov_execution_list` | List executions, optionally filtered by task and type |
+| `gitgov_execution_show` | Show full details of an execution record |
+
+### Identity (4)
+
+| Tool | Description |
+|---|---|
+| `gitgov_actor_new` | Register a new actor (human or agent) |
+| `gitgov_actor_list` | List all actors, optionally filtered by type |
+| `gitgov_actor_show` | Show detailed actor information by ID |
+| `gitgov_agent_new` | Create an AgentRecord for an actor of type agent |
+
+### Workflow (1)
+
+| Tool | Description |
+|---|---|
+| `gitgov_workflow_transitions` | Get available task status transitions from a given status |
+
+### Audit (4)
 
 | Tool | Description |
 |---|---|
@@ -126,7 +149,6 @@ gitgov-mcp --port 3100
 | `gitgov_audit_waive` | Waive an audit finding |
 | `gitgov_audit_waive_list` | List active waivers |
 | `gitgov_agent_run` | Execute a registered agent |
-| `gitgov_actor_new` | Register a new actor |
 
 ## Prompts (3)
 
@@ -152,7 +174,7 @@ MCP clients can browse and read these via the standard resources protocol.
 # Run locally with tsx
 pnpm --filter @gitgov/mcp-server dev
 
-# Run tests (184 tests across 3 levels)
+# Run tests (199 tests across 3 levels)
 pnpm --filter @gitgov/mcp-server test
 
 # Type check
@@ -174,6 +196,10 @@ src/
     task/                     7 task lifecycle tools (CRUD + state transitions)
     feedback/                 3 feedback tools (create, list, resolve)
     cycle/                    8 cycle management tools (CRUD + task linking)
+    execution/                3 execution tools (create, list, show)
+    identity/                 2 identity tools (actor_list, actor_show)
+    workflow/                 1 workflow tool (transitions query)
+    agent/                    1 tool (agent_new)
     sync/                     4 sync tools (push, pull, resolve, audit)
     audit/                    5 tools (audit scan/waive + agent_run + actor_new)
   prompts/                    3 prompt handlers

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -2,6 +2,7 @@
   "name": "@gitgov/mcp-server",
   "version": "0.1.0",
   "description": "MCP server exposing GitGovernance operations as tools for AI agents",
+  "license": "Apache-2.0",
   "type": "module",
   "bin": {
     "gitgov-mcp": "./dist/index.js"

--- a/packages/mcp-server/src/di/mcp_di.ts
+++ b/packages/mcp-server/src/di/mcp_di.ts
@@ -246,6 +246,14 @@ export class McpDependencyInjectionService {
       gitModule,
     });
 
+    // --- Agent Adapter ---
+    const agentAdapter = new Adapters.AgentAdapter({
+      stores: { agents: stores.agents },
+      identity: identityAdapter,
+      keyProvider,
+      eventBus,
+    });
+
     // --- Agent Runner ---
     const agentRunner = new FsAgentRunner({
       projectRoot,
@@ -260,6 +268,8 @@ export class McpDependencyInjectionService {
       feedbackAdapter,
       executionAdapter,
       identityAdapter,
+      agentAdapter,
+      workflowAdapter,
       lintModule,
       syncModule,
       sourceAuditorModule,

--- a/packages/mcp-server/src/di/mcp_di.types.ts
+++ b/packages/mcp-server/src/di/mcp_di.types.ts
@@ -16,7 +16,9 @@ import type {
   IBacklogAdapter,
   IFeedbackAdapter,
   IExecutionAdapter,
+  IAgentAdapter,
   SourceAuditor,
+  WorkflowAdapter,
 } from '@gitgov/core';
 import type { IFsLintModule } from '@gitgov/core/fs';
 
@@ -47,6 +49,8 @@ export interface McpDiContainer {
   feedbackAdapter: IFeedbackAdapter;
   executionAdapter: IExecutionAdapter;
   identityAdapter: IIdentityAdapter;
+  agentAdapter: IAgentAdapter;
+  workflowAdapter: WorkflowAdapter.IWorkflow;
 
   lintModule: IFsLintModule;
   syncModule: ISyncStateModule;

--- a/packages/mcp-server/src/e2e/mcp_e2e.test.ts
+++ b/packages/mcp-server/src/e2e/mcp_e2e.test.ts
@@ -77,9 +77,9 @@ describe('MCP E2E', () => {
       expect(prompts.prompts.length).toBeGreaterThan(0);
     });
 
-    it('[MSRV-EA3] should list exactly 36 tools via tools/list', async () => {
+    it('[MSRV-EA3] should list exactly 43 tools via tools/list', async () => {
       const { tools } = await client.listTools();
-      expect(tools.length).toBe(36);
+      expect(tools.length).toBe(43);
 
       // Verify some key tool names exist
       const names = tools.map((t) => t.name);

--- a/packages/mcp-server/src/integration/protocol/mcp_protocol_integration.test.ts
+++ b/packages/mcp-server/src/integration/protocol/mcp_protocol_integration.test.ts
@@ -11,7 +11,7 @@ import type { MockContainer } from './protocol_test_helpers.js';
 /**
  * MCP Protocol Integration Tests — Level 1.
  *
- * All 36 tools + resources + prompts tested through the real MCP protocol
+ * All 40 tools + resources + prompts tested through the real MCP protocol
  * via InMemoryTransport + Client. DI is mocked — the focus is the protocol layer.
  *
  * Blueprint: specs/integration/mcp_protocol_integration.md
@@ -562,11 +562,11 @@ describe('MCP Protocol Integration', () => {
       expect(data.error).toBeDefined();
     });
 
-    it('[MSRV-PG4] should list exactly 36 tools via MCP protocol', async () => {
+    it('[MSRV-PG4] should list exactly 43 tools via MCP protocol', async () => {
       const result = await client.listTools();
 
       expect(result.tools).toBeDefined();
-      expect(result.tools.length).toBe(36);
+      expect(result.tools.length).toBe(43);
 
       // Each tool should have name, description, and inputSchema
       for (const tool of result.tools) {

--- a/packages/mcp-server/src/tools/agent/agent_new_tool.ts
+++ b/packages/mcp-server/src/tools/agent/agent_new_tool.ts
@@ -1,0 +1,67 @@
+import type { McpToolDefinition } from '../../server/mcp_server.types.js';
+import type { McpDependencyInjectionService } from '../../di/mcp_di.js';
+import type { AgentNewInput } from './agent_tools.types.js';
+import { successResult, errorResult } from '../helpers.js';
+
+/**
+ * gitgov_agent_new — Creates an AgentRecord for an existing actor of type agent.
+ * [ICOMP-D1], [ICOMP-D2], [ICOMP-D3]
+ */
+export const agentNewTool: McpToolDefinition<AgentNewInput> = {
+  name: 'gitgov_agent_new',
+  description:
+    'Create a new AgentRecord linked to an existing actor of type agent. Requires the actor to exist first (via gitgov_actor_new with type=agent).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      actorId: {
+        type: 'string',
+        description: 'Actor ID of type agent (e.g., agent:scribe).',
+      },
+      engineType: {
+        type: 'string',
+        enum: ['local', 'api', 'mcp', 'custom'],
+        description: 'Execution engine type.',
+      },
+    },
+    required: ['actorId', 'engineType'],
+    additionalProperties: false,
+  },
+  handler: async (input: AgentNewInput, di: McpDependencyInjectionService) => {
+    try {
+      const container = await di.getContainer();
+      const { agentAdapter, identityAdapter } = container;
+
+      // [ICOMP-D2] Validate actor exists and is type agent
+      const actor = await identityAdapter.getActor(input.actorId);
+      if (!actor) {
+        return errorResult(`Actor not found: ${input.actorId}`, 'INVALID_ACTOR');
+      }
+      if (actor.type !== 'agent') {
+        return errorResult(`Actor ${input.actorId} is type '${actor.type}', expected 'agent'`, 'INVALID_ACTOR');
+      }
+
+      // [ICOMP-D3] Check for duplicate
+      const existing = await agentAdapter.getAgentRecord(input.actorId);
+      if (existing) {
+        return errorResult(`AgentRecord already exists: ${input.actorId}`, 'DUPLICATE_AGENT');
+      }
+
+      // [ICOMP-D1] Create AgentRecord
+      // Engine is a discriminated union — adapter validates required fields per type
+      const agent = await agentAdapter.createAgentRecord({
+        id: input.actorId,
+        engine: { type: input.engineType } as import('@gitgov/core').AgentRecord['engine'],
+      });
+
+      return successResult({
+        id: agent.id,
+        actorId: agent.id,
+        engine: agent.engine,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResult(`Failed to create agent: ${message}`, 'AGENT_NEW_ERROR');
+    }
+  },
+};

--- a/packages/mcp-server/src/tools/agent/agent_tools.test.ts
+++ b/packages/mcp-server/src/tools/agent/agent_tools.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { McpDependencyInjectionService } from '../../di/mcp_di.js';
+import { agentNewTool } from './agent_new_tool.js';
+
+/**
+ * Agent Tools tests — Block D (ICOMP-D1 to ICOMP-D3)
+ * Blueprint: mcp_tools_agent.md §4
+ */
+
+function parseResult(result: { content: Array<{ text: string }>; isError?: boolean }) {
+  return JSON.parse(result.content[0].text);
+}
+
+function createMockDi(overrides: Record<string, unknown> = {}) {
+  const mockContainer = {
+    agentAdapter: {
+      createAgentRecord: vi.fn().mockResolvedValue({
+        id: 'agent:scribe',
+        status: 'active',
+        engine: { type: 'local' },
+      }),
+      getAgentRecord: vi.fn().mockResolvedValue(null),
+    },
+    identityAdapter: {
+      getActor: vi.fn().mockResolvedValue({
+        id: 'agent:scribe',
+        type: 'agent',
+        displayName: 'Scribe',
+        publicKey: 'test-key',
+        roles: ['contributor'],
+      }),
+    },
+    ...overrides,
+  };
+
+  return {
+    getContainer: vi.fn().mockResolvedValue(mockContainer),
+    _container: mockContainer,
+  } as unknown as McpDependencyInjectionService & { _container: typeof mockContainer };
+}
+
+describe('Agent Tools', () => {
+  describe('4.1. Agent New (ICOMP-D1 to ICOMP-D3)', () => {
+    it('[ICOMP-D1] should create AgentRecord via adapter', async () => {
+      const di = createMockDi();
+      const result = await agentNewTool.handler(
+        { actorId: 'agent:scribe', engineType: 'local' },
+        di,
+      );
+      const data = parseResult(result);
+
+      expect(result.isError).toBeUndefined();
+      expect(data.id).toBe('agent:scribe');
+      expect(data.engine).toEqual({ type: 'local' });
+
+      const container = di._container;
+      expect(container.agentAdapter.createAgentRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'agent:scribe',
+          engine: { type: 'local' },
+        }),
+      );
+    });
+
+    it('[ICOMP-D2] should return INVALID_ACTOR when actor not found or not agent type', async () => {
+      const di = createMockDi();
+      const container = di._container;
+      container.identityAdapter.getActor.mockResolvedValue(null);
+
+      const result = await agentNewTool.handler(
+        { actorId: 'agent:nonexistent', engineType: 'mcp' },
+        di,
+      );
+
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.code).toBe('INVALID_ACTOR');
+      expect(data.error).toContain('not found');
+    });
+
+    it('[ICOMP-D3] should return DUPLICATE_AGENT when AgentRecord already exists', async () => {
+      const di = createMockDi();
+      const container = di._container;
+      container.agentAdapter.getAgentRecord.mockResolvedValue({
+        id: 'agent:scribe',
+        status: 'active',
+        engine: { type: 'local' },
+      });
+
+      const result = await agentNewTool.handler(
+        { actorId: 'agent:scribe', engineType: 'local' },
+        di,
+      );
+
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.code).toBe('DUPLICATE_AGENT');
+      expect(data.error).toContain('already exists');
+    });
+  });
+});

--- a/packages/mcp-server/src/tools/agent/agent_tools.types.ts
+++ b/packages/mcp-server/src/tools/agent/agent_tools.types.ts
@@ -1,0 +1,9 @@
+/**
+ * Input types for agent MCP tools.
+ * Blueprint: mcp_tools_agent.md
+ */
+
+export type AgentNewInput = {
+  actorId: string;
+  engineType: 'local' | 'api' | 'mcp' | 'custom';
+};

--- a/packages/mcp-server/src/tools/agent/index.ts
+++ b/packages/mcp-server/src/tools/agent/index.ts
@@ -1,0 +1,2 @@
+export { agentNewTool } from './agent_new_tool.js';
+export type * from './agent_tools.types.js';

--- a/packages/mcp-server/src/tools/audit/audit_tools.test.ts
+++ b/packages/mcp-server/src/tools/audit/audit_tools.test.ts
@@ -184,11 +184,11 @@ describe('Audit + Agent + Actor Tools', () => {
       expect(data.code).toBe('DUPLICATE_ACTOR');
     });
 
-    it('[MSRV-M5] should expose exactly 36 tools after Cycle 4', () => {
+    it('[MSRV-M5] should expose exactly 43 tools after Cycle 4 + interface_completeness', () => {
       const server = new McpServer({ name: 'test', version: '1.0.0' });
       registerAllTools(server);
-      // 9 read + 7 task + 3 feedback + 8 cycle + 4 sync + 3 audit + 1 agent + 1 actor = 36
-      expect(server.getToolCount()).toBe(36);
+      // 9 read + 7 task + 3 feedback + 8 cycle + 4 sync + 3 audit + 1 agent + 1 actor + 3 execution + 1 agent_new + 1 workflow + 2 identity = 43
+      expect(server.getToolCount()).toBe(43);
     });
   });
 });

--- a/packages/mcp-server/src/tools/execution/execution_create_tool.ts
+++ b/packages/mcp-server/src/tools/execution/execution_create_tool.ts
@@ -1,0 +1,77 @@
+import type { McpToolDefinition } from '../../server/mcp_server.types.js';
+import type { McpDependencyInjectionService } from '../../di/mcp_di.js';
+import type { ExecutionCreateInput } from './execution_tools.types.js';
+import { successResult, errorResult } from '../helpers.js';
+
+/**
+ * gitgov_execution_create — Creates an ExecutionRecord.
+ * [ICOMP-B1], [ICOMP-B2], [ICOMP-B3]
+ */
+export const executionCreateTool: McpToolDefinition<ExecutionCreateInput> = {
+  name: 'gitgov_execution_create',
+  description:
+    'Create an execution record linked to a task. Records proof of work with type (analysis, progress, blocker, completion, info, correction), result, and optional references.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      taskId: {
+        type: 'string',
+        description: 'The ID of the task this execution belongs to.',
+      },
+      result: {
+        type: 'string',
+        description: 'The tangible, verifiable output of the execution.',
+      },
+      type: {
+        type: 'string',
+        enum: ['analysis', 'progress', 'blocker', 'completion', 'info', 'correction'],
+        description: "Semantic classification of the execution event. Defaults to 'progress'.",
+      },
+      title: {
+        type: 'string',
+        description: 'Human-readable title for the execution.',
+      },
+      notes: {
+        type: 'string',
+        description: 'Context, decisions, and rationale behind the result.',
+      },
+      references: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Typed references (commit:abc, pr:123, file:path, url:...).',
+      },
+    },
+    required: ['taskId', 'result'],
+    additionalProperties: false,
+  },
+  handler: async (input: ExecutionCreateInput, di: McpDependencyInjectionService) => {
+    try {
+      const container = await di.getContainer();
+      const { executionAdapter, identityAdapter } = container;
+
+      const actor = await identityAdapter.getCurrentActor();
+      const execution = await executionAdapter.create(
+        {
+          taskId: input.taskId,
+          result: input.result,
+          type: input.type || 'progress', // [ICOMP-B2] default progress
+          title: input.title || '',
+          notes: input.notes,
+          references: input.references,
+        },
+        actor.id,
+      );
+
+      return successResult({
+        id: execution.id,
+        taskId: execution.taskId,
+        type: execution.type,
+        title: execution.title,
+        result: execution.result,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResult(`Failed to create execution: ${message}`, 'EXECUTION_CREATE_ERROR');
+    }
+  },
+};

--- a/packages/mcp-server/src/tools/execution/execution_list_tool.ts
+++ b/packages/mcp-server/src/tools/execution/execution_list_tool.ts
@@ -1,0 +1,70 @@
+import type { McpToolDefinition } from '../../server/mcp_server.types.js';
+import type { McpDependencyInjectionService } from '../../di/mcp_di.js';
+import type { ExecutionListInput } from './execution_tools.types.js';
+import { successResult, errorResult } from '../helpers.js';
+
+/**
+ * gitgov_execution_list — Lists executions with optional filters.
+ * [ICOMP-B4], [ICOMP-B5]
+ */
+export const executionListTool: McpToolDefinition<ExecutionListInput> = {
+  name: 'gitgov_execution_list',
+  description:
+    'List execution records, optionally filtered by task ID and execution type.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      taskId: {
+        type: 'string',
+        description: 'Filter by task ID. If omitted, returns all executions.',
+      },
+      type: {
+        type: 'string',
+        enum: ['analysis', 'progress', 'blocker', 'completion', 'info', 'correction'],
+        description: 'Filter by execution type.',
+      },
+      limit: {
+        type: 'number',
+        description: 'Max number of executions to return.',
+      },
+    },
+    additionalProperties: false,
+  },
+  handler: async (input: ExecutionListInput, di: McpDependencyInjectionService) => {
+    try {
+      const container = await di.getContainer();
+      const { executionAdapter } = container;
+
+      // [ICOMP-B4] + [ICOMP-B5]
+      let executions = input.taskId
+        ? await executionAdapter.getExecutionsByTask(input.taskId)
+        : await executionAdapter.getAllExecutions();
+
+      // Apply type filter
+      if (input.type) {
+        executions = executions.filter((e) => e.type === input.type);
+      }
+
+      // Apply limit
+      if (input.limit && input.limit > 0) {
+        executions = executions.slice(0, input.limit);
+      }
+
+      const items = executions.map((e) => ({
+        id: e.id,
+        taskId: e.taskId,
+        type: e.type,
+        title: e.title,
+        result: e.result,
+      }));
+
+      return successResult({
+        total: items.length,
+        executions: items,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResult(`Failed to list executions: ${message}`, 'EXECUTION_LIST_ERROR');
+    }
+  },
+};

--- a/packages/mcp-server/src/tools/execution/execution_show_tool.ts
+++ b/packages/mcp-server/src/tools/execution/execution_show_tool.ts
@@ -1,0 +1,51 @@
+import type { McpToolDefinition } from '../../server/mcp_server.types.js';
+import type { McpDependencyInjectionService } from '../../di/mcp_di.js';
+import type { ExecutionShowInput } from './execution_tools.types.js';
+import { successResult, errorResult } from '../helpers.js';
+
+/**
+ * gitgov_execution_show — Shows full details of an execution.
+ * [ICOMP-B6], [ICOMP-B7]
+ */
+export const executionShowTool: McpToolDefinition<ExecutionShowInput> = {
+  name: 'gitgov_execution_show',
+  description:
+    'Show full details of a specific execution record by its ID.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      executionId: {
+        type: 'string',
+        description: 'The execution ID to show.',
+      },
+    },
+    required: ['executionId'],
+    additionalProperties: false,
+  },
+  handler: async (input: ExecutionShowInput, di: McpDependencyInjectionService) => {
+    try {
+      const container = await di.getContainer();
+      const { executionAdapter } = container;
+
+      // [ICOMP-B6] + [ICOMP-B7]
+      const execution = await executionAdapter.getExecution(input.executionId);
+
+      if (!execution) {
+        return errorResult(`Execution not found: ${input.executionId}`, 'NOT_FOUND');
+      }
+
+      return successResult({
+        id: execution.id,
+        taskId: execution.taskId,
+        type: execution.type,
+        title: execution.title,
+        result: execution.result,
+        notes: execution.notes ?? null,
+        references: execution.references ?? [],
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResult(`Failed to show execution: ${message}`, 'EXECUTION_SHOW_ERROR');
+    }
+  },
+};

--- a/packages/mcp-server/src/tools/execution/execution_tools.test.ts
+++ b/packages/mcp-server/src/tools/execution/execution_tools.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { McpDependencyInjectionService } from '../../di/mcp_di.js';
+import { executionCreateTool } from './execution_create_tool.js';
+import { executionListTool } from './execution_list_tool.js';
+import { executionShowTool } from './execution_show_tool.js';
+
+/**
+ * Execution Tools tests — Block B (ICOMP-B1 to ICOMP-B7)
+ * Blueprint: mcp_tools_execution.md §4
+ */
+
+function parseResult(result: { content: Array<{ text: string }>; isError?: boolean }) {
+  return JSON.parse(result.content[0].text);
+}
+
+function createMockDi(overrides: Record<string, unknown> = {}) {
+  const mockContainer = {
+    executionAdapter: {
+      create: vi.fn().mockResolvedValue({
+        id: 'exec-1',
+        taskId: 'task-1',
+        type: 'progress',
+        title: 'Work done',
+        result: 'Implemented feature X',
+        notes: null,
+        references: [],
+      }),
+      getExecution: vi.fn().mockResolvedValue(null),
+      getExecutionsByTask: vi.fn().mockResolvedValue([]),
+      getAllExecutions: vi.fn().mockResolvedValue([]),
+    },
+    identityAdapter: {
+      getCurrentActor: vi.fn().mockResolvedValue({ id: 'actor-1', displayName: 'Test', type: 'human' }),
+    },
+    ...overrides,
+  };
+
+  return {
+    getContainer: vi.fn().mockResolvedValue(mockContainer),
+    _container: mockContainer,
+  } as unknown as McpDependencyInjectionService & { _container: typeof mockContainer };
+}
+
+describe('Execution Tools', () => {
+  describe('4.1. Execution Create (ICOMP-B1 to ICOMP-B3)', () => {
+    it('[ICOMP-B1] should create an ExecutionRecord linked to a task', async () => {
+      const di = createMockDi();
+      const result = await executionCreateTool.handler(
+        {
+          taskId: 'task-1',
+          result: 'Implemented feature X',
+          type: 'progress',
+          title: 'Work done',
+        },
+        di,
+      );
+      const data = parseResult(result);
+
+      expect(result.isError).toBeUndefined();
+      expect(data.id).toBe('exec-1');
+      expect(data.taskId).toBe('task-1');
+      expect(data.type).toBe('progress');
+      expect(data.title).toBe('Work done');
+      expect(data.result).toBe('Implemented feature X');
+
+      const container = di._container;
+      expect(container.executionAdapter.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: 'task-1',
+          result: 'Implemented feature X',
+          type: 'progress',
+          title: 'Work done',
+        }),
+        'actor-1',
+      );
+    });
+
+    it('[ICOMP-B2] should default to type progress when not specified', async () => {
+      const di = createMockDi();
+      const result = await executionCreateTool.handler(
+        {
+          taskId: 'task-1',
+          result: 'Some work',
+        },
+        di,
+      );
+
+      expect(result.isError).toBeUndefined();
+
+      const container = di._container;
+      expect(container.executionAdapter.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'progress',
+        }),
+        'actor-1',
+      );
+    });
+
+    it('[ICOMP-B3] should return error when taskId does not exist', async () => {
+      const di = createMockDi();
+      const container = di._container;
+      container.executionAdapter.create.mockRejectedValue(new Error('Task not found: task-nonexistent'));
+
+      const result = await executionCreateTool.handler(
+        {
+          taskId: 'task-nonexistent',
+          result: 'Some work',
+        },
+        di,
+      );
+
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.code).toBe('EXECUTION_CREATE_ERROR');
+      expect(data.error).toContain('Task not found');
+    });
+  });
+
+  describe('4.2. Execution List (ICOMP-B4 to ICOMP-B5)', () => {
+    it('[ICOMP-B4] should filter executions by taskId', async () => {
+      const di = createMockDi();
+      const container = di._container;
+      container.executionAdapter.getExecutionsByTask.mockResolvedValue([
+        { id: 'exec-1', taskId: 'task-1', type: 'progress', title: 'Work 1', result: 'Done 1' },
+        { id: 'exec-2', taskId: 'task-1', type: 'blocker', title: 'Blocked', result: 'API down' },
+      ]);
+
+      const result = await executionListTool.handler({ taskId: 'task-1' }, di);
+      const data = parseResult(result);
+
+      expect(result.isError).toBeUndefined();
+      expect(data.total).toBe(2);
+      expect(data.executions).toHaveLength(2);
+      expect(container.executionAdapter.getExecutionsByTask).toHaveBeenCalledWith('task-1');
+    });
+
+    it('[ICOMP-B5] should return all executions when no filters given', async () => {
+      const di = createMockDi();
+      const container = di._container;
+      container.executionAdapter.getAllExecutions.mockResolvedValue([
+        { id: 'exec-1', taskId: 'task-1', type: 'progress', title: 'Work 1', result: 'Done 1' },
+      ]);
+
+      const result = await executionListTool.handler({}, di);
+      const data = parseResult(result);
+
+      expect(result.isError).toBeUndefined();
+      expect(data.total).toBe(1);
+      expect(container.executionAdapter.getAllExecutions).toHaveBeenCalled();
+    });
+  });
+
+  describe('4.3. Execution Show (ICOMP-B6 to ICOMP-B7)', () => {
+    it('[ICOMP-B6] should return full execution details', async () => {
+      const di = createMockDi();
+      const container = di._container;
+      container.executionAdapter.getExecution.mockResolvedValue({
+        id: 'exec-1',
+        taskId: 'task-1',
+        type: 'progress',
+        title: 'Work done',
+        result: 'Implemented feature X',
+        notes: 'Used pattern Y',
+        references: ['commit:abc123'],
+      });
+
+      const result = await executionShowTool.handler({ executionId: 'exec-1' }, di);
+      const data = parseResult(result);
+
+      expect(result.isError).toBeUndefined();
+      expect(data.id).toBe('exec-1');
+      expect(data.taskId).toBe('task-1');
+      expect(data.type).toBe('progress');
+      expect(data.result).toBe('Implemented feature X');
+      expect(data.notes).toBe('Used pattern Y');
+      expect(data.references).toEqual(['commit:abc123']);
+    });
+
+    it('[ICOMP-B7] should return NOT_FOUND error for non-existent execution', async () => {
+      const di = createMockDi();
+      // Default mock returns null for getExecution
+
+      const result = await executionShowTool.handler({ executionId: 'exec-nonexistent' }, di);
+
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.code).toBe('NOT_FOUND');
+      expect(data.error).toContain('exec-nonexistent');
+    });
+  });
+});

--- a/packages/mcp-server/src/tools/execution/execution_tools.types.ts
+++ b/packages/mcp-server/src/tools/execution/execution_tools.types.ts
@@ -1,0 +1,33 @@
+/**
+ * Input types for the 3 execution MCP tools.
+ * Based on mcp_tools_execution.md §3.2.
+ */
+
+export interface ExecutionCreateInput {
+  /** ID of the task this execution belongs to */
+  taskId: string;
+  /** The tangible, verifiable output */
+  result: string;
+  /** Semantic classification (defaults to 'progress') */
+  type?: 'analysis' | 'progress' | 'blocker' | 'completion' | 'info' | 'correction';
+  /** Human-readable title */
+  title?: string;
+  /** Context and rationale */
+  notes?: string;
+  /** Typed references */
+  references?: string[];
+}
+
+export interface ExecutionListInput {
+  /** Filter by task ID */
+  taskId?: string;
+  /** Filter by execution type */
+  type?: 'analysis' | 'progress' | 'blocker' | 'completion' | 'info' | 'correction';
+  /** Max results */
+  limit?: number;
+}
+
+export interface ExecutionShowInput {
+  /** The execution ID to show */
+  executionId: string;
+}

--- a/packages/mcp-server/src/tools/execution/index.ts
+++ b/packages/mcp-server/src/tools/execution/index.ts
@@ -1,0 +1,4 @@
+export { executionCreateTool } from './execution_create_tool.js';
+export { executionListTool } from './execution_list_tool.js';
+export { executionShowTool } from './execution_show_tool.js';
+export type * from './execution_tools.types.js';

--- a/packages/mcp-server/src/tools/identity/actor_list_tool.ts
+++ b/packages/mcp-server/src/tools/identity/actor_list_tool.ts
@@ -1,0 +1,52 @@
+import type { McpToolDefinition } from '../../server/mcp_server.types.js';
+import type { McpDependencyInjectionService } from '../../di/mcp_di.js';
+import type { ActorListInput } from './identity_tools.types.js';
+import { successResult, errorResult } from '../helpers.js';
+
+/**
+ * gitgov_actor_list — Lists all actors, with optional type filter.
+ * [ICOMP-E5], [ICOMP-E6]
+ */
+export const actorListTool: McpToolDefinition<ActorListInput> = {
+  name: 'gitgov_actor_list',
+  description:
+    'List all actors in the project. Optionally filter by type (human, agent, system).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['human', 'agent'],
+        description: 'Filter actors by type.',
+      },
+    },
+    required: [],
+    additionalProperties: false,
+  },
+  handler: async (input: ActorListInput, di: McpDependencyInjectionService) => {
+    try {
+      const container = await di.getContainer();
+      const { identityAdapter } = container;
+
+      // [ICOMP-E5] List all actors
+      let actors = await identityAdapter.listActors();
+
+      // [ICOMP-E6] Filter by type if specified
+      if (input.type) {
+        actors = actors.filter((a) => a.type === input.type);
+      }
+
+      return successResult({
+        actors: actors.map((a) => ({
+          id: a.id,
+          type: a.type,
+          status: a.status,
+        })),
+        total: actors.length,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResult(`Failed to list actors: ${message}`, 'INTERNAL_ERROR');
+    }
+  },
+};

--- a/packages/mcp-server/src/tools/identity/actor_show_tool.ts
+++ b/packages/mcp-server/src/tools/identity/actor_show_tool.ts
@@ -1,0 +1,51 @@
+import type { McpToolDefinition } from '../../server/mcp_server.types.js';
+import type { McpDependencyInjectionService } from '../../di/mcp_di.js';
+import type { ActorShowInput } from './identity_tools.types.js';
+import { successResult, errorResult } from '../helpers.js';
+
+/**
+ * gitgov_actor_show — Returns detailed info about a single actor.
+ * [ICOMP-E7]
+ */
+export const actorShowTool: McpToolDefinition<ActorShowInput> = {
+  name: 'gitgov_actor_show',
+  description:
+    'Show detailed information about a single actor by ID.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      actorId: {
+        type: 'string',
+        description: 'Actor ID to look up (e.g., human:alice, agent:scribe).',
+      },
+    },
+    required: ['actorId'],
+    additionalProperties: false,
+  },
+  handler: async (input: ActorShowInput, di: McpDependencyInjectionService) => {
+    try {
+      const container = await di.getContainer();
+      const { identityAdapter } = container;
+
+      // [ICOMP-E7] Get actor
+      const actor = await identityAdapter.getActor(input.actorId);
+      if (!actor) {
+        return errorResult(`Actor not found: ${input.actorId}`, 'ACTOR_NOT_FOUND');
+      }
+
+      return successResult({
+        id: actor.id,
+        type: actor.type,
+        displayName: actor.displayName,
+        roles: actor.roles,
+        status: actor.status,
+        publicKey: actor.publicKey,
+        supersededBy: actor.supersededBy,
+        metadata: actor.metadata,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResult(`Failed to show actor: ${message}`, 'INTERNAL_ERROR');
+    }
+  },
+};

--- a/packages/mcp-server/src/tools/identity/identity_tools.test.ts
+++ b/packages/mcp-server/src/tools/identity/identity_tools.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { McpDependencyInjectionService } from '../../di/mcp_di.js';
+import { actorListTool } from './actor_list_tool.js';
+import { actorShowTool } from './actor_show_tool.js';
+
+/**
+ * Identity Tools tests — Block E identity (ICOMP-E5 to ICOMP-E7)
+ * Blueprint: mcp_tools_identity.md §4.1
+ */
+
+function parseResult(result: { content: Array<{ text: string }>; isError?: boolean }) {
+  return JSON.parse(result.content[0].text);
+}
+
+const mockActors = [
+  { id: 'human:alice', type: 'human', displayName: 'Alice', roles: ['dev:frontend'], status: 'active', publicKey: 'key-alice', metadata: {} },
+  { id: 'agent:scribe', type: 'agent', displayName: 'Scribe', roles: ['agent:scribe'], status: 'active', publicKey: 'key-scribe', metadata: {} },
+  { id: 'human:bob', type: 'human', displayName: 'Bob', roles: ['dev:backend'], status: 'revoked', publicKey: 'key-bob', supersededBy: 'human:bob-v2', metadata: {} },
+];
+
+function createMockDi(overrides: Record<string, unknown> = {}) {
+  const mockContainer = {
+    identityAdapter: {
+      listActors: vi.fn().mockResolvedValue([...mockActors]),
+      getActor: vi.fn().mockImplementation((id: string) => {
+        const actor = mockActors.find((a) => a.id === id);
+        return Promise.resolve(actor ?? null);
+      }),
+    },
+    ...overrides,
+  };
+
+  return {
+    getContainer: vi.fn().mockResolvedValue(mockContainer),
+    _container: mockContainer,
+  } as unknown as McpDependencyInjectionService & { _container: typeof mockContainer };
+}
+
+describe('Identity Tools', () => {
+  describe('4.1. Actor List & Show (ICOMP-E5 to ICOMP-E7)', () => {
+    it('[ICOMP-E5] should list all actors', async () => {
+      const di = createMockDi();
+      const result = await actorListTool.handler({}, di);
+      const data = parseResult(result);
+
+      expect(result.isError).toBeUndefined();
+      expect(data.actors).toHaveLength(3);
+      expect(data.total).toBe(3);
+      expect(data.actors[0].id).toBe('human:alice');
+      expect(data.actors[1].id).toBe('agent:scribe');
+    });
+
+    it('[ICOMP-E6] should filter actors by type', async () => {
+      const di = createMockDi();
+      const result = await actorListTool.handler({ type: 'human' }, di);
+      const data = parseResult(result);
+
+      expect(result.isError).toBeUndefined();
+      expect(data.actors).toHaveLength(2);
+      expect(data.total).toBe(2);
+      expect(data.actors.every((a: { type: string }) => a.type === 'human')).toBe(true);
+    });
+
+    it('[ICOMP-E7] should show actor detail or error when not found', async () => {
+      const di = createMockDi();
+
+      // Success case
+      const result = await actorShowTool.handler({ actorId: 'human:alice' }, di);
+      const data = parseResult(result);
+
+      expect(result.isError).toBeUndefined();
+      expect(data.id).toBe('human:alice');
+      expect(data.type).toBe('human');
+      expect(data.displayName).toBe('Alice');
+      expect(data.roles).toEqual(['dev:frontend']);
+      expect(data.publicKey).toBe('key-alice');
+
+      // Not found case
+      const notFound = await actorShowTool.handler({ actorId: 'human:unknown' }, di);
+      expect(notFound.isError).toBe(true);
+      const errData = parseResult(notFound);
+      expect(errData.code).toBe('ACTOR_NOT_FOUND');
+    });
+  });
+});

--- a/packages/mcp-server/src/tools/identity/identity_tools.types.ts
+++ b/packages/mcp-server/src/tools/identity/identity_tools.types.ts
@@ -1,0 +1,7 @@
+export type ActorListInput = {
+  type?: 'human' | 'agent';
+};
+
+export type ActorShowInput = {
+  actorId: string;
+};

--- a/packages/mcp-server/src/tools/identity/index.ts
+++ b/packages/mcp-server/src/tools/identity/index.ts
@@ -1,0 +1,3 @@
+export { actorListTool } from './actor_list_tool.js';
+export { actorShowTool } from './actor_show_tool.js';
+export type { ActorListInput, ActorShowInput } from './identity_tools.types.js';

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -47,6 +47,14 @@ import {
   agentRunTool,
   actorNewTool,
 } from './audit/index.js';
+import {
+  executionCreateTool,
+  executionListTool,
+  executionShowTool,
+} from './execution/index.js';
+import { agentNewTool } from './agent/index.js';
+import { workflowTransitionsTool } from './workflow/index.js';
+import { actorListTool, actorShowTool } from './identity/index.js';
 
 /**
  * Registers all MCP tools on the server.
@@ -100,4 +108,17 @@ export function registerAllTools(server: McpServer): void {
   server.registerTool(auditWaiveListTool);
   server.registerTool(agentRunTool);
   server.registerTool(actorNewTool);
+
+  // Epic interface_completeness: 3 execution tools
+  server.registerTool(executionCreateTool);
+  server.registerTool(executionListTool);
+  server.registerTool(executionShowTool);
+
+  // Epic interface_completeness: 1 agent creation tool
+  server.registerTool(agentNewTool);
+
+  // Epic interface_completeness: 1 workflow + 2 identity tools
+  server.registerTool(workflowTransitionsTool);
+  server.registerTool(actorListTool);
+  server.registerTool(actorShowTool);
 }

--- a/packages/mcp-server/src/tools/workflow/index.ts
+++ b/packages/mcp-server/src/tools/workflow/index.ts
@@ -1,0 +1,2 @@
+export { workflowTransitionsTool } from './workflow_transitions_tool.js';
+export type { WorkflowTransitionsInput } from './workflow_tools.types.js';

--- a/packages/mcp-server/src/tools/workflow/workflow_tools.test.ts
+++ b/packages/mcp-server/src/tools/workflow/workflow_tools.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { McpDependencyInjectionService } from '../../di/mcp_di.js';
+import { workflowTransitionsTool } from './workflow_transitions_tool.js';
+
+/**
+ * Workflow Tools tests — Block E workflow (ICOMP-E1 to ICOMP-E2)
+ * Blueprint: mcp_tools_workflow.md §4.1
+ */
+
+function parseResult(result: { content: Array<{ text: string }>; isError?: boolean }) {
+  return JSON.parse(result.content[0].text);
+}
+
+function createMockDi(overrides: Record<string, unknown> = {}) {
+  const mockContainer = {
+    workflowAdapter: {
+      getAvailableTransitions: vi.fn().mockResolvedValue([
+        { to: 'review', conditions: undefined },
+        { to: 'discarded', conditions: undefined },
+      ]),
+    },
+    ...overrides,
+  };
+
+  return {
+    getContainer: vi.fn().mockResolvedValue(mockContainer),
+    _container: mockContainer,
+  } as unknown as McpDependencyInjectionService & { _container: typeof mockContainer };
+}
+
+describe('Workflow Tools', () => {
+  describe('4.1. Workflow Transitions (ICOMP-E1 to ICOMP-E2)', () => {
+    it('[ICOMP-E1] should return transitions for valid status', async () => {
+      const di = createMockDi();
+      const result = await workflowTransitionsTool.handler(
+        { from: 'draft' },
+        di,
+      );
+      const data = parseResult(result);
+
+      expect(result.isError).toBeUndefined();
+      expect(data.from).toBe('draft');
+      expect(data.transitions).toHaveLength(2);
+      expect(data.transitions[0].to).toBe('review');
+      // Verify undefined → null mapping per blueprint §3.3
+      expect(data.transitions[0].conditions).toBeNull();
+      expect(data.transitions[1].conditions).toBeNull();
+
+      expect(di._container.workflowAdapter.getAvailableTransitions).toHaveBeenCalledWith('draft');
+    });
+
+    it('[ICOMP-E2] should return empty transitions for terminal status', async () => {
+      const di = createMockDi();
+      // Core returns [] for terminal statuses — tool delegates, does not validate
+      di._container.workflowAdapter.getAvailableTransitions.mockResolvedValue([]);
+
+      const result = await workflowTransitionsTool.handler(
+        { from: 'archived' },
+        di,
+      );
+      const data = parseResult(result);
+
+      expect(result.isError).toBeUndefined();
+      expect(data.from).toBe('archived');
+      expect(data.transitions).toHaveLength(0);
+
+      expect(di._container.workflowAdapter.getAvailableTransitions).toHaveBeenCalledWith('archived');
+    });
+  });
+});

--- a/packages/mcp-server/src/tools/workflow/workflow_tools.types.ts
+++ b/packages/mcp-server/src/tools/workflow/workflow_tools.types.ts
@@ -1,0 +1,5 @@
+import type { TaskRecord } from '@gitgov/core';
+
+export type WorkflowTransitionsInput = {
+  from: TaskRecord['status'];
+};

--- a/packages/mcp-server/src/tools/workflow/workflow_transitions_tool.ts
+++ b/packages/mcp-server/src/tools/workflow/workflow_transitions_tool.ts
@@ -1,0 +1,47 @@
+import type { McpToolDefinition } from '../../server/mcp_server.types.js';
+import type { McpDependencyInjectionService } from '../../di/mcp_di.js';
+import type { WorkflowTransitionsInput } from './workflow_tools.types.js';
+import { successResult, errorResult } from '../helpers.js';
+
+/**
+ * gitgov_workflow_transitions — Returns available task status transitions.
+ * Delegates entirely to WorkflowAdapter.getAvailableTransitions(from).
+ * [ICOMP-E1], [ICOMP-E2]
+ */
+export const workflowTransitionsTool: McpToolDefinition<WorkflowTransitionsInput> = {
+  name: 'gitgov_workflow_transitions',
+  description:
+    'Get available task status transitions from a given status. Returns the list of valid target states and their conditions.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      from: {
+        type: 'string',
+        enum: ['draft', 'review', 'ready', 'active', 'done', 'archived', 'paused', 'discarded'],
+        description: 'Current task status to query transitions from.',
+      },
+    },
+    required: ['from'],
+    additionalProperties: false,
+  },
+  handler: async (input: WorkflowTransitionsInput, di: McpDependencyInjectionService) => {
+    try {
+      const container = await di.getContainer();
+      const { workflowAdapter } = container;
+
+      // [ICOMP-E1] Delegate to core — adapter returns [] for terminal/unknown statuses
+      const transitions = await workflowAdapter.getAvailableTransitions(input.from);
+
+      return successResult({
+        from: input.from,
+        transitions: transitions.map((t) => ({
+          to: t.to,
+          conditions: t.conditions ?? null,
+        })),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResult(`Failed to get transitions: ${message}`, 'INTERNAL_ERROR');
+    }
+  },
+};


### PR DESCRIPTION
## Summary

- **core**: Extend `ProjectAdapter` with `execution`/`feedback` record types, add `getProjectType()`, export `TransitionRule` for MCP consumers
- **cli**: Add 3 new commands (`exec`, `feedback`, `actor`), extend `agent` with `new` subcommand, add `init --type human|agent` flag. 15 commands total
- **mcp-server**: Add 7 new tools across 4 domains — execution (3), agent (1), identity (2), workflow (1). 43 tools total
- **licensing**: Add Apache 2.0 LICENSE files to cli, core, and mcp-server. Update monorepo README with badges, packages table, and license section

## Test plan

- [x] `pnpm --filter @gitgov/core tsc --noEmit` — 0 errors
- [x] `pnpm --filter @gitgov/cli tsc --noEmit` — 0 errors
- [x] `pnpm --filter @gitgov/mcp-server tsc --noEmit` — 0 errors
- [x] `pnpm --filter @gitgov/core build` — 5 entry points
- [x] `pnpm --filter @gitgov/cli build` — gitgov.mjs 334KB
- [x] `pnpm --filter @gitgov/mcp-server build` — index.js 83KB
- [x] `pnpm --filter @gitgov/core test` — 450 passed
- [x] `pnpm --filter @gitgov/cli test` — 450 passed (21 suites)
- [x] `pnpm --filter @gitgov/mcp-server test` — 199 passed (17 suites)