### PR TITLE
feat(core): add RECORD_TYPES constant

### DIFF
--- a/packages/core/src/record_types/common.types.ts
+++ b/packages/core/src/record_types/common.types.ts
@@ -18,6 +18,13 @@ export type GitGovRecordType =
   | "feedback";
 
 /**
+ * All valid record types as a readonly array, useful for iteration and validation.
+ */
+export const RECORD_TYPES: readonly GitGovRecordType[] = [
+  'actor', 'agent', 'cycle', 'task', 'execution', 'feedback',
+] as const;
+
+/**
  * Canonical mapping from directory names to record types.
  */
 export const DIR_TO_TYPE: Record<string, GitGovRecordType> = {


### PR DESCRIPTION
## Summary

- Adds `RECORD_TYPES` readonly array constant to `common.types.ts` for runtime iteration and validation of record types
- Triggers semantic-release publish for core v2.9.0 (previous merge had CI timing issue that prevented publish)

## Context

PR #101 merge triggered semantic-release but it failed with "local branch main is behind the remote one". Manual re-trigger also failed. This PR provides a clean merge to trigger the release pipeline with all accumulated changes since `core-v2.8.0`.

## Test plan

- [x] `pnpm tsc --noEmit` — 0 errors
- [x] `pnpm build` — success
- [x] `pnpm test` — 2556 passed, 0 failed