### PR TITLE
fix(core,cli): detect remote-deleted branch on push, remove legacy .gitignore

### DIFF
--- a/packages/cli/src/commands/sync/sync-command.ts
+++ b/packages/cli/src/commands/sync/sync-command.ts
@@ -546,8 +546,12 @@ ${steps.join('\n')}
       }
 
       // [EARS-B2] Handle "no changes" case (can be success=true with 0 files or success=false without conflict)
-      if (result.filesSynced === 0) {
+      if (result.filesSynced === 0 && !result.commitHash) {
         console.log('ℹ️  No local changes to push');
+      } else if (result.filesSynced === 0 && result.commitHash) {
+        // [EARS-B10] Existing commits pushed without new delta
+        console.log(`✅ Pushed existing commits to gitgov-state`);
+        console.log(`📝 Commit: ${result.commitHash.substring(0, 8)}`);
       } else if (result.success) {
         console.log(`✅ ${result.filesSynced} files synced to gitgov-state`);
         if (result.commitHash) {


### PR DESCRIPTION
## Summary

- **WTSYNC-B16**: `pushState()` delta=0 path now detects when local is ahead of remote (remote branch deleted or unpushed commits) and pushes existing commits with `pull --rebase` reconciliation
- **WTSYNC-A7**: `ensureWorktree()` removes legacy `.gitignore` from state branch (created by deprecated `FsSyncState`) — filtering is done in code via `shouldSyncFile()`
- **EARS-B10 (CLI)**: `sync push` output distinguishes "No local changes to push" vs "Pushed existing commits to gitgov-state" based on `commitHash` presence

## Test plan

- [x] 56/56 core worktree sync tests passing
- [x] 22/22 CLI test suites (480 tests) passing
- [x] E2E coverage for push-after-remote-deleted scenario added
- [x] Manual testing: `gitgov push` after deleting remote `gitgov-state` branch works correctly
- [x] `tsc --noEmit` passes for both core and cli