### PR TITLE
fix(cli): replace deprecated getGitgovPath with getWorktreeBasePath

### DIFF
--- a/packages/cli/src/components/diagram/DiagramDashboard.tsx
+++ b/packages/cli/src/components/diagram/DiagramDashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput, useApp } from 'ink';
 import { DiagramGenerator } from '@gitgov/core';
-import { findProjectRoot, getGitgovPath } from '@gitgov/core/fs';
+import { findProjectRoot, getWorktreeBasePath } from '@gitgov/core/fs';
 import { StatusBadge } from '../shared/StatusBadge';
 
 interface DiagramDashboardProps {
@@ -68,7 +68,7 @@ export const DiagramDashboard: React.FC<DiagramDashboardProps> = ({
       const projectRoot = findProjectRoot();
       if (!projectRoot) throw new Error("Project root not found.");
 
-      const actualGitgovPath = getGitgovPath();
+      const actualGitgovPath = getWorktreeBasePath(projectRoot);
       const path = await import('path');
       const actualOutputPath = path.join(projectRoot, outputPath);
 
@@ -161,7 +161,7 @@ export const DiagramDashboard: React.FC<DiagramDashboardProps> = ({
             // Get paths
             const projectRoot = findProjectRoot();
             if (!projectRoot) throw new Error("Project root not found.");
-            const actualGitgovPath = getGitgovPath();
+            const actualGitgovPath = getWorktreeBasePath(projectRoot);
             const path = await import('path');
 
             console.log(`📖 About to regenerate after ${fileName} changed`);


### PR DESCRIPTION
## Summary
- `getGitgovPath` was removed from `@gitgov/core/fs` in the worktree refactor
- `DiagramDashboard.tsx` still imported it, causing the CLI release build to fail
- Replaced with `getWorktreeBasePath(projectRoot)` which is the worktree-aware equivalent

## Test plan
- [x] `pnpm build` passes in CLI
- [x] `pnpm test` — 517 passed, 12 skipped, 6 failed (pre-existing diagram e2e failures)