### PR TITLE
refactor(core): remove custom record type from protocol

### DIFF
--- a/packages/cli/e2e/helpers.ts
+++ b/packages/cli/e2e/helpers.ts
@@ -1,0 +1,196 @@
+/**
+ * Shared E2E Test Helpers
+ *
+ * Common helpers used across all CLI E2E test files.
+ * Each helper is the superset of all implementations found in
+ * init, actor, sync, task, diagram, and dashboard E2E tests.
+ */
+
+import { execSync } from 'child_process';
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RunCliResult {
+  success: boolean;
+  output: string;
+  error: string | null;
+}
+
+export interface RunCliOptions {
+  /** Expected to fail? If true, catches errors instead of throwing */
+  expectError?: boolean;
+  /** Working directory for the command */
+  cwd: string;
+  /** Stdin input to pipe to the command */
+  input?: string;
+  /** Extra environment variables merged into process.env */
+  env?: Record<string, string>;
+}
+
+// ============================================================================
+// CLI Execution
+// ============================================================================
+
+/**
+ * Execute a gitgov CLI command via the compiled binary.
+ *
+ * - Escapes arguments containing spaces (from sync/actor pattern)
+ * - Supports optional stdin input (from task pattern)
+ * - cwd is required (most common pattern)
+ */
+export const runCliCommand = (args: string[], options: RunCliOptions): RunCliResult => {
+  const cliPath = path.join(__dirname, '../build/dist/gitgov.mjs');
+  const escapedArgs = args.map(arg => {
+    if (arg.includes(' ') && !arg.startsWith('"') && !arg.startsWith("'")) {
+      return `"${arg}"`;
+    }
+    return arg;
+  });
+  const command = `node "${cliPath}" ${escapedArgs.join(' ')}`;
+
+  try {
+    const result = execSync(command, {
+      cwd: options.cwd,
+      encoding: 'utf8',
+      stdio: 'pipe',
+      ...(options.input && { input: options.input }),
+      ...(options.env && { env: { ...process.env, ...options.env } }),
+    });
+
+    if (options.expectError) {
+      return { success: false, output: result, error: 'Expected error but command succeeded' };
+    }
+
+    return { success: true, output: result, error: null };
+  } catch (error: any) {
+    const stderr = error.stderr || '';
+    const stdout = error.stdout || '';
+    const message = error.message || '';
+
+    const combinedOutput = `${stdout}\n${stderr}\n${message}`.trim();
+
+    if (options.expectError) {
+      return { success: false, output: stdout || combinedOutput, error: stderr || combinedOutput };
+    }
+
+    throw new Error(`CLI command failed unexpectedly: ${stderr || message}\nStdout: ${stdout}`);
+  }
+};
+
+// ============================================================================
+// Git Repository Helpers
+// ============================================================================
+
+/**
+ * Create a fresh git repository with optional initial commit.
+ *
+ * @param repoPath - Directory for the new repo (created if missing)
+ * @param withInitialCommit - Create README.md + initial commit (default: true)
+ */
+export const createGitRepo = (repoPath: string, withInitialCommit: boolean = true) => {
+  fs.mkdirSync(repoPath, { recursive: true });
+  execSync('git init --initial-branch=main', { cwd: repoPath, stdio: 'pipe' });
+  execSync('git config user.name "Test User"', { cwd: repoPath, stdio: 'pipe' });
+  execSync('git config user.email "test@example.com"', { cwd: repoPath, stdio: 'pipe' });
+
+  if (withInitialCommit) {
+    fs.writeFileSync(path.join(repoPath, 'README.md'), '# Test Project\n');
+    execSync('git add README.md', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git commit -m "Initial commit"', { cwd: repoPath, stdio: 'pipe' });
+  }
+};
+
+/**
+ * Create a bare git repository (for use as remote).
+ *
+ * @param remotePath - Directory for the bare repo
+ */
+export const createBareRemote = (remotePath: string) => {
+  fs.mkdirSync(remotePath, { recursive: true });
+  execSync('git init --bare --initial-branch=main', { cwd: remotePath, stdio: 'pipe' });
+};
+
+/**
+ * Add a remote named "origin" to a local repository.
+ *
+ * @param repoPath - Local repo path
+ * @param remotePath - Path to the bare remote
+ */
+export const addRemote = (repoPath: string, remotePath: string) => {
+  execSync(`git remote add origin "${remotePath}"`, { cwd: repoPath, stdio: 'pipe' });
+};
+
+// ============================================================================
+// Worktree Helpers
+// ============================================================================
+
+/**
+ * Compute the worktree base path for a given project root.
+ * Matches DI.getWorktreeBasePath logic: SHA256(realpath).slice(0,12)
+ *
+ * @param repoPath - Project root path
+ * @returns Path under ~/.gitgov/worktrees/{hash}
+ */
+export const getWorktreeBasePath = (repoPath: string): string => {
+  const resolvedPath = fs.realpathSync(repoPath);
+  const hash = createHash('sha256').update(resolvedPath).digest('hex').slice(0, 12);
+  return path.join(os.homedir(), '.gitgov', 'worktrees', hash);
+};
+
+/**
+ * Clean up a git worktree and its directory.
+ *
+ * @param repoPath - Parent repo path (for git worktree remove)
+ * @param wtPath - Worktree path to clean up
+ */
+export const cleanupWorktree = (repoPath: string, wtPath: string) => {
+  if (wtPath && fs.existsSync(wtPath)) {
+    try { execSync(`git worktree remove "${wtPath}" --force`, { cwd: repoPath, stdio: 'pipe' }); } catch {}
+    if (fs.existsSync(wtPath)) {
+      fs.rmSync(wtPath, { recursive: true, force: true });
+    }
+  }
+};
+
+// ============================================================================
+// Compound Setup Helpers
+// ============================================================================
+
+/**
+ * Full project setup: git repo + bare remote + remote added + gitgov init.
+ * Returns the paths and a cleanup function.
+ *
+ * @param tempDir - Parent temp directory
+ * @param label - Label for directory naming (e.g. 'lint-e2e')
+ */
+export const setupGitgovProject = (tempDir: string, label: string) => {
+  const testProjectRoot = path.join(tempDir, `${label}-project`);
+  const remotePath = path.join(tempDir, `${label}-remote.git`);
+
+  createBareRemote(remotePath);
+  createGitRepo(testProjectRoot, true);
+  addRemote(testProjectRoot, remotePath);
+
+  const worktreeBasePath = getWorktreeBasePath(testProjectRoot);
+
+  // Initialize gitgov
+  runCliCommand(
+    ['init', '--name', `${label} Test`, '--actor-name', 'Test User', '--quiet'],
+    { cwd: testProjectRoot }
+  );
+
+  return {
+    testProjectRoot,
+    remotePath,
+    worktreeBasePath,
+    cleanup: () => {
+      cleanupWorktree(testProjectRoot, worktreeBasePath);
+    }
+  };
+};

--- a/packages/cli/e2e/lint_command_e2e.test.ts
+++ b/packages/cli/e2e/lint_command_e2e.test.ts
@@ -1,0 +1,1057 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  runCliCommand,
+  createGitRepo,
+  createBareRemote,
+  addRemote,
+  getWorktreeBasePath,
+  cleanupWorktree,
+} from './helpers';
+
+/**
+ * E2E Tests for `gitgov lint` Command
+ *
+ * Blueprint: lint_command_e2e.md
+ *
+ * Tests the full stack: CLI → FsLintModule → LintModule → Validators → Output
+ * All tests use REAL records in /tmp (no mocks, no core imports).
+ *
+ * Setup pattern:
+ * 1. Create temp dir with git repo + bare remote
+ * 2. Run `gitgov init` to bootstrap (creates actor, cycle, config in worktree)
+ * 3. Run `gitgov task new` to create valid tasks
+ * 4. Modify JSON files in worktree for corruption scenarios
+ * 5. Run `gitgov lint` and verify stdout/exit code
+ */
+describe('Lint CLI Command - E2E Tests', () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeAll(() => {
+    originalCwd = process.cwd();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitgov-lint-e2e-'));
+  });
+
+  afterAll(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // ============================================================================
+  // Helper: setup a fresh gitgov project in tempDir
+  // ============================================================================
+  const setupProject = (label: string) => {
+    const testProjectRoot = path.join(tempDir, `${label}-project`);
+    const remotePath = path.join(tempDir, `${label}-remote.git`);
+
+    createBareRemote(remotePath);
+    createGitRepo(testProjectRoot, true);
+    addRemote(testProjectRoot, remotePath);
+
+    const worktreeBasePath = getWorktreeBasePath(testProjectRoot);
+
+    // Initialize gitgov (creates actor, cycle, config)
+    runCliCommand(
+      ['init', '--name', `${label} Test`, '--actor-name', 'Test User', '--quiet'],
+      { cwd: testProjectRoot }
+    );
+
+    return { testProjectRoot, remotePath, worktreeBasePath };
+  };
+
+  /**
+   * Read a record JSON from the worktree, modify it, and write it back.
+   */
+  const modifyRecordInWorktree = (
+    worktreeBasePath: string,
+    type: string,
+    filename: string,
+    modifier: (record: any) => any
+  ) => {
+    const filePath = path.join(worktreeBasePath, '.gitgov', type, filename);
+    const content = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    const modified = modifier(content);
+    fs.writeFileSync(filePath, JSON.stringify(modified, null, 2));
+    return filePath;
+  };
+
+  /**
+   * Write a raw JSON file into the worktree .gitgov/ structure.
+   */
+  const writeRawRecord = (
+    worktreeBasePath: string,
+    type: string,
+    filename: string,
+    content: object
+  ) => {
+    const dirPath = path.join(worktreeBasePath, '.gitgov', type);
+    fs.mkdirSync(dirPath, { recursive: true });
+    const filePath = path.join(dirPath, filename);
+    fs.writeFileSync(filePath, JSON.stringify(content, null, 2));
+    return filePath;
+  };
+
+  /**
+   * Find the first .json file in a worktree directory.
+   */
+  const findFirstRecord = (worktreeBasePath: string, type: string): string | null => {
+    const dirPath = path.join(worktreeBasePath, '.gitgov', type);
+    if (!fs.existsSync(dirPath)) return null;
+    const files = fs.readdirSync(dirPath).filter(f => f.endsWith('.json'));
+    return files[0] || null;
+  };
+
+  /**
+   * Read a record JSON from the worktree.
+   */
+  const readRecord = (worktreeBasePath: string, type: string, filename: string) => {
+    const filePath = path.join(worktreeBasePath, '.gitgov', type, filename);
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  };
+
+  // ============================================================================
+  // 3.1. Bloque A: Valid Records — Zero Errors (EARS-A1 to A3)
+  // ============================================================================
+  describe('3.1. Valid Records — Zero Errors (EARS-A1 to A3)', () => {
+    let testProjectRoot: string;
+    let worktreeBasePath: string;
+
+    beforeAll(() => {
+      const setup = setupProject('bloque-a');
+      testProjectRoot = setup.testProjectRoot;
+      worktreeBasePath = setup.worktreeBasePath;
+
+      // Create a valid task via CLI
+      runCliCommand(
+        ['task', 'new', 'Valid Task for Lint Test', '-d', 'This task has valid structure'],
+        { cwd: testProjectRoot }
+      );
+    });
+
+    afterAll(() => {
+      cleanupWorktree(testProjectRoot, worktreeBasePath);
+    });
+
+    it('[EARS-A1] should report zero errors for valid records', () => {
+      const result = runCliCommand(['lint', '--format', 'json', '--quiet'], { cwd: testProjectRoot });
+
+      expect(result.success).toBe(true);
+      const report = JSON.parse(result.output);
+      expect(report.summary.errors).toBe(0);
+    });
+
+    it('[EARS-A2] should validate all record types found and report filesChecked', () => {
+      const result = runCliCommand(['lint', '--format', 'json', '--quiet'], { cwd: testProjectRoot });
+
+      expect(result.success).toBe(true);
+      const report = JSON.parse(result.output);
+      // init creates actor + cycle, task new creates task → at least 3 records
+      expect(report.summary.filesChecked).toBeGreaterThanOrEqual(3);
+      expect(report.summary.errors).toBe(0);
+    });
+
+    it('[EARS-A3] should output valid JSON with correct structure', () => {
+      const result = runCliCommand(['lint', '--format', 'json', '--quiet'], { cwd: testProjectRoot });
+
+      expect(result.success).toBe(true);
+      const report = JSON.parse(result.output);
+
+      // Validate JSON structure
+      expect(report).toHaveProperty('summary');
+      expect(report).toHaveProperty('results');
+      expect(report).toHaveProperty('metadata');
+      expect(report.summary).toHaveProperty('filesChecked');
+      expect(report.summary).toHaveProperty('errors');
+      expect(report.summary).toHaveProperty('warnings');
+      expect(report.summary).toHaveProperty('fixable');
+      expect(report.summary).toHaveProperty('executionTime');
+      expect(report.metadata).toHaveProperty('timestamp');
+      expect(report.metadata).toHaveProperty('options');
+      expect(report.metadata).toHaveProperty('version');
+    });
+  });
+
+  // ============================================================================
+  // 3.2. Bloque B: Schema Validation Errors (EARS-B1 to B3)
+  // ============================================================================
+  describe('3.2. Schema Validation Errors (EARS-B1 to B3)', () => {
+    let testProjectRoot: string;
+    let worktreeBasePath: string;
+
+    beforeAll(() => {
+      const setup = setupProject('bloque-b');
+      testProjectRoot = setup.testProjectRoot;
+      worktreeBasePath = setup.worktreeBasePath;
+
+      // Create a valid task to have something to corrupt
+      runCliCommand(
+        ['task', 'new', 'Schema Test Task', '-d', 'Task for schema validation test'],
+        { cwd: testProjectRoot }
+      );
+    });
+
+    afterAll(() => {
+      cleanupWorktree(testProjectRoot, worktreeBasePath);
+    });
+
+    it('[EARS-B1] should detect missing required fields', () => {
+      // Write a task record missing the required 'title' field
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Remove a required field
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        delete rec.payload.title;
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      const schemaErrors = report.results.filter(
+        (r: any) => r.validator === 'SCHEMA_VALIDATION'
+      );
+      expect(schemaErrors.length).toBeGreaterThan(0);
+      expect(report.summary.errors).toBeGreaterThan(0);
+
+      // Restore original record
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+
+    it('[EARS-B2] should detect additional properties and filter oneOf noise', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Add an undeclared additional property to payload
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.payload.undeclaredField = 'this should not be here';
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      const schemaErrors = report.results.filter(
+        (r: any) => r.validator === 'SCHEMA_VALIDATION'
+      );
+      expect(schemaErrors.length).toBeGreaterThan(0);
+      // Verify oneOf/if-then-else noise is filtered (should not have redundant errors)
+      const redundantErrors = report.results.filter(
+        (r: any) => r.message && (
+          r.message.includes('boolean schema is false') ||
+          r.message.includes('must match "else" schema') ||
+          r.message.includes('must match "then" schema')
+        )
+      );
+      expect(redundantErrors.length).toBe(0);
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+
+    it('[EARS-B3] should reject invalid header.type values', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Set an invalid header.type
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.header.type = 'custom';
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      const schemaErrors = report.results.filter(
+        (r: any) => r.validator === 'SCHEMA_VALIDATION'
+      );
+      expect(schemaErrors.length).toBeGreaterThan(0);
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+  });
+
+  // ============================================================================
+  // 3.3. Bloque C: Checksum & Signature Errors (EARS-C1 to C3)
+  // ============================================================================
+  describe('3.3. Checksum & Signature Errors (EARS-C1 to C3)', () => {
+    let testProjectRoot: string;
+    let worktreeBasePath: string;
+
+    beforeAll(() => {
+      const setup = setupProject('bloque-c');
+      testProjectRoot = setup.testProjectRoot;
+      worktreeBasePath = setup.worktreeBasePath;
+
+      runCliCommand(
+        ['task', 'new', 'Checksum Test Task', '-d', 'Task for checksum/signature test'],
+        { cwd: testProjectRoot }
+      );
+    });
+
+    afterAll(() => {
+      cleanupWorktree(testProjectRoot, worktreeBasePath);
+    });
+
+    it('[EARS-C1] should detect invalid payloadChecksum format', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Corrupt payloadChecksum to invalid format (not 64-hex)
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.header.payloadChecksum = 'INVALID_CHECKSUM';
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      const checksumErrors = report.results.filter(
+        (r: any) => r.validator === 'CHECKSUM_VERIFICATION'
+      );
+      expect(checksumErrors.length).toBeGreaterThan(0);
+      expect(checksumErrors[0].message).toContain('payloadChecksum');
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+
+    it('[EARS-C2] should detect invalid signature pattern', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Set an invalid signature (not valid base64 88 chars)
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.header.signatures[0].signature = 'not-a-valid-base64-signature';
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      // Check for schema validation error on signature pattern
+      const sigErrors = report.results.filter(
+        (r: any) => r.validator === 'SCHEMA_VALIDATION' || r.validator === 'SIGNATURE_STRUCTURE'
+      );
+      expect(sigErrors.length).toBeGreaterThan(0);
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+
+    it('[EARS-C3] should detect missing notes in signature', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Remove notes from signature
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        delete rec.header.signatures[0].notes;
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      // Missing notes could trigger SCHEMA_VALIDATION or SIGNATURE_STRUCTURE
+      const sigErrors = report.results.filter(
+        (r: any) => r.validator === 'SCHEMA_VALIDATION' || r.validator === 'SIGNATURE_STRUCTURE'
+      );
+      expect(sigErrors.length).toBeGreaterThan(0);
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+  });
+
+  // ============================================================================
+  // 3.4. Bloque D: Additional Properties Detection (EARS-D1 to D2)
+  // ============================================================================
+  describe('3.4. Additional Properties Detection (EARS-D1 to D2)', () => {
+    let testProjectRoot: string;
+    let worktreeBasePath: string;
+
+    beforeAll(() => {
+      const setup = setupProject('bloque-d');
+      testProjectRoot = setup.testProjectRoot;
+      worktreeBasePath = setup.worktreeBasePath;
+
+      runCliCommand(
+        ['task', 'new', 'Additional Props Test Task', '-d', 'Task for additional props test'],
+        { cwd: testProjectRoot }
+      );
+    });
+
+    afterAll(() => {
+      cleanupWorktree(testProjectRoot, worktreeBasePath);
+    });
+
+    it('[EARS-D1] should detect additional properties in payload as fixable error', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Add undeclared fields — schema has additionalProperties: false
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.payload.extraField = 'should not be here';
+        rec.payload.anotherExtra = 42;
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      const structErrors = report.results.filter(
+        (r: any) => r.validator === 'EMBEDDED_METADATA_STRUCTURE' ||
+          (r.validator === 'SCHEMA_VALIDATION' && r.message.includes('additional properties'))
+      );
+      expect(structErrors.length).toBeGreaterThan(0);
+      // Additional properties errors should be fixable
+      const fixable = report.results.filter((r: any) => r.fixable);
+      expect(fixable.length).toBeGreaterThan(0);
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+
+    it('[EARS-D2] should detect additional properties in header as error', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Add undeclared field to header
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.header.extraHeaderField = 'should not be in header';
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      expect(report.summary.errors).toBeGreaterThan(0);
+      // Should detect schema error on the header
+      const headerErrors = report.results.filter(
+        (r: any) => r.message && r.message.includes('additional properties')
+      );
+      expect(headerErrors.length).toBeGreaterThan(0);
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+  });
+
+  // ============================================================================
+  // 3.5. Bloque E: Reference Validation — Typed Prefixes (EARS-E1 to E4)
+  // ============================================================================
+  describe('3.5. Reference Validation — Typed Prefixes (EARS-E1 to E4)', () => {
+    let testProjectRoot: string;
+    let worktreeBasePath: string;
+
+    beforeAll(() => {
+      const setup = setupProject('bloque-e');
+      testProjectRoot = setup.testProjectRoot;
+      worktreeBasePath = setup.worktreeBasePath;
+
+      runCliCommand(
+        ['task', 'new', 'Reference Test Task', '-d', 'Task for reference validation test'],
+        { cwd: testProjectRoot }
+      );
+    });
+
+    afterAll(() => {
+      cleanupWorktree(testProjectRoot, worktreeBasePath);
+    });
+
+    it('[EARS-E1] should detect malformed execution record with schema errors', () => {
+      // Write a hand-crafted execution record with invalid structure.
+      // The execution schema validates required fields, so missing ones trigger errors.
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      const taskRecord = readRecord(worktreeBasePath, 'tasks', taskFile!);
+
+      const execId = '9999999999-exec-lint-e2e-malformed';
+      const execRecord = {
+        header: {
+          ...taskRecord.header,
+          type: 'execution'
+        },
+        payload: {
+          id: execId,
+          title: 'Malformed execution',
+          // Missing required fields: taskId, actorId, status
+          description: 'Execution with missing required fields'
+        }
+      };
+
+      writeRawRecord(
+        worktreeBasePath, 'executions',
+        `${execId}.json`, execRecord
+      );
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      const execErrors = report.results.filter(
+        (r: any) => r.entity.id === execId
+      );
+      expect(execErrors.length).toBeGreaterThan(0);
+
+      // Cleanup
+      const execPath = path.join(worktreeBasePath, '.gitgov', 'executions', `${execId}.json`);
+      fs.unlinkSync(execPath);
+    });
+
+    it('[EARS-E2] should accept references array with valid string entries', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Set valid reference strings — schema validates they are strings
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.payload.references = ['file:README.md', 'commit:abc123'];
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot }
+      );
+
+      expect(result.success).toBe(true);
+      const report = JSON.parse(result.output);
+      expect(report.summary.errors).toBe(0);
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+
+    it('[EARS-E3] should reject non-string reference entries via schema', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Set references to non-string types — schema should reject
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.payload.references = [123, { url: 'bad' }];
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      expect(report.summary.errors).toBeGreaterThan(0);
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+
+    it('[EARS-E4] should accept valid typed references without errors', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Add valid references with all known prefixes
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.payload.references = [
+          'file:README.md',
+          'task:1234567890-task-example',
+          'cycle:1234567890-cycle-example',
+          'adapter:github',
+          'url:https://example.com',
+          'commit:a1b2c3d4',
+          'pr:42'
+        ];
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--references', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      // Filter for reference errors on THIS task only
+      const taskId = record.payload.id;
+      const refErrors = report.results.filter(
+        (r: any) => r.validator === 'REFERENTIAL_INTEGRITY' &&
+          r.entity.id === taskId
+      );
+      // There should be no reference errors for valid typed references
+      expect(refErrors.length).toBe(0);
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+  });
+
+  // ============================================================================
+  // 3.6. Bloque F: Bidirectional Consistency (EARS-F1 to F2)
+  // ============================================================================
+  describe('3.6. Bidirectional Consistency (EARS-F1 to F2)', () => {
+    let testProjectRoot: string;
+    let worktreeBasePath: string;
+
+    beforeAll(() => {
+      const setup = setupProject('bloque-f');
+      testProjectRoot = setup.testProjectRoot;
+      worktreeBasePath = setup.worktreeBasePath;
+
+      // Create a task — it will be associated with the root cycle via cycleIds
+      runCliCommand(
+        ['task', 'new', 'Bidirectional Test Task', '-d', 'Task for bidirectional consistency test'],
+        { cwd: testProjectRoot }
+      );
+    });
+
+    afterAll(() => {
+      cleanupWorktree(testProjectRoot, worktreeBasePath);
+    });
+
+    it('[EARS-F1] should detect schema errors when task record is placed in cycles directory', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Copy task record into cycles/ — discovery assigns type 'cycle', schema validation fails
+      writeRawRecord(worktreeBasePath, 'cycles', taskFile!, record);
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      // Task record in cycles/ triggers SCHEMA_VALIDATION errors (wrong schema applied)
+      const misplacedErrors = report.results.filter(
+        (r: any) => r.entity.type === 'cycle' && r.entity.id.includes('task')
+      );
+      expect(misplacedErrors.length).toBeGreaterThan(0);
+
+      // Cleanup
+      const misplacedPath = path.join(worktreeBasePath, '.gitgov', 'cycles', taskFile!);
+      fs.unlinkSync(misplacedPath);
+    });
+
+    it('[EARS-F2] should pass when task and cycle are mutually referenced', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      const cycleFile = findFirstRecord(worktreeBasePath, 'cycles');
+      const taskRecord = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      const cycleRecord = readRecord(worktreeBasePath, 'cycles', cycleFile!);
+
+      // Ensure bidirectional: task references cycle AND cycle references task
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.payload.cycleIds = [cycleRecord.payload.id];
+        return rec;
+      });
+      modifyRecordInWorktree(worktreeBasePath, 'cycles', cycleFile!, (rec) => {
+        if (!rec.payload.taskIds) rec.payload.taskIds = [];
+        if (!rec.payload.taskIds.includes(taskRecord.payload.id)) {
+          rec.payload.taskIds.push(taskRecord.payload.id);
+        }
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--references', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      const biErrors = report.results.filter(
+        (r: any) => r.validator === 'BIDIRECTIONAL_CONSISTENCY'
+      );
+      expect(biErrors.length).toBe(0);
+
+      // Restore
+      const taskPath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      const cyclePath = path.join(worktreeBasePath, '.gitgov', 'cycles', cycleFile!);
+      fs.writeFileSync(taskPath, JSON.stringify(taskRecord, null, 2));
+      fs.writeFileSync(cyclePath, JSON.stringify(cycleRecord, null, 2));
+    });
+  });
+
+  // ============================================================================
+  // 3.7. Bloque G: Signature KeyId Validation (EARS-G1 to G2)
+  // ============================================================================
+  describe('3.7. Signature KeyId Validation (EARS-G1 to G2)', () => {
+    let testProjectRoot: string;
+    let worktreeBasePath: string;
+
+    beforeAll(() => {
+      const setup = setupProject('bloque-g');
+      testProjectRoot = setup.testProjectRoot;
+      worktreeBasePath = setup.worktreeBasePath;
+
+      runCliCommand(
+        ['task', 'new', 'KeyId Test Task', '-d', 'Task for keyId pattern validation'],
+        { cwd: testProjectRoot }
+      );
+    });
+
+    afterAll(() => {
+      cleanupWorktree(testProjectRoot, worktreeBasePath);
+    });
+
+    it('[EARS-G1] should detect invalid keyId pattern in signature', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Set keyId to format that violates ^(human|agent)(:[a-z0-9-]+)+$ pattern
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.header.signatures[0].keyId = 'invalid_format_no_colon';
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      const sigErrors = report.results.filter(
+        (r: any) => r.validator === 'SIGNATURE_STRUCTURE' || r.validator === 'SCHEMA_VALIDATION'
+      );
+      expect(sigErrors.length).toBeGreaterThan(0);
+      expect(sigErrors.some((e: any) => e.message.includes('keyId'))).toBe(true);
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+
+    it('[EARS-G2] should pass with valid keyId pattern', () => {
+      // Unmodified records from gitgov init + task new should have valid keyId
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot }
+      );
+
+      expect(result.success).toBe(true);
+      const report = JSON.parse(result.output);
+      expect(report.summary.errors).toBe(0);
+    });
+  });
+
+  // ============================================================================
+  // 3.8. Bloque H: Fix Mode (EARS-H1 to H4)
+  // ============================================================================
+  describe('3.8. Fix Mode (EARS-H1 to H4)', () => {
+    let testProjectRoot: string;
+    let worktreeBasePath: string;
+
+    beforeAll(() => {
+      const setup = setupProject('bloque-h');
+      testProjectRoot = setup.testProjectRoot;
+      worktreeBasePath = setup.worktreeBasePath;
+
+      runCliCommand(
+        ['task', 'new', 'Fix Mode Test Task', '-d', 'Task for fix mode test'],
+        { cwd: testProjectRoot }
+      );
+    });
+
+    afterAll(() => {
+      cleanupWorktree(testProjectRoot, worktreeBasePath);
+    });
+
+    it('[EARS-H1] should fix additional properties error and create backup', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      // Add additional property — triggers fixable EMBEDDED_METADATA_STRUCTURE error
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.payload.extraFieldToFix = 'this will be removed by --fix';
+        return rec;
+      });
+
+      // Verify lint detects the fixable error
+      const lintResult = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+      const lintReport = JSON.parse(lintResult.output || lintResult.error!);
+      const fixableErrors = lintReport.results.filter((r: any) => r.fixable);
+      expect(fixableErrors.length).toBeGreaterThan(0);
+
+      // Run fix — the CLI has access to the private key from init
+      const fixResult = runCliCommand(
+        ['lint', '--fix', '--fix-validators', 'EMBEDDED_METADATA_STRUCTURE'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+      const fixOutput = fixResult.output || fixResult.error || '';
+      expect(fixOutput).toMatch(/[Ff]ix/);
+
+      // Verify backup was created
+      const tasksDir = path.join(worktreeBasePath, '.gitgov', 'tasks');
+      const backupFiles = fs.readdirSync(tasksDir).filter(f => f.includes('.backup-'));
+      expect(backupFiles.length).toBeGreaterThan(0);
+    });
+
+    it('[EARS-H3] should create backup file before applying fix', () => {
+      // This was already verified in EARS-H1 above
+      const tasksDir = path.join(worktreeBasePath, '.gitgov', 'tasks');
+      const backupFiles = fs.readdirSync(tasksDir).filter(f => f.includes('.backup-'));
+      expect(backupFiles.length).toBeGreaterThan(0);
+    });
+
+    it('[EARS-H4] should report no fixable problems when records are clean', () => {
+      // Use a separate clean project (no corruptions) to test the zero-fixable path
+      const cleanSetup = setupProject('bloque-h-clean');
+      try {
+        runCliCommand(
+          ['task', 'new', 'Clean Task', '-d', 'No corruption here'],
+          { cwd: cleanSetup.testProjectRoot }
+        );
+
+        const result = runCliCommand(
+          ['lint', '--fix'],
+          { cwd: cleanSetup.testProjectRoot }
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.output).toMatch(/[Nn]o fixable problems/);
+      } finally {
+        cleanupWorktree(cleanSetup.testProjectRoot, cleanSetup.worktreeBasePath);
+      }
+    });
+  });
+
+  // ============================================================================
+  // 3.9. Bloque I: Single File & Output Modes (EARS-I1 to I4)
+  // ============================================================================
+  describe('3.9. Single File & Output Modes (EARS-I1 to I4)', () => {
+    let testProjectRoot: string;
+    let worktreeBasePath: string;
+
+    beforeAll(() => {
+      const setup = setupProject('bloque-i');
+      testProjectRoot = setup.testProjectRoot;
+      worktreeBasePath = setup.worktreeBasePath;
+
+      runCliCommand(
+        ['task', 'new', 'Output Mode Test Task', '-d', 'Task for output mode test'],
+        { cwd: testProjectRoot }
+      );
+    });
+
+    afterAll(() => {
+      cleanupWorktree(testProjectRoot, worktreeBasePath);
+    });
+
+    it('[EARS-I1] should validate single file and report filesChecked 1', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      // Use the full path to validate only that file
+      const fullPath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+
+      const result = runCliCommand(
+        ['lint', fullPath, '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot }
+      );
+
+      expect(result.success).toBe(true);
+      const report = JSON.parse(result.output);
+      expect(report.summary.filesChecked).toBe(1);
+    });
+
+    it('[EARS-I2] should show only summary without individual errors', () => {
+      // First corrupt a record so there's something to display
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.payload.description = 'Modified to break checksum';
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--summary'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      // Summary mode should show "Lint Report:" with totals but NOT "Issues:" section
+      expect(result.output || result.error).toContain('Lint Report:');
+      expect(result.output || result.error).toContain('Errors:');
+      expect(result.output || result.error).toContain('Warnings:');
+      expect(result.output || result.error).toContain('Fixable:');
+      // Should NOT have the "Issues:" detailed section
+      expect(result.output || result.error).not.toContain('Issues:');
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+
+    it('[EARS-I3] should exclude specified validators from output and exit code', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+
+      // Add additional property to trigger EMBEDDED_METADATA_STRUCTURE error
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.payload.extraField = 'triggers error';
+        return rec;
+      });
+
+      // First verify lint catches it
+      const resultWithError = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+      const reportWithError = JSON.parse(resultWithError.output || resultWithError.error!);
+      expect(reportWithError.summary.errors).toBeGreaterThan(0);
+
+      // Now exclude all validator types that fire — exit code should be 0
+      const resultExcluded = runCliCommand(
+        ['lint', '--format', 'json', '--quiet', '--exclude-validators', 'EMBEDDED_METADATA_STRUCTURE,SCHEMA_VALIDATION,SIGNATURE_STRUCTURE,CHECKSUM_VERIFICATION,TEMPORAL_CONSISTENCY'],
+        { cwd: testProjectRoot }
+      );
+
+      const reportExcluded = JSON.parse(resultExcluded.output);
+      expect(reportExcluded.summary.errors).toBe(0);
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+
+    it('[EARS-I4] should list legacy records without applying fixes', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+
+      // Create a "legacy" record by removing embedded metadata wrapper markers
+      modifyRecordInWorktree(worktreeBasePath, 'tasks', taskFile!, (rec) => {
+        rec.payload.description = 'Modified payload breaks checksum - legacy indicator';
+        return rec;
+      });
+
+      const result = runCliCommand(
+        ['lint', '--check-migrations'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      // Check-migrations should show migration-related output
+      expect(result.output || result.error).toContain('Migration Detection Report:');
+      // It should NOT have applied any fixes
+      expect(result.output || result.error).not.toContain('Fix Report:');
+
+      // Restore
+      const filePath = path.join(worktreeBasePath, '.gitgov', 'tasks', taskFile!);
+      fs.writeFileSync(filePath, JSON.stringify(record, null, 2));
+    });
+  });
+
+  // ============================================================================
+  // 3.10. Bloque J: File Naming Conventions (EARS-J1 to J2)
+  // ============================================================================
+  describe('3.10. File Naming Conventions (EARS-J1 to J2)', () => {
+    let testProjectRoot: string;
+    let worktreeBasePath: string;
+
+    beforeAll(() => {
+      const setup = setupProject('bloque-j');
+      testProjectRoot = setup.testProjectRoot;
+      worktreeBasePath = setup.worktreeBasePath;
+
+      runCliCommand(
+        ['task', 'new', 'File Naming Test Task', '-d', 'Task for file naming convention test'],
+        { cwd: testProjectRoot }
+      );
+    });
+
+    afterAll(() => {
+      cleanupWorktree(testProjectRoot, worktreeBasePath);
+    });
+
+    it('[EARS-J1] should detect record placed in wrong directory via schema mismatch', () => {
+      const taskFile = findFirstRecord(worktreeBasePath, 'tasks');
+      expect(taskFile).not.toBeNull();
+
+      const record = readRecord(worktreeBasePath, 'tasks', taskFile!);
+      // Copy the task record into the cycles directory (wrong location).
+      // Discovery assigns type 'cycle', but the content is a task record,
+      // so schema validation fails (id pattern, status enum, missing fields).
+      writeRawRecord(worktreeBasePath, 'cycles', taskFile!, record);
+
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot, expectError: true }
+      );
+
+      const report = JSON.parse(result.output || result.error!);
+      // The misplaced file should produce errors (schema mismatch)
+      const misplacedErrors = report.results.filter(
+        (r: any) => r.entity.type === 'cycle' && r.entity.id.includes('task')
+      );
+      expect(misplacedErrors.length).toBeGreaterThan(0);
+
+      // Cleanup: remove the misplaced file
+      const misplacedPath = path.join(worktreeBasePath, '.gitgov', 'cycles', taskFile!);
+      fs.unlinkSync(misplacedPath);
+    });
+
+    it('[EARS-J2] should validate records with correct filenames pass', () => {
+      // Records created via CLI have correct filenames (ID matches filename).
+      // Verify no FILE_NAMING_CONVENTION errors on valid records.
+      const result = runCliCommand(
+        ['lint', '--format', 'json', '--quiet'],
+        { cwd: testProjectRoot }
+      );
+
+      expect(result.success).toBe(true);
+      const report = JSON.parse(result.output);
+      const namingErrors = report.results.filter(
+        (r: any) => r.validator === 'FILE_NAMING_CONVENTION'
+      );
+      expect(namingErrors.length).toBe(0);
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,7 +97,6 @@ export type {
   GitGovRecordType,
   Signature,
   EmbeddedMetadataRecord,
-  CustomRecord,
 } from "./record_types";
 export * as DiagramGenerator from "./diagram_generator";
 

--- a/packages/core/src/lint/fs/fs_lint.ts
+++ b/packages/core/src/lint/fs/fs_lint.ts
@@ -154,6 +154,13 @@ export class FsLintModule implements IFsLintModule {
   }
 
   /**
+   * Delegates to LintModule.lintRecordReferences() for prefix validation.
+   */
+  lintRecordReferences(record: GitGovRecord, context: LintRecordContext): LintResult[] {
+    return this.lintModule.lintRecordReferences(record, context);
+  }
+
+  /**
    * Delegates to LintModule.fixRecord() for pure fix.
    */
   fixRecord(record: GitGovRecord, results: LintResult[], options: FixRecordOptions): GitGovRecord {
@@ -443,6 +450,16 @@ export class FsLintModule implements IFsLintModule {
       if (options.validateFileNaming) {
         const namingResults = this.validateFileNaming(record, recordId, filePath, entityType);
         results.push(...namingResults);
+      }
+
+      // [EARS-D2] Reference prefix validation (pure, no stores needed)
+      if (options.validateReferences) {
+        const refResults = this.lintModule.lintRecordReferences(record, {
+          recordId,
+          entityType,
+          filePath
+        });
+        results.push(...refResults);
       }
 
     } catch (error) {

--- a/packages/core/src/lint/fs/fs_lint.ts
+++ b/packages/core/src/lint/fs/fs_lint.ts
@@ -399,7 +399,7 @@ export class FsLintModule implements IFsLintModule {
   private async lintSingleRecord(
     recordId: string,
     options: FsLintOptions,
-    entityType: Exclude<GitGovRecordType, 'custom'>
+    entityType: GitGovRecordType
   ): Promise<LintResult[]> {
     const results: LintResult[] = [];
     let filePath: string;
@@ -502,11 +502,11 @@ export class FsLintModule implements IFsLintModule {
     _record: GitGovRecord,
     recordId: string,
     filePath: string,
-    entityType: Exclude<GitGovRecordType, 'custom'>
+    entityType: GitGovRecordType
   ): LintResult[] {
     const results: LintResult[] = [];
 
-    const dirNameMap: Record<Exclude<GitGovRecordType, 'custom'>, string> = {
+    const dirNameMap: Record<GitGovRecordType, string> = {
       'task': 'tasks', 'cycle': 'cycles', 'execution': 'executions',
       'changelog': 'changelogs', 'feedback': 'feedbacks',
       'actor': 'actors', 'agent': 'agents'
@@ -548,14 +548,14 @@ export class FsLintModule implements IFsLintModule {
    * [EARS-A1] Discovers all records with their types by scanning filesystem.
    * @private
    */
-  private async discoverAllRecordsWithTypes(_path?: string): Promise<Array<{ id: string; type: Exclude<GitGovRecordType, 'custom'> }>> {
+  private async discoverAllRecordsWithTypes(_path?: string): Promise<Array<{ id: string; type: GitGovRecordType }>> {
     // Note: _path parameter is deprecated, projectRoot is now injected via constructor
-    const recordTypes: Array<Exclude<GitGovRecordType, 'custom'>> = [
+    const recordTypes: Array<GitGovRecordType> = [
       'actor', 'agent', 'cycle', 'task', 'execution', 'changelog', 'feedback'
     ];
-    const allRecords: Array<{ id: string; type: Exclude<GitGovRecordType, 'custom'> }> = [];
+    const allRecords: Array<{ id: string; type: GitGovRecordType }> = [];
 
-    const dirNameMap: Record<Exclude<GitGovRecordType, 'custom'>, string> = {
+    const dirNameMap: Record<GitGovRecordType, string> = {
       'task': 'tasks', 'cycle': 'cycles', 'execution': 'executions',
       'changelog': 'changelogs', 'feedback': 'feedbacks',
       'actor': 'actors', 'agent': 'agents'
@@ -580,8 +580,8 @@ export class FsLintModule implements IFsLintModule {
    * Gets file path for a record.
    * @private
    */
-  private getFilePath(recordId: string, entityType: Exclude<GitGovRecordType, 'custom'>): string {
-    const dirNameMap: Record<Exclude<GitGovRecordType, 'custom'>, string> = {
+  private getFilePath(recordId: string, entityType: GitGovRecordType): string {
+    const dirNameMap: Record<GitGovRecordType, string> = {
       'task': 'tasks', 'cycle': 'cycles', 'execution': 'executions',
       'changelog': 'changelogs', 'feedback': 'feedbacks',
       'actor': 'actors', 'agent': 'agents'

--- a/packages/core/src/lint/lint.test.ts
+++ b/packages/core/src/lint/lint.test.ts
@@ -11,16 +11,18 @@
  * FsLintModule EARS (see fs_lint_module.md):
  * - File Discovery, File Naming, Backup Operations, etc.
  *
- * LintModule EARS (Bloques A-I):
- * - Bloque A: Initialization & Dependencies (EARS-A1, A2, A3)
- * - Bloque B: Core Lint Operations (EARS-B1, B2, B3, B4)
+ * LintModule EARS (Bloques A-K):
+ * - Bloque A: Initialization & Dependencies (EARS-A1, A2, A3, A4)
+ * - Bloque B: Core Lint Operations (EARS-B1, B2, B3, B4, B5, B6)
  * - Bloque C: Store Validation (EARS-C1, C2, C3, C4)
  * - Bloque D: Timestamp Validation (EARS-D1, D2)
- * - Bloque E: Reference Validation (EARS-E1 a E6)
+ * - Bloque E: Reference Validation (EARS-E1 a E7)
  * - Bloque F: Auto-Fix Operations (EARS-F1 a F12)
  * - Bloque G: Performance & Concurrency (EARS-G1, G2, G3)
  * - Bloque H: Error Handling & Recovery (EARS-H1, H2)
  * - Bloque I: Schema Version Detection (EARS-I1)
+ * - Bloque J: Integration Scenarios (EARS-J1, J2, J3)
+ * - Bloque K: Multi-Record Type Coverage (EARS-K1 a K8)
  */
 
 import { LintModule } from './index';
@@ -469,8 +471,8 @@ describe('LintModule + FsLintModule', () => {
       expect(pureLintModule.fixRecord).toBeDefined();
     });
 
-    // FsLintModule requires lintModule (not an EARS - FsLintModule specific behavior)
-    it('FsLintModule should throw error without lintModule', () => {
+    // [EARS-A4]
+    it('[EARS-A4] FsLintModule should throw error without lintModule', () => {
       expect(() => new FsLintModule({} as FsLintModuleDependencies)).toThrow();
     });
 
@@ -525,17 +527,7 @@ describe('LintModule + FsLintModule', () => {
         return [];
       }) as typeof readdir);
 
-      // Mock file with EmbeddedMetadataRecord structure but invalid payload
-      const invalidRecord = {
-        header: {
-          version: '1.0' as const,
-          type: 'task' as const,
-          payloadChecksum: 'abc123',
-          signatures: [createTestSignature('test-actor', 'author', 'Test')]
-        },
-        payload: { id: 'invalid-task', status: 'draft', priority: 'medium', description: 'Test' } // Missing 'title'
-      };
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(invalidRecord));
+      // Mock file read to reject with validation error (simulates loader failure)
       mocks.fileSystem.readFile.mockRejectedValue(validationError);
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
@@ -555,7 +547,6 @@ describe('LintModule + FsLintModule', () => {
       // Mock filesystem discovery: return one task file
       mockFilesystemDiscovery(mockReaddir, [{ id: recordId, type: 'task' }]);
 
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
 
       const report = await fsLintModule.lint({
@@ -580,7 +571,6 @@ describe('LintModule + FsLintModule', () => {
         return [];
       }) as typeof readdir);
 
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify({ id: 'task-1', title: null }));
       mocks.fileSystem.readFile.mockRejectedValue(
         new DetailedValidationError('TaskRecord', [
           { field: 'title', message: 'Invalid', value: null }
@@ -604,7 +594,6 @@ describe('LintModule + FsLintModule', () => {
         return [];
       }) as typeof readdir);
 
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify({ id: 'task-1', title: null }));
       mocks.fileSystem.readFile.mockRejectedValue(
         new DetailedValidationError('TaskRecord', [
           { field: 'title', message: 'Invalid', value: null }
@@ -620,12 +609,11 @@ describe('LintModule + FsLintModule', () => {
   });
 
   // ==========================================================================
-  // Bloque B (Store Path): LintModule.lint() iterates stores directly
-  // Validates EARS-B3/B4 via the pure LintModule path (no FsLintModule)
+  // LintModule.lint() via stores (supplementary — canonical B3/B4 above)
   // ==========================================================================
 
-  describe('Bloque B (Store Path): LintModule.lint() via stores', () => {
-    // [EARS-B3] LintModule.lint() accumulates all errors from stores
+  describe('LintModule.lint() via stores', () => {
+    // [EARS-B3] (additional test via lint() batch path)
     it('[EARS-B3] should accumulate all errors from stores by default', async () => {
       // Populate tasks store with 3 invalid records (missing title → schema error)
       const invalidRecord1 = {
@@ -655,7 +643,7 @@ describe('LintModule + FsLintModule', () => {
       expect(report.summary.errors).toBeGreaterThanOrEqual(3);
     });
 
-    // [EARS-B4] LintModule.lint() stops at first error in failFast mode
+    // [EARS-B4] (additional test via lint() batch path)
     it('[EARS-B4] should stop at first error from stores in failFast mode', async () => {
       // Populate tasks store with 3 invalid records
       const invalidRecord1 = {
@@ -687,8 +675,8 @@ describe('LintModule + FsLintModule', () => {
       expect(report.summary.filesChecked).toBeLessThanOrEqual(3);
     });
 
-    // Validates LintModule.lint() collects records from multiple stores
-    it('should collect and validate records from multiple stores', async () => {
+    // [EARS-B5]
+    it('[EARS-B5] should collect and validate records from multiple stores', async () => {
       const validTask = createMockTaskRecord({ title: 'Valid Task' });
       const validCycle = createMockCycleRecord({ title: 'Valid Cycle' });
 
@@ -704,8 +692,8 @@ describe('LintModule + FsLintModule', () => {
       expect(report.metadata.version).toBe('1.0.0');
     });
 
-    // Validates LintModule.lint() returns empty report when stores are empty
-    it('should return empty report when all stores are empty', async () => {
+    // [EARS-B6]
+    it('[EARS-B6] should return empty report when all stores are empty', async () => {
       // All stores return empty lists (default mock behavior)
       const report = await lintModule.lint();
 
@@ -733,8 +721,6 @@ describe('LintModule + FsLintModule', () => {
 
       mockFilesystemDiscovery(mockReaddir, [{ id: recordId, type: 'task' }]);
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
-      // Loader will be called internally, recordStore.read may be called as fallback
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
 
@@ -751,7 +737,6 @@ describe('LintModule + FsLintModule', () => {
       ]);
 
       mockFilesystemDiscovery(mockReaddir, [{ id: 'bad-task', type: 'task' }]);
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify({ id: 'bad-task', status: 'invalid-status' }));
       mocks.fileSystem.readFile.mockRejectedValue(schemaError);
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
@@ -769,7 +754,6 @@ describe('LintModule + FsLintModule', () => {
 
       mockFilesystemDiscovery(mockReaddir, [{ id: recordId, type: 'task' }]);
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
 
@@ -783,7 +767,6 @@ describe('LintModule + FsLintModule', () => {
       ]);
 
       mockFilesystemDiscovery(mockReaddir, [{ id: 'bad-checksum', type: 'task' }]);
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify({ id: 'bad-checksum', header: { payloadChecksum: 'wrong' } }));
       mocks.fileSystem.readFile.mockRejectedValue(embeddedError);
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
@@ -810,7 +793,6 @@ describe('LintModule + FsLintModule', () => {
       const recordId = mockRecord.payload.id;
 
       mockFilesystemDiscovery(mockReaddir, [{ id: recordId, type: 'task' }]);
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
 
       const report = await fsLintModule.lint({
@@ -1097,6 +1079,56 @@ describe('LintModule + FsLintModule', () => {
       expect(softDeleteWarnings[0]?.level).toBe('warning');
       expect(softDeleteWarnings[0]?.entity.type).toBe('execution');
     });
+
+    // [EARS-E7]
+    it('[EARS-E7] should expose lintRecordReferences as public method', () => {
+      const module = new LintModule(mocks.lintModuleDeps);
+
+      // Valid references → no results
+      const validRecord = createMockTaskRecord({
+        references: ['task:123', 'file:README.md', 'url:https://example.com']
+      });
+      const validResults = module.lintRecordReferences(validRecord, {
+        recordId: validRecord.payload.id,
+        entityType: 'task',
+        filePath: 'tasks/test.json'
+      });
+      expect(validResults).toEqual([]);
+
+      // Unknown prefix → warning
+      const unknownRecord = createMockTaskRecord({
+        references: ['unknown:value', 'no-colon']
+      });
+      const unknownResults = module.lintRecordReferences(unknownRecord, {
+        recordId: unknownRecord.payload.id,
+        entityType: 'task',
+        filePath: 'tasks/test.json'
+      });
+      expect(unknownResults).toHaveLength(2);
+      expect(unknownResults.every(r => r.level === 'warning')).toBe(true);
+      expect(unknownResults.every(r => r.validator === 'REFERENTIAL_INTEGRITY')).toBe(true);
+
+      // Empty value after known prefix → error
+      const emptyRecord = createMockTaskRecord({
+        references: ['file:', 'task:']
+      });
+      const emptyResults = module.lintRecordReferences(emptyRecord, {
+        recordId: emptyRecord.payload.id,
+        entityType: 'task',
+        filePath: 'tasks/test.json'
+      });
+      expect(emptyResults).toHaveLength(2);
+      expect(emptyResults.every(r => r.level === 'error')).toBe(true);
+
+      // Empty/no references → no results
+      const noRefRecord = createMockTaskRecord({ references: [] });
+      const noRefResults = module.lintRecordReferences(noRefRecord, {
+        recordId: noRefRecord.payload.id,
+        entityType: 'task',
+        filePath: 'tasks/test.json'
+      });
+      expect(noRefResults).toEqual([]);
+    });
   });
 
   // ==========================================================================
@@ -1157,8 +1189,8 @@ describe('LintModule + FsLintModule', () => {
       expect(mocks.fileSystem.writeFile).toHaveBeenCalled();
     });
 
-    // Test for fixing additional properties in payload
-    it('should remove additional properties from payload when fixing EMBEDDED_METADATA_STRUCTURE', async () => {
+    // [EARS-F2] (additional test — remove additional properties from payload)
+    it('[EARS-F2] should remove additional properties from payload when fixing EMBEDDED_METADATA_STRUCTURE', async () => {
       const lintReport: LintReport = {
         summary: { filesChecked: 1, errors: 1, warnings: 0, fixable: 1, executionTime: 100 },
         results: [{
@@ -1944,7 +1976,6 @@ describe('LintModule + FsLintModule', () => {
 
       mockFilesystemDiscovery(mockReaddir, recordIds.map(id => ({ id, type: 'task' as const })));
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
 
       const startTime = Date.now();
       const report = await fsLintModule.lint({
@@ -1966,7 +1997,6 @@ describe('LintModule + FsLintModule', () => {
 
       mockFilesystemDiscovery(mockReaddir, recordIds.map(id => ({ id, type: 'task' as const })));
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
 
       const startTime = Date.now();
       const report = await fsLintModule.lint({
@@ -1985,7 +2015,6 @@ describe('LintModule + FsLintModule', () => {
       const mockRecord = createMockTaskRecord();
 
       mockFilesystemDiscovery(mockReaddir, recordIds.map(id => ({ id, type: 'task' as const })));
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
 
       const report = await fsLintModule.lint({
@@ -2012,10 +2041,9 @@ describe('LintModule + FsLintModule', () => {
         { id: 'task-1', type: 'task' },
         { id: 'task-2', type: 'task' }
       ]);
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify({ id: 'task-1' }));
       mocks.fileSystem.readFile
         .mockRejectedValueOnce(new Error('Random validator error'))
-        .mockResolvedValueOnce(createMockTaskRecord());
+        .mockResolvedValueOnce(JSON.stringify(createMockTaskRecord()));
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
 
@@ -2027,7 +2055,6 @@ describe('LintModule + FsLintModule', () => {
     // [EARS-H2]
     it('[EARS-H2] should handle file read errors gracefully', async () => {
       mockFilesystemDiscovery(mockReaddir, [{ id: 'corrupt-file', type: 'task' }]);
-      mocks.fileSystem.readFile.mockRejectedValue(new Error('File read error: corrupt'));
       mocks.fileSystem.readFile.mockRejectedValue(new Error('File read error: corrupt'));
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
@@ -2061,7 +2088,6 @@ describe('LintModule + FsLintModule', () => {
       ]);
 
       mockFilesystemDiscovery(mockReaddir, [{ id: 'outdated-task', type: 'task' }]);
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify({ id: 'outdated-task', legacyField: 'value' }));
       mocks.fileSystem.readFile.mockRejectedValue(schemaError);
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
@@ -2079,12 +2105,13 @@ describe('LintModule + FsLintModule', () => {
   // Additional Integration Tests
   // ==========================================================================
 
-  describe('Integration Scenarios', () => {
+  describe('Bloque J: Integration Scenarios (EARS-J1 a J3)', () => {
     beforeEach(() => {
       lintModule = new LintModule(mocks.lintModuleDeps);
     });
 
-    it('should handle lintFile() for single file validation', async () => {
+    // [EARS-J1]
+    it('[EARS-J1] should handle lintFile() for single file validation', async () => {
       const mockRecord = createMockTaskRecord();
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
 
@@ -2098,29 +2125,30 @@ describe('LintModule + FsLintModule', () => {
 
     // Note: EARS-F1 (Filter oneOf errors) is in fs/index.test.ts
 
-    it('should provide detailed context in error messages', async () => {
+    // [EARS-J2]
+    it('[EARS-J2] should provide detailed context in error messages', async () => {
       const error = new DetailedValidationError('TaskRecord', [
         { field: 'priority', message: 'Invalid enum', value: 'urgent' }
       ]);
 
       mockFilesystemDiscovery(mockReaddir, [{ id: 'bad-priority', type: 'task' }]);
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify({ id: 'bad-priority', priority: 'urgent' }));
       mocks.fileSystem.readFile.mockRejectedValue(error);
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
 
-      const firstResult = report.results[0];
-      if (firstResult && firstResult.context) {
-        expect(firstResult.context).toBeDefined();
-      }
+      expect(report.results.length).toBeGreaterThan(0);
+      const resultWithContext = report.results.find(r => r.context);
+      expect(resultWithContext).toBeDefined();
+      expect(resultWithContext!.context).toBeDefined();
+      expect(resultWithContext!.context!.field).toBeDefined();
     });
 
-    it('should respect validation flags', async () => {
+    // [EARS-J3]
+    it('[EARS-J3] should respect validation flags', async () => {
       const mockRecord = createMockTaskRecord();
       const recordId = mockRecord.payload.id;
 
       mockFilesystemDiscovery(mockReaddir, [{ id: recordId, type: 'task' }]);
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockRecord));
 
       const report = await fsLintModule.lint({
@@ -2130,8 +2158,14 @@ describe('LintModule + FsLintModule', () => {
         validateFileNaming: false
       });
 
-      // Should only do base validation from recordStore
       expect(report.summary.filesChecked).toBe(1);
+      // Verify that reference and actor validators were NOT invoked
+      const refErrors = report.results.filter(r => r.validator === 'REFERENTIAL_INTEGRITY');
+      const actorErrors = report.results.filter(r => r.validator === 'ACTOR_RESOLUTION');
+      const namingErrors = report.results.filter(r => r.validator === 'FILE_NAMING_CONVENTION');
+      expect(refErrors.length).toBe(0);
+      expect(actorErrors.length).toBe(0);
+      expect(namingErrors.length).toBe(0);
     });
   });
 
@@ -2139,18 +2173,18 @@ describe('LintModule + FsLintModule', () => {
   // Multi-Record Type Validation Tests
   // ==========================================================================
 
-  describe('Multi-Record Type Validation', () => {
+  describe('Bloque K: Multi-Record Type Coverage (EARS-K1 a K8)', () => {
     beforeEach(() => {
       lintModule = new LintModule(mocks.lintModuleDeps);
     });
 
-    it('should validate TaskRecord correctly', async () => {
+    // [EARS-K1]
+    it('[EARS-K1] should validate TaskRecord correctly', async () => {
       const mockTask = createMockTaskRecord();
       const recordId = mockTask.payload.id;
 
       mockFilesystemDiscovery(mockReaddir, [{ id: recordId, type: 'task' }]);
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockTask));
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockTask));
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
 
@@ -2158,13 +2192,13 @@ describe('LintModule + FsLintModule', () => {
       expect(report.summary.errors).toBe(0);
     });
 
-    it('should validate CycleRecord correctly', async () => {
+    // [EARS-K2]
+    it('[EARS-K2] should validate CycleRecord correctly', async () => {
       const mockCycle = createMockCycleRecord();
       const recordId = mockCycle.payload.id;
 
       mockFilesystemDiscovery(mockReaddir, [{ id: recordId, type: 'cycle' }]);
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockCycle));
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockCycle));
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
 
@@ -2172,13 +2206,13 @@ describe('LintModule + FsLintModule', () => {
       expect(report.summary.errors).toBe(0);
     });
 
-    it('should validate ExecutionRecord correctly', async () => {
+    // [EARS-K3]
+    it('[EARS-K3] should validate ExecutionRecord correctly', async () => {
       const mockExecution = createMockExecutionRecord();
       const recordId = mockExecution.payload.id;
 
       mockFilesystemDiscovery(mockReaddir, [{ id: recordId, type: 'execution' }]);
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockExecution));
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockExecution));
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
 
@@ -2186,13 +2220,13 @@ describe('LintModule + FsLintModule', () => {
       expect(report.summary.errors).toBe(0);
     });
 
-    it('should validate ChangelogRecord correctly', async () => {
+    // [EARS-K4]
+    it('[EARS-K4] should validate ChangelogRecord correctly', async () => {
       const mockChangelog = createMockChangelogRecord();
       const recordId = mockChangelog.payload.id;
 
       mockFilesystemDiscovery(mockReaddir, [{ id: recordId, type: 'changelog' }]);
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockChangelog));
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockChangelog));
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
 
@@ -2200,13 +2234,13 @@ describe('LintModule + FsLintModule', () => {
       expect(report.summary.errors).toBe(0);
     });
 
-    it('should validate FeedbackRecord correctly', async () => {
+    // [EARS-K5]
+    it('[EARS-K5] should validate FeedbackRecord correctly', async () => {
       const mockFeedback = createMockFeedbackRecord();
       const recordId = mockFeedback.payload.id;
 
       mockFilesystemDiscovery(mockReaddir, [{ id: recordId, type: 'feedback' }]);
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockFeedback));
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockFeedback));
 
       const report = await fsLintModule.lint({ path: `${testRoot}/.gitgov/` });
 
@@ -2214,13 +2248,13 @@ describe('LintModule + FsLintModule', () => {
       expect(report.summary.errors).toBe(0);
     });
 
-    it('should validate ActorRecord correctly', async () => {
+    // [EARS-K6]
+    it('[EARS-K6] should validate ActorRecord correctly', async () => {
       const mockActor = createMockActorRecord();
       const recordId = mockActor.payload.id;
 
       mockFilesystemDiscovery(mockReaddir, [{ id: recordId, type: 'actor' }]);
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockActor));
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockActor));
 
       const report = await fsLintModule.lint({
         path: `${testRoot}/.gitgov/`,
@@ -2231,13 +2265,13 @@ describe('LintModule + FsLintModule', () => {
       expect(report.summary.errors).toBe(0);
     });
 
-    it('should validate AgentRecord correctly', async () => {
+    // [EARS-K7]
+    it('[EARS-K7] should validate AgentRecord correctly', async () => {
       const mockAgent = createMockAgentRecord();
       const recordId = mockAgent.payload.id;
 
       mockFilesystemDiscovery(mockReaddir, [{ id: recordId, type: 'agent' }]);
       mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockAgent));
-      mocks.fileSystem.readFile.mockResolvedValue(JSON.stringify(mockAgent));
 
       const report = await fsLintModule.lint({
         path: `${testRoot}/.gitgov/`,
@@ -2248,7 +2282,8 @@ describe('LintModule + FsLintModule', () => {
       expect(report.summary.errors).toBe(0);
     });
 
-    it('should validate mixed record types in single lint run', async () => {
+    // [EARS-K8]
+    it('[EARS-K8] should validate mixed record types in single lint run', async () => {
       const mockTask = createMockTaskRecord();
       const mockCycle = createMockCycleRecord();
       const mockExecution = createMockExecutionRecord();

--- a/packages/core/src/lint/lint.ts
+++ b/packages/core/src/lint/lint.ts
@@ -167,6 +167,26 @@ export class LintModule implements ILintModule {
   }
 
   /**
+   * Validates typed references by prefix (pure, no I/O).
+   * Delegates to private validateTypedReferencesByPrefix.
+   */
+  lintRecordReferences(
+    record: GitGovRecord,
+    context: LintRecordContext
+  ): LintResult[] {
+    const payload = record.payload as { references?: string[] };
+    if (!Array.isArray(payload.references) || payload.references.length === 0) {
+      return [];
+    }
+    return this.validateTypedReferencesByPrefix(
+      payload.references,
+      context.recordId,
+      context.filePath || `unknown/${context.recordId}.json`,
+      context.entityType
+    );
+  }
+
+  /**
    * Validates all records from stores.
    * Iterates this.stores to collect records, then validates each one.
    *

--- a/packages/core/src/lint/lint.types.ts
+++ b/packages/core/src/lint/lint.types.ts
@@ -53,6 +53,19 @@ export interface ILintModule {
   ): Promise<LintReport>;
 
   /**
+   * Validates typed references by prefix (pure, no I/O).
+   * Returns warnings for unknown prefixes, errors for empty values.
+   *
+   * @param record - The GitGovRecord object to validate
+   * @param context - Context with recordId and entityType
+   * @returns Array of lint results for reference issues
+   */
+  lintRecordReferences(
+    record: GitGovRecord,
+    context: LintRecordContext
+  ): LintResult[];
+
+  /**
    * Applies fixes to a record and returns the fixed version.
    * Does NOT write to disk - returns modified object.
    *

--- a/packages/core/src/lint/lint.types.ts
+++ b/packages/core/src/lint/lint.types.ts
@@ -78,7 +78,7 @@ export interface RecordEntry {
   /** Record ID */
   id: string;
   /** Entity type */
-  type: Exclude<GitGovRecordType, 'custom'>;
+  type: GitGovRecordType;
   /** Optional file path for error reporting (FsLintModule provides this) */
   filePath?: string;
 }
@@ -90,7 +90,7 @@ export interface LintRecordContext {
   /** Record ID */
   recordId: string;
   /** Entity type */
-  entityType: Exclude<GitGovRecordType, 'custom'>;
+  entityType: GitGovRecordType;
   /** Optional file path for error reporting */
   filePath?: string;
 }
@@ -276,7 +276,6 @@ export interface LintResult {
 export type ValidatorType =
   | "SCHEMA_VALIDATION"
   | "REFERENTIAL_INTEGRITY"
-  | "TYPED_REFERENCE"
   | "BIDIRECTIONAL_CONSISTENCY"
   | "EMBEDDED_METADATA_STRUCTURE"
   | "CHECKSUM_VERIFICATION"

--- a/packages/core/src/record_factories/embedded_metadata_factory.test.ts
+++ b/packages/core/src/record_factories/embedded_metadata_factory.test.ts
@@ -85,13 +85,13 @@ describe('EmbeddedMetadata Factory', () => {
 
     it('[EARS-5] should allow overriding header type', async () => {
       const result = createEmbeddedMetadataRecord(validActorPayload, {
-        header: { type: 'custom' }
+        header: { type: 'task' }
       });
 
-      expect(result.header.type).toBe('custom');
+      expect(result.header.type).toBe('task');
     });
 
-    it('[EARS-6] should use default version 1.0', async () => {
+    it('[EARS-6] should always use version 1.0', async () => {
       const result = createEmbeddedMetadataRecord(validActorPayload);
 
       expect(result.header.version).toBe('1.0');
@@ -116,18 +116,11 @@ describe('EmbeddedMetadata Factory', () => {
       expect(result.header.payloadChecksum).not.toBe('a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456');
     });
 
-    it('[EARS-9] should include schemaUrl and schemaChecksum for custom type', async () => {
-      const result = createEmbeddedMetadataRecord(validActorPayload, {
-        header: {
-          type: 'custom',
-          schemaUrl: 'https://example.com/schema.json',
-          schemaChecksum: 'abc123def456789012345678901234567890abcdef1234567890abcdef123456'
-        }
-      });
+    it('[EARS-9] should not include schemaUrl or schemaChecksum', async () => {
+      const result = createEmbeddedMetadataRecord(validActorPayload);
 
-      expect(result.header.type).toBe('custom');
-      expect(result.header).toHaveProperty('schemaUrl', 'https://example.com/schema.json');
-      expect(result.header).toHaveProperty('schemaChecksum', 'abc123def456789012345678901234567890abcdef1234567890abcdef123456');
+      expect(result.header).not.toHaveProperty('schemaUrl');
+      expect(result.header).not.toHaveProperty('schemaChecksum');
     });
 
     it('[EARS-10] should throw DetailedValidationError when validation fails', () => {
@@ -154,7 +147,7 @@ describe('EmbeddedMetadata Factory', () => {
       ).toThrow('EmbeddedMetadataRecord');
     });
 
-    it('[EARS-11] should calculate real SHA-256 checksum of payload', async () => {
+    it('[EARS-11] should produce deterministic checksum for identical payloads', async () => {
       const result = createEmbeddedMetadataRecord(validActorPayload);
 
       // Checksum should be 64 hex characters (SHA-256)

--- a/packages/core/src/record_factories/embedded_metadata_factory.ts
+++ b/packages/core/src/record_factories/embedded_metadata_factory.ts
@@ -1,4 +1,4 @@
-import type { EmbeddedMetadataRecord, GitGovRecordPayload } from '../record_types';
+import type { EmbeddedMetadataRecord, GitGovRecordPayload, GitGovRecordType } from '../record_types';
 import type { Signature, EmbeddedMetadataHeader } from '../record_types/embedded.types';
 import { validateEmbeddedMetadataDetailed } from '../record_validations/embedded_metadata_validator';
 import { DetailedValidationError } from '../record_validations/common';
@@ -19,7 +19,7 @@ export type SignatureConfig = Partial<Pick<Signature, 'keyId' | 'role' | 'notes'
  */
 export type CreateEmbeddedMetadataOptions = {
   /** Header configuration (partial override, excludes auto-generated fields) */
-  header?: Partial<Pick<EmbeddedMetadataHeader, 'version' | 'type' | 'schemaUrl' | 'schemaChecksum'>>;
+  header?: Partial<Pick<EmbeddedMetadataHeader, 'version' | 'type'>>;
   /** Signature configuration (if not provided, uses default test signature) */
   signature?: SignatureConfig;
   /** Custom signatures array (if provided, overrides signature config) */
@@ -56,7 +56,7 @@ export function createTestSignature(
  * @param payload - The record payload
  * @returns The inferred type string
  */
-function inferTypeFromPayload(payload: GitGovRecordPayload): string {
+function inferTypeFromPayload(payload: GitGovRecordPayload): GitGovRecordType {
   // Check for distinctive properties of each record type
   if ('engine' in payload) return 'agent';
   if ('taskId' in payload && 'result' in payload) return 'execution';
@@ -66,7 +66,7 @@ function inferTypeFromPayload(payload: GitGovRecordPayload): string {
   if ('priority' in payload && 'description' in payload) return 'task';
   if ('displayName' in payload && 'publicKey' in payload) return 'actor';
 
-  return 'custom';
+  return 'task';
 }
 
 
@@ -125,10 +125,6 @@ export function createEmbeddedMetadataRecord<T extends GitGovRecordPayload>(
     type: type,
     payloadChecksum,
     signatures,
-    ...(type === 'custom' && {
-      schemaUrl: options.header?.schemaUrl,
-      schemaChecksum: options.header?.schemaChecksum
-    })
   };
 
   const embeddedRecord = {

--- a/packages/core/src/record_schemas/generated/embedded_metadata_schema.json
+++ b/packages/core/src/record_schemas/generated/embedded_metadata_schema.json
@@ -24,19 +24,9 @@
             "execution",
             "changelog",
             "feedback",
-            "cycle",
-            "custom"
+            "cycle"
           ],
           "description": "The type of the record contained in the payload."
-        },
-        "schemaUrl": {
-          "type": "string",
-          "description": "Optional URL to a custom schema for the payload."
-        },
-        "schemaChecksum": {
-          "type": "string",
-          "pattern": "^[a-fA-F0-9]{64}$",
-          "description": "Optional SHA-256 checksum of the custom schema."
         },
         "payloadChecksum": {
           "type": "string",
@@ -257,32 +247,6 @@
         "properties": {
           "payload": {
             "$ref": "ref:cycle_record_schema"
-          }
-        }
-      },
-      "else": false
-    },
-    {
-      "if": {
-        "properties": {
-          "header": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "const": "custom"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "header": {
-            "type": "object",
-            "required": [
-              "schemaUrl",
-              "schemaChecksum"
-            ]
           }
         }
       },

--- a/packages/core/src/record_types/common.types.ts
+++ b/packages/core/src/record_types/common.types.ts
@@ -8,14 +8,6 @@ import type { FeedbackRecord } from "./";
 import type { EmbeddedMetadataRecord } from "./embedded.types";
 
 /**
- * A custom record type for testing purposes.
- */
-export type CustomRecord = {
-  type: 'custom';
-  data: unknown;
-}
-
-/**
  * Defines the possible 'type' values for any record in the system.
  */
 export type GitGovRecordType =
@@ -25,8 +17,7 @@ export type GitGovRecordType =
   | "task"
   | "execution"
   | "changelog"
-  | "feedback"
-  | "custom";
+  | "feedback";
 
 /**
  * The canonical payload for any GitGovernance record.
@@ -38,8 +29,7 @@ export type GitGovRecordPayload =
   | TaskRecord
   | ExecutionRecord
   | ChangelogRecord
-  | FeedbackRecord
-  | CustomRecord;
+  | FeedbackRecord;
 
 /**
  * The canonical type for any record in GitGovernance, wrapping a payload with metadata.

--- a/packages/core/src/record_types/generated/embedded_metadata.ts
+++ b/packages/core/src/record_types/generated/embedded_metadata.ts
@@ -16,15 +16,7 @@ export type EmbeddedMetadataRecord = {
     /**
      * The type of the record contained in the payload.
      */
-    type: 'actor' | 'agent' | 'task' | 'execution' | 'changelog' | 'feedback' | 'cycle' | 'custom';
-    /**
-     * Optional URL to a custom schema for the payload.
-     */
-    schemaUrl?: string;
-    /**
-     * Optional SHA-256 checksum of the custom schema.
-     */
-    schemaChecksum?: string;
+    type: 'actor' | 'agent' | 'task' | 'execution' | 'changelog' | 'feedback' | 'cycle';
     /**
      * SHA-256 checksum of the canonically serialized payload.
      */

--- a/packages/core/src/sync_state/fs/fs_sync_state.test.ts
+++ b/packages/core/src/sync_state/fs/fs_sync_state.test.ts
@@ -3818,6 +3818,7 @@ describe("FsSyncStateModule", () => {
       const mockLintModule: ILintModule = {
         lint: jest.fn().mockResolvedValue(lintReportMock),
         lintRecord: jest.fn().mockReturnValue([]),
+        lintRecordReferences: jest.fn().mockReturnValue([]),
         fixRecord: jest.fn().mockImplementation((record) => record),
       };
 
@@ -3925,6 +3926,7 @@ describe("FsSyncStateModule", () => {
       const mockLintModule: ILintModule = {
         lint: jest.fn().mockResolvedValue(lintReportMock),
         lintRecord: jest.fn().mockReturnValue([]),
+        lintRecordReferences: jest.fn().mockReturnValue([]),
         fixRecord: jest.fn().mockImplementation((record) => record),
       };
 
@@ -3969,6 +3971,7 @@ describe("FsSyncStateModule", () => {
       const mockLintModule: ILintModule = {
         lint: jest.fn().mockResolvedValue(lintReportMock),
         lintRecord: jest.fn().mockReturnValue([]),
+        lintRecordReferences: jest.fn().mockReturnValue([]),
         fixRecord: jest.fn().mockImplementation((record) => record),
       };
 

--- a/packages/core/src/utils/id_parser.ts
+++ b/packages/core/src/utils/id_parser.ts
@@ -10,11 +10,6 @@
 import type { GitGovRecordType } from '../record_types';
 
 /**
- * Types of GitGov entities (excludes 'custom').
- */
-export type GitGovEntityType = Exclude<GitGovRecordType, 'custom'>;
-
-/**
  * Parsed result of a timestamp-based record ID.
  */
 export interface ParsedTimestampedId {
@@ -34,7 +29,7 @@ export interface ParsedActorId {
 /**
  * Mapping from directory names to entity types.
  */
-export const DIR_TO_TYPE: Record<string, GitGovEntityType> = {
+export const DIR_TO_TYPE: Record<string, GitGovRecordType> = {
   'tasks': 'task',
   'cycles': 'cycle',
   'executions': 'execution',
@@ -47,10 +42,10 @@ export const DIR_TO_TYPE: Record<string, GitGovEntityType> = {
 /**
  * Mapping from entity types to directory names (inverse of DIR_TO_TYPE).
  */
-export const TYPE_TO_DIR: Record<GitGovEntityType, string> =
+export const TYPE_TO_DIR: Record<GitGovRecordType, string> =
   Object.fromEntries(
     Object.entries(DIR_TO_TYPE).map(([dir, type]) => [type, dir]),
-  ) as Record<GitGovEntityType, string>;
+  ) as Record<GitGovRecordType, string>;
 
 /**
  * Valid directory names for GitGov records.
@@ -84,7 +79,7 @@ export function extractRecordIdFromPath(filePath: string): string {
  * getEntityTypeFromPath('.gitgov/actors/human_dev.json') // 'actor'
  * getEntityTypeFromPath('/some/other/path.json') // null
  */
-export function getEntityTypeFromPath(filePath: string): GitGovEntityType | null {
+export function getEntityTypeFromPath(filePath: string): GitGovRecordType | null {
   const pathParts = filePath.split('/');
   const typeDirIndex = pathParts.findIndex(part => VALID_DIRS.includes(part));
 
@@ -117,7 +112,7 @@ export function getEntityTypeFromPath(filePath: string): GitGovEntityType | null
  * inferEntityTypeFromId('agent:code-reviewer') // 'agent'
  * inferEntityTypeFromId('1234567890-task-implement-auth') // 'task'
  */
-export function inferEntityTypeFromId(recordId: string): GitGovEntityType {
+export function inferEntityTypeFromId(recordId: string): GitGovRecordType {
   // Execution patterns
   if (recordId.match(/^\d+-exec-/) || recordId.includes('-execution-')) {
     return 'execution';


### PR DESCRIPTION
## Summary

### Refactor: Remove custom record type
- Remove `custom` from `header.type` enum (7 valid types remain: actor, agent, task, execution, changelog, feedback, cycle)
- Remove `schemaUrl` and `schemaChecksum` conditional properties (only existed for custom type)
- Remove `CustomRecord` type and all custom-specific test cases (EARS-25 through EARS-29)
- Clean up `Exclude<GitGovRecordType, 'custom'>` patterns across lint, fs_lint, id_parser modules
- Remove dead `TYPED_REFERENCE` from `ValidatorType` union (never emitted, code uses `REFERENTIAL_INTEGRITY`)

**Note:** `custom:*` namespace in `signature.role` is a different concept (role namespace pattern) and is correctly preserved.

### Audit fixes: lint_module and fs_lint_module triads
- Fix 20+ duplicate mock patterns in lint tests (dead `mockResolvedValue` overwritten by `mockRejectedValue`)
- Fix weak assertions in EARS-J2 (remove if guard) and EARS-J3 (add validator absence checks)
- Fix H1 mock to return JSON.stringify'd value instead of raw object
- Add `lintRecordReferences()` public method and wire in FsLintModule
- Add CLI e2e helpers and lint_command_e2e test

## Test plan

- [x] `tsc --noEmit` — 0 errors (core, cli, mcp-server)
- [x] core: 2765 tests passed
- [x] cli: 7/7 e2e suites passed, 22/22 total suites
- [x] mcp-server: 199 tests passed
- [x] All 3 packages build successfully
- [x] `CustomRecord` grep returns 0 matches across core, cli, mcp-server