### PR TITLE
feat(core): SARIF 2.1.0 module — Cycle 1

### DIFF
--- a/packages/cli/src/commands/audit/audit-command.test.ts
+++ b/packages/cli/src/commands/audit/audit-command.test.ts
@@ -483,18 +483,21 @@ describe('AuditCommand', () => {
 
       await auditCommand.execute(createDefaultOptions({ scope: 'full' }));
 
+      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
       expect(mockProcessExit).toHaveBeenCalledWith(0);
     });
 
     it('[EARS-D2] should exit 1 when findings match fail-on severity', async () => {
       await auditCommand.execute(createDefaultOptions({ scope: 'full' }));
 
+      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
       expect(mockProcessExit).toHaveBeenCalledWith(1);
     });
 
     it('[EARS-D2] should exit 1 when --fail-on high and high findings exist', async () => {
       await auditCommand.execute(createDefaultOptions({ scope: 'full', failOn: 'high' }));
 
+      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
       expect(mockProcessExit).toHaveBeenCalledWith(1);
     });
 
@@ -512,6 +515,7 @@ describe('AuditCommand', () => {
 
       await auditCommand.execute(createDefaultOptions({ scope: 'full' }));
 
+      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
       expect(mockProcessExit).toHaveBeenCalledWith(0);
     });
 
@@ -531,6 +535,7 @@ describe('AuditCommand', () => {
 
       await auditCommand.execute(createDefaultOptions({ scope: 'full', failOn: 'medium' }));
 
+      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
       expect(mockProcessExit).toHaveBeenCalledWith(0);
     });
 
@@ -550,6 +555,7 @@ describe('AuditCommand', () => {
 
       await auditCommand.execute(createDefaultOptions({ scope: 'full', failOn: 'low' }));
 
+      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
       expect(mockProcessExit).toHaveBeenCalledWith(1);
     });
   });
@@ -634,66 +640,50 @@ describe('AuditCommand', () => {
     // Commander before reaching the execute() method.
 
     it('[EARS-F1] should accept valid --scope values (diff, full, baseline)', async () => {
-      // Test that valid scope values are accepted
-      await auditCommand.execute(createDefaultOptions({ scope: 'diff' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
-
-      mockSourceAuditorModule.audit.mockClear();
-      await auditCommand.execute(createDefaultOptions({ scope: 'full' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
-
-      mockSourceAuditorModule.audit.mockClear();
-      await auditCommand.execute(createDefaultOptions({ scope: 'baseline' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
+      for (const scope of ['diff', 'full', 'baseline'] as const) {
+        mockSourceAuditorModule.audit.mockClear();
+        mockConsoleError.mockClear();
+        await auditCommand.execute(createDefaultOptions({ scope }));
+        expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
+        expect(mockConsoleError).not.toHaveBeenCalled();
+      }
     });
 
     it('[EARS-F2] should accept valid --output values (text, json, sarif)', async () => {
-      await auditCommand.execute(createDefaultOptions({ output: 'text' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
-
-      mockSourceAuditorModule.audit.mockClear();
-      await auditCommand.execute(createDefaultOptions({ output: 'json' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
-
-      mockSourceAuditorModule.audit.mockClear();
-      await auditCommand.execute(createDefaultOptions({ output: 'sarif' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
+      for (const output of ['text', 'json', 'sarif'] as const) {
+        mockSourceAuditorModule.audit.mockClear();
+        mockConsoleError.mockClear();
+        await auditCommand.execute(createDefaultOptions({ output }));
+        expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
+        expect(mockConsoleError).not.toHaveBeenCalled();
+      }
     });
 
     it('[EARS-F3] should accept valid --group-by values (file, severity, category)', async () => {
-      await auditCommand.execute(createDefaultOptions({ groupBy: 'file' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
-
-      mockSourceAuditorModule.audit.mockClear();
-      await auditCommand.execute(createDefaultOptions({ groupBy: 'severity' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
-
-      mockSourceAuditorModule.audit.mockClear();
-      await auditCommand.execute(createDefaultOptions({ groupBy: 'category' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
+      for (const groupBy of ['file', 'severity', 'category'] as const) {
+        mockSourceAuditorModule.audit.mockClear();
+        mockConsoleError.mockClear();
+        await auditCommand.execute(createDefaultOptions({ groupBy }));
+        expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
+        expect(mockConsoleError).not.toHaveBeenCalled();
+      }
     });
 
     it('[EARS-F4] should accept valid --fail-on values (critical, high, medium, low)', async () => {
-      await auditCommand.execute(createDefaultOptions({ failOn: 'critical' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
-
-      mockSourceAuditorModule.audit.mockClear();
-      await auditCommand.execute(createDefaultOptions({ failOn: 'high' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
-
-      mockSourceAuditorModule.audit.mockClear();
-      await auditCommand.execute(createDefaultOptions({ failOn: 'medium' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
-
-      mockSourceAuditorModule.audit.mockClear();
-      await auditCommand.execute(createDefaultOptions({ failOn: 'low' }));
-      expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
+      for (const failOn of ['critical', 'high', 'medium', 'low'] as const) {
+        mockSourceAuditorModule.audit.mockClear();
+        mockConsoleError.mockClear();
+        await auditCommand.execute(createDefaultOptions({ failOn }));
+        expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
+        expect(mockConsoleError).not.toHaveBeenCalled();
+      }
     });
 
     it('[EARS-F5] should accept valid --target values (code)', async () => {
-      // MVP only supports 'code' target
+      mockConsoleError.mockClear();
       await auditCommand.execute(createDefaultOptions({ target: 'code' }));
       expect(mockSourceAuditorModule.audit).toHaveBeenCalled();
+      expect(mockConsoleError).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/commands/audit/audit-command.test.ts
+++ b/packages/cli/src/commands/audit/audit-command.test.ts
@@ -11,22 +11,26 @@
  */
 
 // Mock @gitgov/core
-jest.doMock('@gitgov/core', () => ({
-  Config: {
-    ConfigManager: {
-      findProjectRoot: jest.fn().mockReturnValue('/mock/project/root'),
-      findGitgovRoot: jest.fn().mockReturnValue('/mock/project/root/.gitgov'),
-    }
-  },
-  SourceAuditor: {
-    SourceAuditorModule: jest.fn(),
-    WaiverReader: jest.fn(),
-    WaiverWriter: jest.fn(),
-  },
-  FindingDetector: {
-    FindingDetectorModule: jest.fn(),
-  }
-}));
+jest.doMock('@gitgov/core', () => {
+  const actual = jest.requireActual('@gitgov/core');
+  return {
+    Config: {
+      ConfigManager: {
+        findProjectRoot: jest.fn().mockReturnValue('/mock/project/root'),
+        findGitgovRoot: jest.fn().mockReturnValue('/mock/project/root/.gitgov'),
+      }
+    },
+    SourceAuditor: {
+      SourceAuditorModule: jest.fn(),
+      WaiverReader: jest.fn(),
+      WaiverWriter: jest.fn(),
+    },
+    FindingDetector: {
+      FindingDetectorModule: jest.fn(),
+    },
+    Sarif: actual.Sarif,
+  };
+});
 
 // Mock DependencyInjectionService
 jest.mock('../../services/dependency-injection', () => ({
@@ -392,7 +396,9 @@ describe('AuditCommand', () => {
 
       expect(sarifCall).toBeDefined();
       const sarif = JSON.parse(sarifCall![0]);
-      expect(sarif.$schema).toContain('sarif-schema-2.1.0');
+      expect(sarif.$schema).toBe(
+        'https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json'
+      );
       expect(sarif.runs).toHaveLength(1);
       expect(sarif.runs[0].tool.driver.name).toBe('gitgov-audit');
     });

--- a/packages/cli/src/commands/audit/audit-command.ts
+++ b/packages/cli/src/commands/audit/audit-command.ts
@@ -1,7 +1,9 @@
 import { Command, Option } from 'commander';
 import { BaseCommand } from '../../base/base-command';
 import type { BaseCommandOptions } from '../../interfaces/command';
-import type { SourceAuditor, FindingDetector, IConfigManager } from '@gitgov/core';
+import { readFile } from 'node:fs/promises';
+import type { SourceAuditor, FindingDetector, IConfigManager, Sarif } from '@gitgov/core';
+import { Sarif as SarifModule } from '@gitgov/core';
 
 // Types are imported from Core via the SourceAuditor namespace
 // Re-export for consumers of this command
@@ -175,7 +177,7 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
       }
 
       // Format and display output
-      this.formatOutput(result, options);
+      await this.formatOutput(result, options);
 
       // Calculate exit code
       const exitCode = this.calculateExitCode(result, options.failOn);
@@ -262,7 +264,7 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
    * Format and display output based on --output option
    * [EARS-C1, EARS-C2, EARS-C3, EARS-C4]
    */
-  private formatOutput(result: SourceAuditor.AuditResult, options: AuditCommandOptions): void {
+  private async formatOutput(result: SourceAuditor.AuditResult, options: AuditCommandOptions): Promise<void> {
     // [EARS-C4] Quiet mode - only show critical findings
     if (options.quiet) {
       const criticals = result.findings.filter(f => f.severity === 'critical');
@@ -281,8 +283,8 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
         this.formatJsonOutput(result);
         break;
       case 'sarif':
-        // [EARS-C3] SARIF output
-        this.formatSarifOutput(result);
+        // [EARS-C3] SARIF output — delegated to SarifBuilder from @gitgov/core
+        await this.formatSarifOutput(result);
         break;
       default:
         // [EARS-C1, C5, C6, C7] Text output with grouping and limits
@@ -453,37 +455,31 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
   }
 
   /**
-   * Format SARIF output for GitHub Code Scanning
-   * [EARS-C3]
+   * Format SARIF output using SarifBuilder from @gitgov/core
+   * [EARS-C3, SARIF-H1, SARIF-H2, SARIF-H3]
    */
-  private formatSarifOutput(result: SourceAuditor.AuditResult): void {
-    const sarif = {
-      $schema: 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
-      version: '2.1.0',
-      runs: [{
-        tool: {
-          driver: {
-            name: 'gitgov-audit',
-            version: '1.0.0',
-            informationUri: 'https://gitgovernance.com/audit',
-            rules: this.extractRules(result.findings),
-          },
-        },
-        results: result.findings.map(f => ({
-          ruleId: f.ruleId,
-          level: this.mapSeverityToSarifLevel(f.severity),
-          message: { text: f.message },
-          locations: [{
-            physicalLocation: {
-              artifactLocation: { uri: f.file },
-              region: { startLine: f.line, startColumn: f.column },
-            },
-          }],
-          fingerprints: { 'gitgov/v1': f.fingerprint },
-        })),
-      }],
+  private async formatSarifOutput(result: SourceAuditor.AuditResult): Promise<void> {
+    const builder = SarifModule.createSarifBuilder();
+
+    const getLineContent: Sarif.GetLineContentFn = async (file, line) => {
+      try {
+        const content = await readFile(file, 'utf-8');
+        const lines = content.split('\n');
+        return lines[line - 1] ?? null;
+      } catch {
+        return null;
+      }
     };
-    console.log(JSON.stringify(sarif, null, 2));
+
+    const sarifLog = await builder.build({
+      toolName: 'gitgov-audit',
+      toolVersion: '2.1.0',
+      informationUri: 'https://gitgovernance.com/audit',
+      findings: result.findings,
+      getLineContent,
+    });
+
+    console.log(JSON.stringify(sarifLog, null, 2));
   }
 
   /**
@@ -629,28 +625,4 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
     return colors[severity] ?? '\x1b[37m';
   }
 
-  private extractRules(findings: FindingDetector.Finding[]): Array<{ id: string; name: string; shortDescription: { text: string } }> {
-    const ruleMap = new Map<string, { id: string; name: string; shortDescription: { text: string } }>();
-    for (const f of findings) {
-      if (!ruleMap.has(f.ruleId)) {
-        ruleMap.set(f.ruleId, {
-          id: f.ruleId,
-          name: f.ruleId,
-          shortDescription: { text: f.message },
-        });
-      }
-    }
-    return Array.from(ruleMap.values());
-  }
-
-  private mapSeverityToSarifLevel(severity: string): string {
-    const map: Record<string, string> = {
-      critical: 'error',
-      high: 'error',
-      medium: 'warning',
-      low: 'note',
-      info: 'note',
-    };
-    return map[severity] ?? 'note';
-  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@octokit/rest": "^22.0.1",
     "ajv": "^8.17.1",
+    "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^3.0.1",
     "chokidar": "^3.6.0",
     "fast-glob": "^3.3.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,10 @@
       "types": "./dist/src/prisma.d.ts",
       "import": "./dist/src/prisma.js"
     },
+    "./sarif": {
+      "types": "./dist/src/sarif/index.d.ts",
+      "import": "./dist/src/sarif/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,6 +105,7 @@ export * as DiagramGenerator from "./diagram_generator";
 // Audit modules
 export * as FindingDetector from "./finding_detector";
 export * as SourceAuditor from "./source_auditor";
+export * as Sarif from "./sarif";
 
 // Agent runner
 export * as Runner from "./agent_runner";

--- a/packages/core/src/sarif/fixtures/sarif-schema-2.1.0.json
+++ b/packages/core/src/sarif/fixtures/sarif-schema-2.1.0.json
@@ -1,0 +1,3389 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema",
+  "id": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
+  "description": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema: a standard format for the output of static analysis tools.",
+  "additionalProperties": false,
+  "type": "object",
+  "properties": {
+
+    "$schema": {
+      "description": "The URI of the JSON schema corresponding to the version.",
+      "type": "string",
+      "format": "uri"
+    },
+
+    "version": {
+      "description": "The SARIF format version of this log file.",
+      "enum": [ "2.1.0" ],
+      "type": "string"
+    },
+
+    "runs": {
+      "description": "The set of runs contained in this log file.",
+      "type": [ "array", "null" ],
+      "minItems": 0,
+      "uniqueItems": false,
+      "items": {
+        "$ref": "#/definitions/run"
+      }
+    },
+
+    "inlineExternalProperties": {
+      "description": "References to external property files that share data between runs.",
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/externalProperties"
+      }
+    },
+
+    "properties": {
+      "description": "Key/value pairs that provide additional information about the log file.",
+      "$ref": "#/definitions/propertyBag"
+    }
+  },
+
+  "required": [ "version", "runs" ],
+
+  "definitions": {
+
+    "address": {
+      "description": "A physical or virtual address, or a range of addresses, in an 'addressable region' (memory or a binary file).",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "absoluteAddress": {
+          "description": "The address expressed as a byte offset from the start of the addressable region.",
+          "type": "integer",
+          "minimum": -1,
+          "default": -1
+
+        },
+
+        "relativeAddress": {
+          "description": "The address expressed as a byte offset from the absolute address of the top-most parent object.",
+          "type": "integer"
+
+        },
+
+        "length": {
+          "description": "The number of bytes in this range of addresses.",
+          "type": "integer"
+        },
+
+        "kind": {
+          "description": "An open-ended string that identifies the address kind. 'data', 'function', 'header','instruction', 'module', 'page', 'section', 'segment', 'stack', 'stackFrame', 'table' are well-known values.",
+          "type": "string"
+        },
+
+        "name": {
+          "description": "A name that is associated with the address, e.g., '.text'.",
+          "type": "string"
+        },
+
+        "fullyQualifiedName": {
+          "description": "A human-readable fully qualified name that is associated with the address.",
+          "type": "string"
+        },
+
+        "offsetFromParent": {
+          "description": "The byte offset of this address from the absolute or relative address of the parent object.",
+          "type": "integer"
+        },
+
+        "index": {
+          "description": "The index within run.addresses of the cached object for this address.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "parentIndex": {
+          "description": "The index within run.addresses of the parent object.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the address.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "artifact": {
+      "description": "A single artifact. In some cases, this artifact might be nested within another artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "description": {
+          "description": "A short description of the artifact.",
+          "$ref": "#/definitions/message"
+        },
+
+        "location": {
+          "description": "The location of the artifact.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "parentIndex": {
+          "description": "Identifies the index of the immediate parent of the artifact, if this artifact is nested.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "offset": {
+          "description": "The offset in bytes of the artifact within its containing artifact.",
+          "type": "integer",
+          "minimum": 0
+        },
+
+        "length": {
+          "description": "The length of the artifact in bytes.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "roles": {
+          "description": "The role or roles played by the artifact in the analysis.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "enum": [
+              "analysisTarget",
+              "attachment",
+              "responseFile",
+              "resultFile",
+              "standardStream",
+              "tracedFile",
+              "unmodified",
+              "modified",
+              "added",
+              "deleted",
+              "renamed",
+              "uncontrolled",
+              "driver",
+              "extension",
+              "translation",
+              "taxonomy",
+              "policy",
+              "referencedOnCommandLine",
+              "memoryContents",
+              "directory",
+              "userSpecifiedConfiguration",
+              "toolSpecifiedConfiguration",
+              "debugOutputFile"
+            ],
+            "type": "string"
+          }
+        },
+
+        "mimeType": {
+          "description": "The MIME type (RFC 2045) of the artifact.",
+          "type": "string",
+          "pattern": "[^/]+/.+"
+        },
+
+        "contents": {
+          "description": "The contents of the artifact.",
+          "$ref": "#/definitions/artifactContent"
+        },
+
+        "encoding": {
+          "description": "Specifies the encoding for an artifact object that refers to a text file.",
+          "type": "string"
+        },
+
+        "sourceLanguage": {
+          "description": "Specifies the source language for any artifact object that refers to a text file that contains source code.",
+          "type": "string"
+        },
+
+        "hashes": {
+          "description": "A dictionary, each of whose keys is the name of a hash function and each of whose values is the hashed value of the artifact produced by the specified hash function.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "lastModifiedTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the artifact was most recently modified. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the artifact.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "artifactChange": {
+      "description": "A change to a single artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "artifactLocation": {
+          "description": "The location of the artifact to change.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "replacements": {
+          "description": "An array of replacement objects, each of which represents the replacement of a single region in a single artifact specified by 'artifactLocation'.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/replacement"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the change.",
+          "$ref": "#/definitions/propertyBag"
+        }
+
+      },
+
+      "required": [ "artifactLocation", "replacements" ]
+    },
+
+    "artifactContent": {
+      "description": "Represents the contents of an artifact.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "text": {
+          "description": "UTF-8-encoded content from a text artifact.",
+          "type": "string"
+        },
+
+        "binary": {
+          "description": "MIME Base64-encoded content from a binary artifact, or from a text artifact in its original encoding.",
+          "type": "string"
+        },
+
+        "rendered": {
+          "description": "An alternate rendered representation of the artifact (e.g., a decompiled representation of a binary region).",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the artifact content.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "artifactLocation": {
+      "description": "Specifies the location of an artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "uri": {
+          "description": "A string containing a valid relative or absolute URI.",
+          "type": "string",
+          "format": "uri-reference"
+        },
+
+        "uriBaseId": {
+          "description": "A string which indirectly specifies the absolute URI with respect to which a relative URI in the \"uri\" property is interpreted.",
+          "type": "string"
+        },
+
+        "index": {
+          "description": "The index within the run artifacts array of the artifact object associated with the artifact location.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "description": {
+          "description": "A short description of the artifact location.",
+          "$ref": "#/definitions/message"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the artifact location.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "attachment": {
+      "description": "An artifact relevant to a result.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "description": {
+          "description": "A message describing the role played by the attachment.",
+          "$ref": "#/definitions/message"
+        },
+
+        "artifactLocation": {
+          "description": "The location of the attachment.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "regions": {
+          "description": "An array of regions of interest within the attachment.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/region"
+          }
+        },
+
+        "rectangles": {
+          "description": "An array of rectangles specifying areas of interest within the image.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/rectangle"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the attachment.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "artifactLocation" ]
+    },
+
+    "codeFlow": {
+      "description": "A set of threadFlows which together describe a pattern of code execution relevant to detecting a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "message": {
+          "description": "A message relevant to the code flow.",
+          "$ref": "#/definitions/message"
+        },
+
+        "threadFlows": {
+          "description": "An array of one or more unique threadFlow objects, each of which describes the progress of a program through a thread of execution.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/threadFlow"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the code flow.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "threadFlows" ]
+    },
+
+    "configurationOverride": {
+      "description": "Information about how a specific rule or notification was reconfigured at runtime.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "configuration": {
+          "description": "Specifies how the rule or notification was configured during the scan.",
+          "$ref": "#/definitions/reportingConfiguration"
+        },
+
+        "descriptor": {
+          "description": "A reference used to locate the descriptor whose configuration was overridden.",
+          "$ref": "#/definitions/reportingDescriptorReference"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the configuration override.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "configuration", "descriptor" ]
+    },
+
+    "conversion": {
+      "description": "Describes how a converter transformed the output of a static analysis tool from the analysis tool's native output format into the SARIF format.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "tool": {
+          "description": "A tool object that describes the converter.",
+          "$ref": "#/definitions/tool"
+        },
+
+        "invocation": {
+          "description": "An invocation object that describes the invocation of the converter.",
+          "$ref": "#/definitions/invocation"
+        },
+
+        "analysisToolLogFiles": {
+          "description": "The locations of the analysis tool's per-run log files.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the conversion.",
+          "$ref": "#/definitions/propertyBag"
+        }
+
+      },
+
+      "required": [ "tool" ]
+    },
+
+    "edge": {
+      "description": "Represents a directed edge in a graph.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "id": {
+          "description": "A string that uniquely identifies the edge within its graph.",
+          "type": "string"
+        },
+
+        "label": {
+          "description": "A short description of the edge.",
+          "$ref": "#/definitions/message"
+        },
+
+        "sourceNodeId": {
+          "description": "Identifies the source node (the node at which the edge starts).",
+          "type": "string"
+        },
+
+        "targetNodeId": {
+          "description": "Identifies the target node (the node at which the edge ends).",
+          "type": "string"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the edge.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "id", "sourceNodeId", "targetNodeId" ]
+    },
+
+    "edgeTraversal": {
+      "description": "Represents the traversal of a single edge during a graph traversal.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "edgeId": {
+          "description": "Identifies the edge being traversed.",
+          "type": "string"
+        },
+
+        "message": {
+          "description": "A message to display to the user as the edge is traversed.",
+          "$ref": "#/definitions/message"
+        },
+
+        "finalState": {
+          "description": "The values of relevant expressions after the edge has been traversed.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "stepOverEdgeCount": {
+          "description": "The number of edge traversals necessary to return from a nested graph.",
+          "type": "integer",
+          "minimum": 0
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the edge traversal.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "edgeId" ]
+    },
+
+    "exception": {
+      "description": "Describes a runtime exception encountered during the execution of an analysis tool.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "kind": {
+          "type": "string",
+          "description": "A string that identifies the kind of exception, for example, the fully qualified type name of an object that was thrown, or the symbolic name of a signal."
+        },
+
+        "message": {
+          "description": "A message that describes the exception.",
+          "type": "string"
+        },
+
+        "stack": {
+          "description": "The sequence of function calls leading to the exception.",
+          "$ref": "#/definitions/stack"
+        },
+
+        "innerExceptions": {
+          "description": "An array of exception objects each of which is considered a cause of this exception.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/exception"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the exception.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "externalProperties": {
+      "description": "The top-level element of an external property file.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "schema": {
+          "description": "The URI of the JSON schema corresponding to the version of the external property file format.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "version": {
+          "description": "The SARIF format version of this external properties object.",
+          "enum": [ "2.1.0" ],
+          "type": "string"
+        },
+
+        "guid": {
+          "description": "A stable, unique identifier for this external properties object, in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "runGuid": {
+          "description": "A stable, unique identifier for the run associated with this external properties object, in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "conversion": {
+          "description": "A conversion object that will be merged with a separate run.",
+          "$ref": "#/definitions/conversion"
+        },
+
+        "graphs": {
+          "description": "An array of graph objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        },
+
+        "externalizedProperties": {
+          "description": "Key/value pairs that provide additional information that will be merged with a separate run.",
+          "$ref": "#/definitions/propertyBag"
+        },
+
+        "artifacts": {
+          "description": "An array of artifact objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifact"
+          }
+        },
+
+        "invocations": {
+          "description": "Describes the invocation of the analysis tool that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/invocation"
+          }
+        },
+
+        "logicalLocations": {
+          "description": "An array of logical locations such as namespaces, types or functions that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          }
+        },
+
+        "threadFlowLocations": {
+          "description": "An array of threadFlowLocation objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+
+        "results": {
+          "description": "An array of result objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/result"
+          }
+        },
+
+        "taxonomies": {
+          "description": "Tool taxonomies that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "driver": {
+          "description": "The analysis tool object that will be merged with a separate run.",
+          "$ref": "#/definitions/toolComponent"
+        },
+
+        "extensions": {
+          "description": "Tool extensions that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "policies": {
+          "description": "Tool policies that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "translations": {
+          "description": "Tool translations that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "addresses": {
+          "description": "Addresses that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/address"
+          }
+        },
+
+        "webRequests": {
+          "description": "Requests that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webRequest"
+          }
+        },
+
+        "webResponses": {
+          "description": "Responses that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webResponse"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the external properties.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "externalPropertyFileReference": {
+      "description": "Contains information that enables a SARIF consumer to locate the external property file that contains the value of an externalized property associated with the run.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "location": {
+          "description": "The location of the external property file.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "guid": {
+          "description": "A stable, unique identifier for the external property file in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "itemCount": {
+          "description": "A non-negative integer specifying the number of items contained in the external property file.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the external property file.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "anyOf": [
+        { "required": [ "location" ] },
+        { "required": [ "guid" ] }
+      ]
+    },
+
+    "externalPropertyFileReferences": {
+      "description": "References to external property files that should be inlined with the content of a root log file.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "conversion": {
+          "description": "An external property file containing a run.conversion object to be merged with the root log file.",
+          "$ref": "#/definitions/externalPropertyFileReference"
+        },
+
+        "graphs": {
+          "description": "An array of external property files containing a run.graphs object to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "externalizedProperties": {
+          "description": "An external property file containing a run.properties object to be merged with the root log file.",
+          "$ref": "#/definitions/externalPropertyFileReference"
+        },
+
+        "artifacts": {
+          "description": "An array of external property files containing run.artifacts arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "invocations": {
+          "description": "An array of external property files containing run.invocations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "logicalLocations": {
+          "description": "An array of external property files containing run.logicalLocations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "threadFlowLocations": {
+          "description": "An array of external property files containing run.threadFlowLocations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "results": {
+          "description": "An array of external property files containing run.results arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "taxonomies": {
+          "description": "An array of external property files containing run.taxonomies arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "addresses": {
+          "description": "An array of external property files containing run.addresses arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "driver": {
+          "description": "An external property file containing a run.driver object to be merged with the root log file.",
+          "$ref": "#/definitions/externalPropertyFileReference"
+        },
+
+        "extensions": {
+          "description": "An array of external property files containing run.extensions arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "policies": {
+          "description": "An array of external property files containing run.policies arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "translations": {
+          "description": "An array of external property files containing run.translations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "webRequests": {
+          "description": "An array of external property files containing run.requests arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "webResponses": {
+          "description": "An array of external property files containing run.responses arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the external property files.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "fix": {
+      "description": "A proposed fix for the problem represented by a result object. A fix specifies a set of artifacts to modify. For each artifact, it specifies a set of bytes to remove, and provides a set of new bytes to replace them.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "description": {
+          "description": "A message that describes the proposed fix, enabling viewers to present the proposed change to an end user.",
+          "$ref": "#/definitions/message"
+        },
+
+        "artifactChanges": {
+          "description": "One or more artifact changes that comprise a fix for a result.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifactChange"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the fix.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "artifactChanges" ]
+    },
+
+    "graph": {
+      "description": "A network of nodes and directed edges that describes some aspect of the structure of the code (for example, a call graph).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "description": {
+          "description": "A description of the graph.",
+          "$ref": "#/definitions/message"
+        },
+
+        "nodes": {
+          "description": "An array of node objects representing the nodes of the graph.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/node"
+          }
+        },
+
+        "edges": {
+          "description": "An array of edge objects representing the edges of the graph.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/edge"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the graph.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "graphTraversal": {
+      "description": "Represents a path through a graph.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "runGraphIndex": {
+          "description": "The index within the run.graphs to be associated with the result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "resultGraphIndex": {
+          "description": "The index within the result.graphs to be associated with the result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "description": {
+          "description": "A description of this graph traversal.",
+          "$ref": "#/definitions/message"
+        },
+
+        "initialState": {
+          "description": "Values of relevant expressions at the start of the graph traversal that may change during graph traversal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "immutableState": {
+          "description": "Values of relevant expressions at the start of the graph traversal that remain constant for the graph traversal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "edgeTraversals": {
+          "description": "The sequences of edges traversed by this graph traversal.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/edgeTraversal"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the graph traversal.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "oneOf": [
+        { "required": [ "runGraphIndex" ] },
+        { "required": [ "resultGraphIndex" ] }
+      ]
+    },
+
+    "invocation": {
+      "description": "The runtime environment of the analysis tool run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "commandLine": {
+          "description": "The command line used to invoke the tool.",
+          "type": "string"
+        },
+
+        "arguments": {
+          "description": "An array of strings, containing in order the command line arguments passed to the tool from the operating system.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "responseFiles": {
+          "description": "The locations of any response files specified on the tool's command line.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+
+        "startTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the invocation started. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "endTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the invocation ended. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "exitCode": {
+          "description": "The process exit code.",
+          "type": "integer"
+        },
+
+        "ruleConfigurationOverrides": {
+          "description": "An array of configurationOverride objects that describe rules related runtime overrides.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/configurationOverride"
+          }
+        },
+
+        "notificationConfigurationOverrides": {
+          "description": "An array of configurationOverride objects that describe notifications related runtime overrides.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/configurationOverride"
+          }
+        },
+
+        "toolExecutionNotifications": {
+          "description": "A list of runtime conditions detected by the tool during the analysis.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/notification"
+          }
+        },
+
+        "toolConfigurationNotifications": {
+          "description": "A list of conditions detected by the tool that are relevant to the tool's configuration.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/notification"
+          }
+        },
+
+        "exitCodeDescription": {
+          "description": "The reason for the process exit.",
+          "type": "string"
+        },
+
+        "exitSignalName": {
+          "description": "The name of the signal that caused the process to exit.",
+          "type": "string"
+        },
+
+        "exitSignalNumber": {
+          "description": "The numeric value of the signal that caused the process to exit.",
+          "type": "integer"
+        },
+
+        "processStartFailureMessage": {
+          "description": "The reason given by the operating system that the process failed to start.",
+          "type": "string"
+        },
+
+        "executionSuccessful": {
+          "description": "Specifies whether the tool's execution completed successfully.",
+          "type": "boolean"
+        },
+
+        "machine": {
+          "description": "The machine on which the invocation occurred.",
+          "type": "string"
+        },
+
+        "account": {
+          "description": "The account under which the invocation occurred.",
+          "type": "string"
+        },
+
+        "processId": {
+          "description": "The id of the process in which the invocation occurred.",
+          "type": "integer"
+        },
+
+        "executableLocation": {
+          "description": "An absolute URI specifying the location of the executable that was invoked.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "workingDirectory": {
+          "description": "The working directory for the invocation.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "environmentVariables": {
+          "description": "The environment variables associated with the analysis tool process, expressed as key/value pairs.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "stdin": {
+          "description": "A file containing the standard input stream to the process that was invoked.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "stdout": {
+          "description": "A file containing the standard output stream from the process that was invoked.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "stderr": {
+          "description": "A file containing the standard error stream from the process that was invoked.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "stdoutStderr": {
+          "description": "A file containing the interleaved standard output and standard error stream from the process that was invoked.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the invocation.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "executionSuccessful" ]
+    },
+
+    "location": {
+      "description": "A location within a programming artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "id": {
+          "description": "Value that distinguishes this location from all other locations within a single result object.",
+          "type": "integer",
+          "minimum": -1,
+          "default": -1
+        },
+
+        "physicalLocation": {
+          "description": "Identifies the artifact and region.",
+          "$ref": "#/definitions/physicalLocation"
+        },
+
+        "logicalLocations": {
+          "description": "The logical locations associated with the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          }
+        },
+
+        "message": {
+          "description": "A message relevant to the location.",
+          "$ref": "#/definitions/message"
+        },
+
+        "annotations": {
+          "description": "A set of regions relevant to the location.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/region"
+          }
+        },
+
+        "relationships": {
+          "description": "An array of objects that describe relationships between this location and others.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/locationRelationship"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the location.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "locationRelationship": {
+      "description": "Information about the relation of one location to another.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "target": {
+          "description": "A reference to the related location.",
+          "type": "integer",
+          "minimum": 0
+        },
+
+        "kinds": {
+          "description": "A set of distinct strings that categorize the relationship. Well-known kinds include 'includes', 'isIncludedBy' and 'relevant'.",
+          "type": "array",
+          "default": [ "relevant" ],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "description": {
+          "description": "A description of the location relationship.",
+          "$ref": "#/definitions/message"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the location relationship.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "target" ]
+    },
+
+    "logicalLocation": {
+      "description": "A logical location of a construct that produced a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "name": {
+          "description": "Identifies the construct in which the result occurred. For example, this property might contain the name of a class or a method.",
+          "type": "string"
+        },
+
+        "index": {
+          "description": "The index within the logical locations array.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "fullyQualifiedName": {
+          "description": "The human-readable fully qualified name of the logical location.",
+          "type": "string"
+        },
+
+        "decoratedName": {
+          "description": "The machine-readable name for the logical location, such as a mangled function name provided by a C++ compiler that encodes calling convention, return type and other details along with the function name.",
+          "type": "string"
+        },
+
+        "parentIndex": {
+          "description": "Identifies the index of the immediate parent of the construct in which the result was detected. For example, this property might point to a logical location that represents the namespace that holds a type.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "kind": {
+          "description": "The type of construct this logical location component refers to. Should be one of 'function', 'member', 'module', 'namespace', 'parameter', 'resource', 'returnType', 'type', 'variable', 'object', 'array', 'property', 'value', 'element', 'text', 'attribute', 'comment', 'declaration', 'dtd' or 'processingInstruction', if any of those accurately describe the construct.",
+          "type": "string"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the logical location.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "message": {
+      "description": "Encapsulates a message intended to be read by the end user.",
+      "type": "object",
+      "additionalProperties": false,
+
+      "properties": {
+
+        "text": {
+          "description": "A plain text message string.",
+          "type": "string"
+        },
+
+        "markdown": {
+          "description": "A Markdown message string.",
+          "type": "string"
+        },
+
+        "id": {
+          "description": "The identifier for this message.",
+          "type": "string"
+        },
+
+        "arguments": {
+          "description": "An array of strings to substitute into the message string.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the message.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "anyOf": [
+        { "required": [ "text" ] },
+        { "required": [ "id" ] }
+      ]
+    },
+
+    "multiformatMessageString": {
+      "description": "A message string or message format string rendered in multiple formats.",
+      "type": "object",
+      "additionalProperties": false,
+
+      "properties": {
+
+        "text": {
+          "description": "A plain text message string or format string.",
+          "type": "string"
+        },
+
+        "markdown": {
+          "description": "A Markdown message string or format string.",
+          "type": "string"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the message.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "text" ]
+    },
+
+    "node": {
+      "description": "Represents a node in a graph.",
+      "type": "object",
+      "additionalProperties": false,
+
+      "properties": {
+
+        "id": {
+          "description": "A string that uniquely identifies the node within its graph.",
+          "type": "string"
+        },
+
+        "label": {
+          "description": "A short description of the node.",
+          "$ref": "#/definitions/message"
+        },
+
+        "location": {
+          "description": "A code location associated with the node.",
+          "$ref": "#/definitions/location"
+        },
+
+        "children": {
+          "description": "Array of child nodes.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/node"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the node.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "id" ]
+    },
+
+    "notification": {
+      "description": "Describes a condition relevant to the tool itself, as opposed to being relevant to a target being analyzed by the tool.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "locations": {
+          "description": "The locations relevant to this notification.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/location"
+          }
+        },
+
+        "message": {
+          "description": "A message that describes the condition that was encountered.",
+          "$ref": "#/definitions/message"
+        },
+
+        "level": {
+          "description": "A value specifying the severity level of the notification.",
+          "default": "warning",
+          "enum": [ "none", "note", "warning", "error" ],
+          "type": "string"
+        },
+
+        "threadId": {
+          "description": "The thread identifier of the code that generated the notification.",
+          "type": "integer"
+        },
+
+        "timeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the analysis tool generated the notification.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "exception": {
+          "description": "The runtime exception, if any, relevant to this notification.",
+          "$ref": "#/definitions/exception"
+        },
+
+        "descriptor": {
+          "description": "A reference used to locate the descriptor relevant to this notification.",
+          "$ref": "#/definitions/reportingDescriptorReference"
+        },
+
+        "associatedRule": {
+          "description": "A reference used to locate the rule descriptor associated with this notification.",
+          "$ref": "#/definitions/reportingDescriptorReference"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the notification.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "message" ]
+    },
+
+    "physicalLocation": {
+      "description": "A physical location relevant to a result. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "address": {
+          "description": "The address of the location.",
+          "$ref": "#/definitions/address"
+        },
+
+        "artifactLocation": {
+          "description": "The location of the artifact.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "region": {
+          "description": "Specifies a portion of the artifact.",
+          "$ref": "#/definitions/region"
+        },
+
+        "contextRegion": {
+          "description": "Specifies a portion of the artifact that encloses the region. Allows a viewer to display additional context around the region.",
+          "$ref": "#/definitions/region"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the physical location.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "anyOf": [
+        {
+          "required": [ "address" ]
+        },
+        {
+          "required": [ "artifactLocation" ]
+        }
+      ]
+    },
+
+    "propertyBag": {
+      "description": "Key/value pairs that provide additional information about the object.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "tags": {
+
+          "description": "A set of distinct strings that provide additional information.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+
+    "rectangle": {
+      "description": "An area within an image.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "top": {
+          "description": "The Y coordinate of the top edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+
+        "left": {
+          "description": "The X coordinate of the left edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+
+        "bottom": {
+          "description": "The Y coordinate of the bottom edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+
+        "right": {
+          "description": "The X coordinate of the right edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+
+        "message": {
+          "description": "A message relevant to the rectangle.",
+          "$ref": "#/definitions/message"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the rectangle.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "region": {
+      "description": "A region within an artifact where a result was detected.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "startLine": {
+          "description": "The line number of the first character in the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+
+        "startColumn": {
+          "description": "The column number of the first character in the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+
+        "endLine": {
+          "description": "The line number of the last character in the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+
+        "endColumn": {
+          "description": "The column number of the character following the end of the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+
+        "charOffset": {
+          "description": "The zero-based offset from the beginning of the artifact of the first character in the region.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "charLength": {
+          "description": "The length of the region in characters.",
+          "type": "integer",
+          "minimum": 0
+        },
+
+        "byteOffset": {
+          "description": "The zero-based offset from the beginning of the artifact of the first byte in the region.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "byteLength": {
+          "description": "The length of the region in bytes.",
+          "type": "integer",
+          "minimum": 0
+        },
+
+        "snippet": {
+          "description": "The portion of the artifact contents within the specified region.",
+          "$ref": "#/definitions/artifactContent"
+        },
+
+        "message": {
+          "description": "A message relevant to the region.",
+          "$ref": "#/definitions/message"
+        },
+
+        "sourceLanguage": {
+          "description": "Specifies the source language, if any, of the portion of the artifact specified by the region object.",
+          "type": "string"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the region.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "anyOf": [
+        { "required": [ "startLine" ] },
+        { "required": [ "charOffset" ] },
+        { "required": [ "byteOffset" ] }
+      ]
+    },
+
+    "replacement": {
+      "description": "The replacement of a single region of an artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "deletedRegion": {
+          "description": "The region of the artifact to delete.",
+          "$ref": "#/definitions/region"
+        },
+
+        "insertedContent": {
+          "description": "The content to insert at the location specified by the 'deletedRegion' property.",
+          "$ref": "#/definitions/artifactContent"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the replacement.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "deletedRegion" ]
+    },
+
+    "reportingDescriptor": {
+      "description": "Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "id": {
+          "description": "A stable, opaque identifier for the report.",
+          "type": "string"
+        },
+
+        "deprecatedIds": {
+          "description": "An array of stable, opaque identifiers by which this report was known in some previous version of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "guid": {
+          "description": "A unique identifier for the reporting descriptor in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "deprecatedGuids": {
+          "description": "An array of unique identifies in the form of a GUID by which this report was known in some previous version of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+          }
+        },
+
+        "name": {
+          "description": "A report identifier that is understandable to an end user.",
+          "type": "string"
+        },
+
+        "deprecatedNames": {
+          "description": "An array of readable identifiers by which this report was known in some previous version of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "shortDescription": {
+          "description": "A concise description of the report. Should be a single sentence that is understandable when visible space is limited to a single line of text.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "fullDescription": {
+          "description": "A description of the report. Should, as far as possible, provide details sufficient to enable resolution of any problem indicated by the result.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "messageStrings": {
+          "description": "A set of name/value pairs with arbitrary names. Each value is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "defaultConfiguration": {
+          "description": "Default reporting configuration information.",
+          "$ref": "#/definitions/reportingConfiguration"
+        },
+
+        "helpUri": {
+          "description": "A URI where the primary documentation for the report can be found.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "help": {
+          "description": "Provides the primary documentation for the report, useful when there is no online documentation.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "relationships": {
+          "description": "An array of objects that describe relationships between this reporting descriptor and others.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorRelationship"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the report.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "id" ]
+    },
+
+    "reportingConfiguration": {
+      "description": "Information about a rule or notification that can be configured at runtime.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "enabled": {
+          "description": "Specifies whether the report may be produced during the scan.",
+          "type": "boolean",
+          "default": true
+        },
+
+        "level": {
+          "description": "Specifies the failure level for the report.",
+          "default": "warning",
+          "enum": [ "none", "note", "warning", "error" ],
+          "type": "string"
+        },
+
+        "rank": {
+          "description": "Specifies the relative priority of the report. Used for analysis output only.",
+          "type": "number",
+          "default": -1.0,
+          "minimum": -1.0,
+          "maximum": 100.0
+        },
+
+        "parameters": {
+          "description": "Contains configuration information specific to a report.",
+          "$ref": "#/definitions/propertyBag"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the reporting configuration.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "reportingDescriptorReference": {
+      "description": "Information about how to locate a relevant reporting descriptor.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "id": {
+          "description": "The id of the descriptor.",
+          "type": "string"
+        },
+
+        "index": {
+          "description": "The index into an array of descriptors in toolComponent.ruleDescriptors, toolComponent.notificationDescriptors, or toolComponent.taxonomyDescriptors, depending on context.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "guid": {
+          "description": "A guid that uniquely identifies the descriptor.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "toolComponent": {
+          "description": "A reference used to locate the toolComponent associated with the descriptor.",
+          "$ref": "#/definitions/toolComponentReference"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the reporting descriptor reference.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "anyOf": [
+        { "required": [ "index" ] },
+        { "required": [ "guid" ] },
+        { "required": [ "id" ] }
+      ]
+    },
+
+    "reportingDescriptorRelationship": {
+      "description": "Information about the relation of one reporting descriptor to another.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "target": {
+          "description": "A reference to the related reporting descriptor.",
+          "$ref": "#/definitions/reportingDescriptorReference"
+        },
+
+        "kinds": {
+          "description": "A set of distinct strings that categorize the relationship. Well-known kinds include 'canPrecede', 'canFollow', 'willPrecede', 'willFollow', 'superset', 'subset', 'equal', 'disjoint', 'relevant', and 'incomparable'.",
+          "type": "array",
+          "default": [ "relevant" ],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "description": {
+          "description": "A description of the reporting descriptor relationship.",
+          "$ref": "#/definitions/message"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the reporting descriptor reference.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "target" ]
+    },
+
+    "result": {
+      "description": "A result produced by an analysis tool.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "ruleId": {
+          "description": "The stable, unique identifier of the rule, if any, to which this result is relevant.",
+          "type": "string"
+        },
+
+        "ruleIndex": {
+          "description": "The index within the tool component rules array of the rule object associated with this result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "rule": {
+          "description": "A reference used to locate the rule descriptor relevant to this result.",
+          "$ref": "#/definitions/reportingDescriptorReference"
+        },
+
+        "kind": {
+          "description": "A value that categorizes results by evaluation state.",
+          "default": "fail",
+          "enum": [ "notApplicable", "pass", "fail", "review", "open", "informational" ],
+          "type": "string"
+        },
+
+        "level": {
+          "description": "A value specifying the severity level of the result.",
+          "default": "warning",
+          "enum": [ "none", "note", "warning", "error" ],
+          "type": "string"
+        },
+
+        "message": {
+          "description": "A message that describes the result. The first sentence of the message only will be displayed when visible space is limited.",
+          "$ref": "#/definitions/message"
+        },
+
+        "analysisTarget": {
+          "description": "Identifies the artifact that the analysis tool was instructed to scan. This need not be the same as the artifact where the result actually occurred.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "locations": {
+          "description": "The set of locations where the result was detected. Specify only one location unless the problem indicated by the result can only be corrected by making a change at every specified location.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/location"
+          }
+        },
+
+        "guid": {
+          "description": "A stable, unique identifier for the result in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "correlationGuid": {
+          "description": "A stable, unique identifier for the equivalence class of logically identical results to which this result belongs, in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "occurrenceCount": {
+          "description": "A positive integer specifying the number of times this logically unique result was observed in this run.",
+          "type": "integer",
+          "minimum": 1
+        },
+
+        "partialFingerprints": {
+          "description": "A set of strings that contribute to the stable, unique identity of the result.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "fingerprints": {
+          "description": "A set of strings each of which individually defines a stable, unique identity for the result.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "stacks": {
+          "description": "An array of 'stack' objects relevant to the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/stack"
+          }
+        },
+
+        "codeFlows": {
+          "description": "An array of 'codeFlow' objects relevant to the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/codeFlow"
+          }
+        },
+
+        "graphs": {
+          "description": "An array of zero or more unique graph objects associated with the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        },
+
+        "graphTraversals": {
+          "description": "An array of one or more unique 'graphTraversal' objects.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/graphTraversal"
+          }
+        },
+
+        "relatedLocations": {
+          "description": "A set of locations relevant to this result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/location"
+          }
+        },
+
+        "suppressions": {
+          "description": "A set of suppressions relevant to this result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/suppression"
+          }
+        },
+
+        "baselineState": {
+          "description": "The state of a result relative to a baseline of a previous run.",
+          "enum": [
+            "new",
+            "unchanged",
+            "updated",
+            "absent"
+          ],
+          "type": "string"
+        },
+
+        "rank": {
+          "description": "A number representing the priority or importance of the result.",
+          "type": "number",
+          "default": -1.0,
+          "minimum": -1.0,
+          "maximum": 100.0
+        },
+
+        "attachments": {
+          "description": "A set of artifacts relevant to the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/attachment"
+          }
+        },
+
+        "hostedViewerUri": {
+          "description": "An absolute URI at which the result can be viewed.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "workItemUris": {
+          "description": "The URIs of the work items associated with this result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+
+        "provenance": {
+          "description": "Information about how and when the result was detected.",
+          "$ref": "#/definitions/resultProvenance"
+        },
+
+        "fixes": {
+          "description": "An array of 'fix' objects, each of which represents a proposed fix to the problem indicated by the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/fix"
+          }
+        },
+
+        "taxa": {
+          "description": "An array of references to taxonomy reporting descriptors that are applicable to the result.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorReference"
+          }
+        },
+
+        "webRequest": {
+          "description": "A web request associated with this result.",
+          "$ref": "#/definitions/webRequest"
+        },
+
+        "webResponse": {
+          "description": "A web response associated with this result.",
+          "$ref": "#/definitions/webResponse"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the result.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "message" ]
+    },
+
+    "resultProvenance": {
+      "description": "Contains information about how and when a result was detected.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "firstDetectionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the result was first detected. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "lastDetectionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the result was most recently detected. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "firstDetectionRunGuid": {
+          "description": "A GUID-valued string equal to the automationDetails.guid property of the run in which the result was first detected.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "lastDetectionRunGuid": {
+          "description": "A GUID-valued string equal to the automationDetails.guid property of the run in which the result was most recently detected.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "invocationIndex": {
+          "description": "The index within the run.invocations array of the invocation object which describes the tool invocation that detected the result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "conversionSources": {
+          "description": "An array of physicalLocation objects which specify the portions of an analysis tool's output that a converter transformed into the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/physicalLocation"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the result.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "run": {
+      "description": "Describes a single run of an analysis tool, and contains the reported output of that run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "tool": {
+          "description": "Information about the tool or tool pipeline that generated the results in this run. A run can only contain results produced by a single tool or tool pipeline. A run can aggregate results from multiple log files, as long as context around the tool run (tool command-line arguments and the like) is identical for all aggregated files.",
+          "$ref": "#/definitions/tool"
+        },
+
+        "invocations": {
+          "description": "Describes the invocation of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/invocation"
+          }
+        },
+
+        "conversion": {
+          "description": "A conversion object that describes how a converter transformed an analysis tool's native reporting format into the SARIF format.",
+          "$ref": "#/definitions/conversion"
+        },
+
+        "language": {
+          "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
+          "type": "string",
+          "default": "en-US",
+          "pattern": "^[a-zA-Z]{2}(-[a-zA-Z]{2})?$"
+        },
+
+        "versionControlProvenance": {
+          "description": "Specifies the revision in version control of the artifacts that were scanned.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/versionControlDetails"
+          }
+        },
+
+        "originalUriBaseIds": {
+          "description": "The artifact location specified by each uriBaseId symbol on the machine where the tool originally ran.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+
+        "artifacts": {
+          "description": "An array of artifact objects relevant to the run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifact"
+          }
+        },
+
+        "logicalLocations": {
+          "description": "An array of logical locations such as namespaces, types or functions.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          }
+        },
+
+        "graphs": {
+          "description": "An array of zero or more unique graph objects associated with the run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        },
+
+        "results": {
+          "description": "The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting rules metadata. It must be present (but may be empty) if a log file represents an actual scan.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/result"
+          }
+        },
+
+        "automationDetails": {
+          "description": "Automation details that describe this run.",
+          "$ref": "#/definitions/runAutomationDetails"
+        },
+
+        "runAggregates": {
+          "description": "Automation details that describe the aggregate of runs to which this run belongs.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/runAutomationDetails"
+          }
+        },
+
+        "baselineGuid": {
+          "description": "The 'guid' property of a previous SARIF 'run' that comprises the baseline that was used to compute result 'baselineState' properties for the run.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "redactionTokens": {
+          "description": "An array of strings used to replace sensitive information in a redaction-aware property.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "defaultEncoding": {
+          "description": "Specifies the default encoding for any artifact object that refers to a text file.",
+          "type": "string"
+        },
+
+        "defaultSourceLanguage": {
+          "description": "Specifies the default source language for any artifact object that refers to a text file that contains source code.",
+          "type": "string"
+        },
+
+        "newlineSequences": {
+          "description": "An ordered list of character sequences that were treated as line breaks when computing region information for the run.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "default": [ "\r\n", "\n" ],
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "columnKind": {
+          "description": "Specifies the unit in which the tool measures columns.",
+          "enum": [ "utf16CodeUnits", "unicodeCodePoints" ],
+          "type": "string"
+        },
+
+        "externalPropertyFileReferences": {
+          "description": "References to external property files that should be inlined with the content of a root log file.",
+          "$ref": "#/definitions/externalPropertyFileReferences"
+        },
+
+        "threadFlowLocations": {
+          "description": "An array of threadFlowLocation objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+
+        "taxonomies": {
+          "description": "An array of toolComponent objects relevant to a taxonomy in which results are categorized.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "addresses": {
+          "description": "Addresses associated with this run instance, if any.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/address"
+          }
+        },
+
+        "translations": {
+          "description": "The set of available translations of the localized data provided by the tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "policies": {
+          "description": "Contains configurations that may potentially override both reportingDescriptor.defaultConfiguration (the tool's default severities) and invocation.configurationOverrides (severities established at run-time from the command line).",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "webRequests": {
+          "description": "An array of request objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webRequest"
+          }
+        },
+
+        "webResponses": {
+          "description": "An array of response objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webResponse"
+          }
+        },
+
+        "specialLocations": {
+          "description": "A specialLocations object that defines locations of special significance to SARIF consumers.",
+          "$ref": "#/definitions/specialLocations"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the run.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "tool" ]
+    },
+
+    "runAutomationDetails": {
+      "description": "Information that describes a run's identity and role within an engineering system process.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "description": {
+          "description": "A description of the identity and role played within the engineering system by this object's containing run object.",
+          "$ref": "#/definitions/message"
+        },
+
+        "id": {
+          "description": "A hierarchical string that uniquely identifies this object's containing run object.",
+          "type": "string"
+        },
+
+        "guid": {
+          "description": "A stable, unique identifier for this object's containing run object in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "correlationGuid": {
+          "description": "A stable, unique identifier for the equivalence class of runs to which this object's containing run object belongs in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the run automation details.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "specialLocations": {
+      "description": "Defines locations of special significance to SARIF consumers.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "displayBase": {
+          "description": "Provides a suggestion to SARIF consumers to display file paths relative to the specified location.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the special locations.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "stack": {
+      "description": "A call stack that is relevant to a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "message": {
+          "description": "A message relevant to this call stack.",
+          "$ref": "#/definitions/message"
+        },
+
+        "frames": {
+          "description": "An array of stack frames that represents a sequence of calls, rendered in reverse chronological order, that comprise the call stack.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/stackFrame"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the stack.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "frames" ]
+    },
+
+    "stackFrame": {
+      "description": "A function call within a stack trace.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "location": {
+          "description": "The location to which this stack frame refers.",
+          "$ref": "#/definitions/location"
+        },
+
+        "module": {
+          "description": "The name of the module that contains the code of this stack frame.",
+          "type": "string"
+        },
+
+        "threadId": {
+          "description": "The thread identifier of the stack frame.",
+          "type": "integer"
+        },
+
+        "parameters": {
+          "description": "The parameters of the call that is executing.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "type": "string",
+            "default": []
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the stack frame.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "suppression": {
+      "description": "A suppression that is relevant to a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "guid": {
+          "description": "A stable, unique identifier for the suprression in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "kind": {
+          "description": "A string that indicates where the suppression is persisted.",
+          "enum": [
+            "inSource",
+            "external"
+          ],
+          "type": "string"
+        },
+
+        "status": {
+          "description": "A string that indicates the review status of the suppression.",
+          "enum": [
+            "accepted",
+            "underReview",
+            "rejected"
+          ],
+          "type": "string"
+        },
+
+        "justification": {
+          "description": "A string representing the justification for the suppression.",
+          "type": "string"
+        },
+
+        "location": {
+          "description": "Identifies the location associated with the suppression.",
+          "$ref": "#/definitions/location"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the suppression.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "kind" ]
+    },
+
+    "threadFlow": {
+      "description": "Describes a sequence of code locations that specify a path through a single thread of execution such as an operating system or fiber.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "id": {
+          "description": "An string that uniquely identifies the threadFlow within the codeFlow in which it occurs.",
+          "type": "string"
+        },
+
+        "message": {
+          "description": "A message relevant to the thread flow.",
+          "$ref": "#/definitions/message"
+        },
+
+
+        "initialState": {
+          "description": "Values of relevant expressions at the start of the thread flow that may change during thread flow execution.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "immutableState": {
+          "description": "Values of relevant expressions at the start of the thread flow that remain constant.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "locations": {
+          "description": "A temporally ordered array of 'threadFlowLocation' objects, each of which describes a location visited by the tool while producing the result.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the thread flow.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "locations" ]
+    },
+
+    "threadFlowLocation": {
+      "description": "A location visited by an analysis tool while simulating or monitoring the execution of a program.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "index": {
+          "description": "The index within the run threadFlowLocations array.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "location": {
+          "description": "The code location.",
+          "$ref": "#/definitions/location"
+        },
+
+        "stack": {
+          "description": "The call stack leading to this location.",
+          "$ref": "#/definitions/stack"
+        },
+
+        "kinds": {
+          "description": "A set of distinct strings that categorize the thread flow location. Well-known kinds include 'acquire', 'release', 'enter', 'exit', 'call', 'return', 'branch', 'implicit', 'false', 'true', 'caution', 'danger', 'unknown', 'unreachable', 'taint', 'function', 'handler', 'lock', 'memory', 'resource', 'scope' and 'value'.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "taxa": {
+          "description": "An array of references to rule or taxonomy reporting descriptors that are applicable to the thread flow location.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorReference"
+          }
+        },
+
+        "module": {
+          "description": "The name of the module that contains the code that is executing.",
+          "type": "string"
+        },
+
+        "state": {
+          "description": "A dictionary, each of whose keys specifies a variable or expression, the associated value of which represents the variable or expression value. For an annotation of kind 'continuation', for example, this dictionary might hold the current assumed values of a set of global variables.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "nestingLevel": {
+          "description": "An integer representing a containment hierarchy within the thread flow.",
+          "type": "integer",
+          "minimum": 0
+        },
+
+        "executionOrder": {
+          "description": "An integer representing the temporal order in which execution reached this location.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "executionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which this location was executed.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "importance": {
+          "description": "Specifies the importance of this location in understanding the code flow in which it occurs. The order from most to least important is \"essential\", \"important\", \"unimportant\". Default: \"important\".",
+          "enum": [ "important", "essential", "unimportant" ],
+          "default": "important",
+          "type": "string"
+        },
+
+        "webRequest": {
+          "description": "A web request associated with this thread flow location.",
+          "$ref": "#/definitions/webRequest"
+        },
+
+        "webResponse": {
+          "description": "A web response associated with this thread flow location.",
+          "$ref": "#/definitions/webResponse"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the threadflow location.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "tool": {
+      "description": "The analysis tool that was run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "driver": {
+          "description": "The analysis tool that was run.",
+          "$ref": "#/definitions/toolComponent"
+        },
+
+        "extensions": {
+          "description": "Tool extensions that contributed to or reconfigured the analysis tool that was run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the tool.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "driver" ]
+    },
+
+    "toolComponent": {
+      "description": "A component, such as a plug-in or the driver, of the analysis tool that was run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "guid": {
+          "description": "A unique identifier for the tool component in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "name": {
+          "description": "The name of the tool component.",
+          "type": "string"
+        },
+
+        "organization": {
+          "description": "The organization or company that produced the tool component.",
+          "type": "string"
+        },
+
+        "product": {
+          "description": "A product suite to which the tool component belongs.",
+          "type": "string"
+        },
+
+        "productSuite": {
+          "description": "A localizable string containing the name of the suite of products to which the tool component belongs.",
+          "type": "string"
+        },
+
+        "shortDescription": {
+          "description": "A brief description of the tool component.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "fullDescription": {
+          "description": "A comprehensive description of the tool component.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "fullName": {
+          "description": "The name of the tool component along with its version and any other useful identifying information, such as its locale.",
+          "type": "string"
+        },
+
+        "version": {
+          "description": "The tool component version, in whatever format the component natively provides.",
+          "type": "string"
+        },
+
+        "semanticVersion": {
+          "description": "The tool component version in the format specified by Semantic Versioning 2.0.",
+          "type": "string"
+        },
+
+        "dottedQuadFileVersion": {
+          "description": "The binary version of the tool component's primary executable file expressed as four non-negative integers separated by a period (for operating systems that express file versions in this way).",
+          "type": "string",
+          "pattern": "[0-9]+(\\.[0-9]+){3}"
+        },
+
+        "releaseDateUtc": {
+          "description": "A string specifying the UTC date (and optionally, the time) of the component's release.",
+          "type": "string"
+        },
+
+        "downloadUri": {
+          "description": "The absolute URI from which the tool component can be downloaded.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "informationUri": {
+          "description": "The absolute URI at which information about this version of the tool component can be found.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "globalMessageStrings": {
+          "description": "A dictionary, each of whose keys is a resource identifier and each of whose values is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "notifications": {
+          "description": "An array of reportingDescriptor objects relevant to the notifications related to the configuration and runtime execution of the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          }
+        },
+
+        "rules": {
+          "description": "An array of reportingDescriptor objects relevant to the analysis performed by the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          }
+        },
+
+        "taxa": {
+          "description": "An array of reportingDescriptor objects relevant to the definitions of both standalone and tool-defined taxonomies.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          }
+        },
+
+        "locations": {
+          "description": "An array of the artifactLocation objects associated with the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+
+        "language": {
+          "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
+          "type": "string",
+          "default": "en-US",
+          "pattern": "^[a-zA-Z]{2}(-[a-zA-Z]{2})?$"
+        },
+
+        "contents": {
+          "description": "The kinds of data contained in this object.",
+          "type": "array",
+          "uniqueItems": true,
+          "default": [ "localizedData", "nonLocalizedData" ],
+          "items": {
+            "enum": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "type": "string"
+          }
+        },
+
+        "isComprehensive": {
+          "description": "Specifies whether this object contains a complete definition of the localizable and/or non-localizable data for this component, as opposed to including only data that is relevant to the results persisted to this log file.",
+          "type": "boolean",
+          "default": false
+        },
+
+        "localizedDataSemanticVersion": {
+          "description": "The semantic version of the localized strings defined in this component; maintained by components that provide translations.",
+          "type": "string"
+        },
+
+        "minimumRequiredLocalizedDataSemanticVersion": {
+          "description": "The minimum value of localizedDataSemanticVersion required in translations consumed by this component; used by components that consume translations.",
+          "type": "string"
+        },
+
+        "associatedComponent": {
+          "description": "The component which is strongly associated with this component. For a translation, this refers to the component which has been translated. For an extension, this is the driver that provides the extension's plugin model.",
+          "$ref": "#/definitions/toolComponentReference"
+        },
+
+        "translationMetadata": {
+          "description": "Translation metadata, required for a translation, not populated by other component types.",
+          "$ref": "#/definitions/translationMetadata"
+        },
+
+        "supportedTaxonomies": {
+          "description": "An array of toolComponentReference objects to declare the taxonomies supported by the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponentReference"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the tool component.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "name" ]
+    },
+
+    "toolComponentReference": {
+      "description": "Identifies a particular toolComponent object, either the driver or an extension.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "name": {
+          "description": "The 'name' property of the referenced toolComponent.",
+          "type": "string"
+        },
+
+        "index": {
+          "description": "An index into the referenced toolComponent in tool.extensions.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "guid": {
+          "description": "The 'guid' property of the referenced toolComponent.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the toolComponentReference.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "translationMetadata": {
+      "description": "Provides additional metadata related to translation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "name": {
+          "description": "The name associated with the translation metadata.",
+          "type": "string"
+        },
+
+        "fullName": {
+          "description": "The full name associated with the translation metadata.",
+          "type": "string"
+        },
+
+        "shortDescription": {
+          "description": "A brief description of the translation metadata.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "fullDescription": {
+          "description": "A comprehensive description of the translation metadata.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "downloadUri": {
+          "description": "The absolute URI from which the translation metadata can be downloaded.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "informationUri": {
+          "description": "The absolute URI from which information related to the translation metadata can be downloaded.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the translation metadata.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "name" ]
+    },
+
+    "versionControlDetails": {
+      "description": "Specifies the information necessary to retrieve a desired revision from a version control system.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "repositoryUri": {
+          "description": "The absolute URI of the repository.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "revisionId": {
+          "description": "A string that uniquely and permanently identifies the revision within the repository.",
+          "type": "string"
+        },
+
+        "branch": {
+          "description": "The name of a branch containing the revision.",
+          "type": "string"
+        },
+
+        "revisionTag": {
+          "description": "A tag that has been applied to the revision.",
+          "type": "string"
+        },
+
+        "asOfTimeUtc": {
+          "description": "A Coordinated Universal Time (UTC) date and time that can be used to synchronize an enlistment to the state of the repository at that time.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "mappedTo": {
+          "description": "The location in the local file system to which the root of the repository was mapped at the time of the analysis.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the version control details.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "repositoryUri" ]
+    },
+
+    "webRequest": {
+      "description": "Describes an HTTP request.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "index": {
+          "description": "The index within the run.webRequests array of the request object associated with this result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+
+        },
+
+        "protocol": {
+          "description": "The request protocol. Example: 'http'.",
+          "type": "string"
+        },
+
+        "version": {
+          "description": "The request version. Example: '1.1'.",
+          "type": "string"
+        },
+
+        "target": {
+          "description": "The target of the request.",
+          "type": "string"
+        },
+
+        "method": {
+          "description": "The HTTP method. Well-known values are 'GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT'.",
+          "type": "string"
+        },
+
+        "headers": {
+          "description": "The request headers.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "parameters": {
+          "description": "The request parameters.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "body": {
+          "description": "The body of the request.",
+          "$ref": "#/definitions/artifactContent"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the request.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "webResponse": {
+      "description": "Describes the response to an HTTP request.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "index": {
+          "description": "The index within the run.webResponses array of the response object associated with this result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "protocol": {
+          "description": "The response protocol. Example: 'http'.",
+          "type": "string"
+        },
+
+        "version": {
+          "description": "The response version. Example: '1.1'.",
+          "type": "string"
+        },
+
+        "statusCode": {
+          "description": "The response status code. Example: 451.",
+          "type": "integer"
+        },
+
+        "reasonPhrase": {
+          "description": "The response reason. Example: 'Not found'.",
+          "type": "string"
+        },
+
+        "headers": {
+          "description": "The response headers.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "body": {
+          "description": "The body of the response.",
+          "$ref": "#/definitions/artifactContent"
+        },
+
+        "noResponseReceived": {
+          "description": "Specifies whether a response was received from the server.",
+          "type": "boolean",
+          "default": false
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the response.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/sarif/index.ts
+++ b/packages/core/src/sarif/index.ts
@@ -1,0 +1,34 @@
+// Public API of @gitgov/core/sarif
+export { createSarifBuilder } from './sarif_builder';
+export { toSarifWaiver } from './sarif_builder';
+export {
+  normalizeLineContent,
+  computePrimaryLocationLineHash,
+  buildPartialFingerprints,
+  createOccurrenceContext,
+} from './sarif_hash';
+export type { OccurrenceContext } from './sarif.types';
+export type {
+  SarifLog,
+  SarifRun,
+  SarifTool,
+  SarifToolDriver,
+  SarifResult,
+  SarifLevel,
+  SarifLocation,
+  SarifPhysicalLocation,
+  SarifRegion,
+  SarifSuppression,
+  SarifInvocation,
+  SarifReportingDescriptor,
+  SarifResultProperties,
+  SarifRunProperties,
+  SarifBuilderOptions,
+  SarifBuilder,
+  SarifActiveWaiver,
+  ValidationResult,
+  RedactionLevel,
+  GetLineContentFn,
+  SarifVersionStrategy,
+  SarifExecutionMetadata,
+} from './sarif.types';

--- a/packages/core/src/sarif/sarif.types.ts
+++ b/packages/core/src/sarif/sarif.types.ts
@@ -1,0 +1,471 @@
+import type { Finding, FindingCategory, DetectorName } from '../finding_detector/types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SARIF 2.1.0 structural types
+// Basados en https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Top-level SARIF log object.
+ * §3.13 sarifLog object
+ */
+export type SarifLog = {
+  /** JSON Schema URL for validation */
+  $schema: string;
+  /** SARIF version — always "2.1.0" */
+  version: '2.1.0';
+  /** One or more runs in this log */
+  runs: SarifRun[];
+};
+
+/**
+ * A single tool execution run.
+ * §3.14 run object
+ */
+export type SarifRun = {
+  /** Tool that produced the results */
+  tool: SarifTool;
+  /** Results detected during the run */
+  results: SarifResult[];
+  /** Describes the tool invocations */
+  invocations?: SarifInvocation[];
+  /** Custom GitGov properties for the run */
+  properties?: SarifRunProperties;
+};
+
+/**
+ * Tool descriptor.
+ * §3.18 tool object
+ */
+export type SarifTool = {
+  /** Primary tool component */
+  driver: SarifToolDriver;
+};
+
+/**
+ * Tool driver (the analysis tool itself).
+ * §3.19 toolComponent object
+ */
+export type SarifToolDriver = {
+  /** Tool name (e.g., "gitgov-audit") */
+  name: string;
+  /** Semantic version (e.g., "2.8.0") */
+  version: string;
+  /** URI for tool documentation */
+  informationUri: string;
+  /** Rules detected by this tool */
+  rules?: SarifReportingDescriptor[];
+};
+
+/**
+ * Rule descriptor.
+ * §3.49 reportingDescriptor object
+ */
+export type SarifReportingDescriptor = {
+  /** Rule ID (e.g., "PII-001") */
+  id: string;
+  /** Human-readable rule name */
+  name?: string;
+  /** Short description */
+  shortDescription?: { text: string };
+  /** Full description */
+  fullDescription?: { text: string };
+  /** Help URI */
+  helpUri?: string;
+};
+
+/**
+ * A single analysis result.
+ * §3.27 result object
+ */
+export type SarifResult = {
+  /** Rule that produced the result */
+  ruleId: string;
+  /** Severity level */
+  level: SarifLevel;
+  /** Human-readable message */
+  message: { text: string };
+  /** Locations where the result was detected */
+  locations: SarifLocation[];
+  /**
+   * Stable partial fingerprints for deduplication.
+   * §3.27.17 partialFingerprints
+   * Key: "primaryLocationLineHash/v1", Value: "hexHash:occurrence"
+   */
+  partialFingerprints?: Record<string, string>;
+  /**
+   * Fingerprints for result identity.
+   * §3.27.16 fingerprints
+   * Note: GitGov uses partialFingerprints (primaryLocationLineHash/v1) as primary identity.
+   */
+  fingerprints?: Record<string, string>;
+  /**
+   * Suppressions for this result.
+   * §3.27.23 suppressions
+   */
+  suppressions?: SarifSuppression[];
+  /**
+   * GitGov governance metadata.
+   * §3.8 PropertyBag
+   */
+  properties?: SarifResultProperties;
+};
+
+/**
+ * SARIF severity levels.
+ * §3.27.10 level property
+ */
+export type SarifLevel = 'error' | 'warning' | 'note' | 'none';
+
+/**
+ * Location of a result in source.
+ * §3.28 location object
+ */
+export type SarifLocation = {
+  physicalLocation: SarifPhysicalLocation;
+};
+
+/**
+ * Physical file location.
+ * §3.29 physicalLocation object
+ */
+export type SarifPhysicalLocation = {
+  artifactLocation: { uri: string };
+  region: SarifRegion;
+};
+
+/**
+ * Source region.
+ * §3.30 region object
+ */
+export type SarifRegion = {
+  /** 1-based line number */
+  startLine: number;
+  /** 1-based column number (optional) */
+  startColumn?: number;
+  /** Source code snippet at this region. §3.30.4 */
+  snippet?: { text: string };
+};
+
+/**
+ * A suppression for a result.
+ * §3.27.23 suppressions
+ */
+export type SarifSuppression = {
+  /**
+   * "inSource": suppression authored in source (e.g., comment).
+   * "external": suppression in an external system.
+   * For GitGov waivers: always "inSource".
+   */
+  kind: 'inSource' | 'external';
+  /**
+   * Current status of the suppression.
+   * "accepted": suppression is in effect.
+   * "underReview": under review.
+   * "rejected": rejected, result is NOT suppressed.
+   */
+  status: 'accepted' | 'underReview' | 'rejected';
+  /** Human-readable justification (maps from FeedbackRecord.content) */
+  justification?: string;
+  /** GitGov traceability back to the FeedbackRecord */
+  properties?: {
+    'gitgov/feedbackId': string;
+    'gitgov/expiresAt'?: string;
+    'gitgov/approvedBy'?: string;
+  };
+};
+
+/**
+ * Tool invocation descriptor.
+ * §3.14.11 invocations property
+ */
+export type SarifInvocation = {
+  /** Whether the tool executed successfully */
+  executionSuccessful: boolean;
+  /** Command line used to invoke the tool */
+  commandLine?: string;
+  /** ISO 8601 start timestamp */
+  startTimeUtc?: string;
+  /** ISO 8601 end timestamp */
+  endTimeUtc?: string;
+  /** Process exit code */
+  exitCode?: number;
+  /** GitGov correlation properties */
+  properties?: {
+    'gitgov/executionId'?: string;
+  };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GitGov property bag types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Custom GitGov properties on each result.
+ * All fields optional — only populated when available from context.
+ */
+export type SarifResultProperties = {
+  /**
+   * Links the finding to the ExecutionRecord that produced it.
+   * Source: ExecutionRecord.id
+   */
+  'gitgov/executionId'?: string;
+  /**
+   * Task that originated the audit.
+   * Source: ExecutionRecord.taskId
+   */
+  'gitgov/taskId'?: string;
+  /**
+   * Actor that signed the ExecutionRecord.
+   * Source: header.signatures[0].keyId
+   */
+  'gitgov/actorId'?: string;
+  /**
+   * Integrity checksum of the ExecutionRecord payload.
+   * Source: header.payloadChecksum (SHA256 hex, 64 chars)
+   */
+  'gitgov/payloadChecksum'?: string;
+  /**
+   * Protocol version that produced this record.
+   * Source: header.version (e.g., "1.1")
+   */
+  'gitgov/protocolVersion'?: string;
+  /** Semantic category of the finding */
+  'gitgov/category': FindingCategory;
+  /** Detector that generated the finding */
+  'gitgov/detector': DetectorName;
+  /** Confidence level 0-1 */
+  'gitgov/confidence': number;
+  /** Legal reference (e.g., "GDPR Art. 5(1)(f)") */
+  'gitgov/legalReference'?: string;
+};
+
+/**
+ * Custom GitGov properties on the run.
+ */
+export type SarifRunProperties = {
+  /** Policy decision computed after evaluation */
+  'gitgov/policyDecision'?: 'pass' | 'block';
+  /** Number of Ed25519 signatures in the ExecutionRecord */
+  'gitgov/signatureCount'?: number;
+  /** Agent that executed the scan */
+  'gitgov/agentId'?: string;
+  /** Scope of the scan */
+  'gitgov/scanScope'?: 'diff' | 'full' | 'baseline';
+  /** Number of files scanned */
+  'gitgov/scannedFiles'?: number;
+  /** Number of lines scanned */
+  'gitgov/scannedLines'?: number;
+  /** Redaction level applied to findings before SARIF generation. Tag only — builder does not redact */
+  'gitgov/redactionLevel'?: RedactionLevel;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SarifBuilder input types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Callback to retrieve the content of a specific line in a file.
+ * Returns null if the file/line is not accessible.
+ * Used to compute primaryLocationLineHash.
+ */
+export type GetLineContentFn = (file: string, line: number) => Promise<string | null>;
+
+/**
+ * Context for occurrence tracking within a single file.
+ * Maps normalizedLine → count of occurrences seen so far.
+ * Used by buildPartialFingerprints() — must be per-file, not shared across files.
+ */
+export type OccurrenceContext = Map<string, number>;
+
+/**
+ * Controls what snippet content is included in SARIF output.
+ * "l1": Git level — snippets redacted for sensitive categories (safe for ExecutionRecord in Git)
+ * "l2": Projection level — full snippet content included (for SaaS/PostgreSQL)
+ */
+export type RedactionLevel = 'l1' | 'l2';
+
+/**
+ * An active waiver to be mapped to a SARIF suppression.
+ * Derived from FeedbackRecord type: "approval".
+ * Note: There is no WaiverRecord type — waivers ARE FeedbackRecords.
+ */
+export type SarifActiveWaiver = {
+  /**
+   * Fingerprint to match against result.partialFingerprints["primaryLocationLineHash/v1"].
+   * This is the primaryLocationLineHash/v1 value (content-based hash).
+   */
+  fingerprint: string;
+  /** FeedbackRecord ID for traceability */
+  feedbackId: string;
+  /** Waiver justification (from FeedbackRecord.content) */
+  content: string;
+  /** Expiration date in ISO 8601 (if set) */
+  expiresAt?: string;
+  /** Actor who approved the waiver */
+  approvedBy?: string;
+};
+
+/**
+ * All inputs to SarifBuilder.build().
+ * Uses type (not interface) — data only, no methods.
+ */
+export type SarifBuilderOptions = {
+  // ── Tool info ──────────────────────────────────────────────
+  /** Tool name (e.g., "gitgov-audit") */
+  toolName: string;
+  /** Tool version (e.g., "2.8.0") */
+  toolVersion: string;
+  /** Tool documentation URI */
+  informationUri: string;
+
+  // ── Findings ───────────────────────────────────────────────
+  /** Findings to include in SARIF output */
+  findings: Finding[];
+
+  // ── GitGov context for result.properties ──────────────────
+  /** ExecutionRecord ID */
+  executionId?: string;
+  /** Task that originated the audit */
+  taskId?: string;
+  /** Actor ID (from signatures) */
+  actorId?: string;
+  /** Payload checksum (SHA256 hex) */
+  payloadChecksum?: string;
+  /** Protocol version */
+  protocolVersion?: string;
+
+  // ── GitGov context for run.properties ─────────────────────
+  /** Policy decision post-evaluation. Populated by the orchestrator, not by the agent. */
+  policyDecision?: 'pass' | 'block';
+  /** Number of signatures in ExecutionRecord */
+  signatureCount?: number;
+  /** Agent that executed */
+  agentId?: string;
+  /** Scan scope */
+  scanScope?: 'diff' | 'full' | 'baseline';
+  /** Files scanned */
+  scannedFiles?: number;
+  /** Lines scanned */
+  scannedLines?: number;
+
+  // ── Invocations ────────────────────────────────────────────
+  /** Whether the tool executed successfully (default: true) */
+  executionSuccessful?: boolean;
+  /** ISO 8601 start time */
+  startTimeUtc?: string;
+  /** ISO 8601 end time */
+  endTimeUtc?: string;
+  /** CLI command line (e.g., "gitgov audit --output sarif") */
+  commandLine?: string;
+  /** Process exit code */
+  exitCode?: number;
+
+  // ── Suppressions ───────────────────────────────────────────
+  /** Active waivers to map to suppressions */
+  activeWaivers?: SarifActiveWaiver[];
+
+  // ── Content access ─────────────────────────────────────────
+  /**
+   * Callback to get line content for primaryLocationLineHash.
+   * If undefined or returns null: partialFingerprints omitted for that result.
+   */
+  getLineContent?: GetLineContentFn;
+
+  // ── Output control ─────────────────────────────────────────
+  /** Controls snippet redaction in SARIF output */
+  redactionLevel?: RedactionLevel;
+};
+
+/**
+ * Result of SARIF validation.
+ */
+export type ValidationResult = {
+  /** Whether the SARIF is valid against the 2.1.0 schema */
+  valid: boolean;
+  /** Validation errors (if valid: false) */
+  errors?: string[];
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SarifBuilder interface — has methods, so uses interface (not type)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Builds SARIF 2.1.0 logs from GitGovernance findings.
+ * Use createSarifBuilder() to get an instance.
+ */
+export interface SarifBuilder {
+  /**
+   * Builds a SARIF 2.1.0 log from findings and GitGov context.
+   * Pure function — no side effects, no I/O.
+   * @param options - Builder inputs
+   * @returns SarifLog ready to be serialized
+   */
+  build(options: SarifBuilderOptions): Promise<SarifLog>;
+
+  /**
+   * Validates a SARIF log against the official JSON Schema.
+   * @param sarif - Log to validate
+   * @returns { valid: true } or { valid: false, errors: [...] }
+   */
+  validate(sarif: SarifLog): ValidationResult;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Extensibility types (not implemented in v1, designed for future)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Strategy for multi-version SARIF support.
+ * v1 only supports 2.1.0. This interface enables future 2.X adapters.
+ */
+export interface SarifVersionStrategy {
+  /** Supported SARIF versions */
+  readonly supportedVersions: string[];
+  /** Default version to produce */
+  readonly defaultVersion: string;
+  /**
+   * Build a SARIF log in a specific version.
+   * @param version - Target version (e.g., "2.1.0")
+   * @param options - Builder inputs
+   */
+  build(version: string, options: SarifBuilderOptions): Promise<SarifLog>;
+  /**
+   * Detect the version of an unknown SARIF object.
+   * @param sarif - Unknown SARIF object
+   * @returns Version string or "unknown"
+   */
+  detectVersion(sarif: unknown): string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Contrato: SARIF dentro de ExecutionRecord.metadata
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Formato del metadata en ExecutionRecord cuando contiene SARIF.
+ * El AgentRunner o el orquestador wrappea el SarifLog en esta estructura.
+ *
+ * Ejemplo:
+ *   ExecutionRecord.metadata = { kind: "sarif", version: "2.1.0", data: sarifLog }
+ *
+ * Consumidores:
+ * - Projection (epic projection_schema_v2): lee kind === "sarif", descompone data.runs[0].results → GitgovFinding
+ * - Orquestador (epic audit_orchestration): lee data de cada ExecutionRecord para consolidar findings
+ * - Policy (epic policy_evaluation): extrae findings consolidados para evaluacion
+ */
+export type SarifExecutionMetadata = {
+  /** Discriminador — siempre "sarif" para SARIF content */
+  kind: 'sarif';
+  /** Version SARIF del contenido */
+  version: '2.1.0';
+  /** SarifLog completo producido por SarifBuilder.build() */
+  data: SarifLog;
+  /** Summary para queries rapidas sin deserializar el SarifLog completo */
+  summary?: {
+    total: number;
+    bySeverity: Record<string, number>;
+    byCategory: Record<string, number>;
+  };
+};

--- a/packages/core/src/sarif/sarif_builder.test.ts
+++ b/packages/core/src/sarif/sarif_builder.test.ts
@@ -1,0 +1,343 @@
+// All EARS prefixes map to sarif_module.md
+import { createSarifBuilder, toSarifWaiver } from './sarif_builder';
+import type { Finding } from '../finding_detector/types';
+import type { SarifBuilderOptions, SarifActiveWaiver, SarifLog } from './sarif.types';
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const baseFindings: Finding[] = [
+  {
+    id: 'finding-001',
+    ruleId: 'PII-001',
+    category: 'pii-email',
+    severity: 'high',
+    file: 'src/auth/login.ts',
+    line: 42,
+    column: 5,
+    snippet: 'const email = user.email;',
+    message: 'PII email detected in source code',
+    suggestion: 'Remove email from source',
+    legalReference: 'GDPR Art. 5(1)(f)',
+    detector: 'regex',
+    fingerprint: 'abc123def456',
+    confidence: 0.95,
+  },
+];
+
+const baseOptions: SarifBuilderOptions = {
+  toolName: 'gitgov-audit',
+  toolVersion: '2.8.0',
+  informationUri: 'https://gitgovernance.com/audit',
+  findings: baseFindings,
+};
+
+/** Helper to get the first run from a SarifLog safely */
+function firstRun(sarif: SarifLog) {
+  const run = sarif.runs[0];
+  if (!run) throw new Error('No runs in SarifLog');
+  return run;
+}
+
+/** Helper to get the first result from a SarifLog safely */
+function firstResult(sarif: SarifLog) {
+  const run = firstRun(sarif);
+  const result = run.results[0];
+  if (!result) throw new Error('No results in run');
+  return result;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('SarifBuilder', () => {
+  const builder = createSarifBuilder();
+
+  describe('4.1. Structure and severity mapping (SARIF-A1 to A3)', () => {
+
+    it('[SARIF-A1] build: should return SarifLog with version 2.1.0 and correct $schema', async () => {
+      const sarif = await builder.build(baseOptions);
+      expect(sarif.version).toBe('2.1.0');
+      expect(sarif.$schema).toContain('errata01');
+    });
+
+    it('[SARIF-A2] build: should return empty results array when findings is empty', async () => {
+      const sarif = await builder.build({ ...baseOptions, findings: [] });
+      expect(firstRun(sarif).results).toEqual([]);
+    });
+
+    it('[SARIF-A3] build: should map critical/high → error, medium → warning, low → note, info → none', async () => {
+      const severities: Finding['severity'][] = ['critical', 'high', 'medium', 'low', 'info'];
+      const expected = ['error', 'error', 'warning', 'note', 'none'];
+
+      for (let i = 0; i < severities.length; i++) {
+        const sev = severities[i]!;
+        const exp = expected[i]!;
+        const finding: Finding = { ...baseFindings[0]!, id: `f-${i}`, severity: sev };
+        const sarif = await builder.build({ ...baseOptions, findings: [finding] });
+        expect(firstResult(sarif).level).toBe(exp);
+      }
+    });
+  });
+
+  describe('4.3. Build core (SARIF-C1 to C8)', () => {
+
+    it('[SARIF-C1] build: should populate location with correct line and column', async () => {
+      const sarif = await builder.build(baseOptions);
+      const loc = firstResult(sarif).locations[0];
+      expect(loc).toBeDefined();
+      const region = loc!.physicalLocation.region;
+      expect(region.startLine).toBe(42);
+      expect(region.startColumn).toBe(5);
+    });
+
+    it('[SARIF-C2] build: findings with same ruleId should produce one rule entry', async () => {
+      const dup: Finding = { ...baseFindings[0]!, id: 'finding-002', line: 50 };
+      const sarif = await builder.build({ ...baseOptions, findings: [baseFindings[0]!, dup] });
+      const rules = firstRun(sarif).tool.driver.rules ?? [];
+      const pii001Count = rules.filter(r => r.id === 'PII-001').length;
+      expect(pii001Count).toBe(1);
+    });
+
+    it('[SARIF-C3] build: rule with legalReference should include helpUri based on ruleId', async () => {
+      const sarif = await builder.build(baseOptions);
+      const rules = firstRun(sarif).tool.driver.rules ?? [];
+      const rule = rules.find(r => r.id === 'PII-001');
+      expect(rule).toBeDefined();
+      expect(rule!.helpUri).toBe('https://gitgovernance.com/rules/PII-001');
+    });
+
+    it('[SARIF-C4] build: should populate partialFingerprints when getLineContent provided', async () => {
+      const opts: SarifBuilderOptions = {
+        ...baseOptions,
+        getLineContent: async () => 'const email = user.email;',
+      };
+      const sarif = await builder.build(opts);
+      const result = firstResult(sarif);
+      expect(result.partialFingerprints).toBeDefined();
+      expect(result.partialFingerprints!['primaryLocationLineHash/v1']).toMatch(/^[0-9a-f]{16}:1$/);
+    });
+
+    it('[SARIF-C5] build: should not include partialFingerprints when getLineContent not provided', async () => {
+      const sarif = await builder.build(baseOptions);
+      expect(firstResult(sarif).partialFingerprints).toBeUndefined();
+    });
+
+    it('[SARIF-C6] build: $schema should point to OASIS Errata 01 official URL', async () => {
+      const sarif = await builder.build(baseOptions);
+      expect(sarif.$schema).toBe(
+        'https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json'
+      );
+    });
+
+    it('[SARIF-C7] build: finding with snippet should include snippet.text in region', async () => {
+      const sarif = await builder.build(baseOptions);
+      const loc = firstResult(sarif).locations[0];
+      const snippet = loc!.physicalLocation.region.snippet;
+      expect(snippet).toBeDefined();
+      expect(snippet!.text).toBe('const email = user.email;');
+    });
+
+    it('[SARIF-C8] build: finding without snippet should not include snippet in region', async () => {
+      const findingNoSnippet: Finding = { ...baseFindings[0]!, id: 'f-no-snippet', snippet: '' };
+      const sarif = await builder.build({ ...baseOptions, findings: [findingNoSnippet] });
+      const loc = firstResult(sarif).locations[0];
+      // Empty string snippet should be omitted (falsy)
+      expect(loc!.physicalLocation.region.snippet).toBeUndefined();
+    });
+  });
+
+  describe('4.4. GitGov properties (SARIF-D1 to D5)', () => {
+
+    it('[SARIF-D1] build: should include gitgov/executionId in result.properties when provided', async () => {
+      const sarif = await builder.build({ ...baseOptions, executionId: 'exec-42' });
+      expect(firstResult(sarif).properties?.['gitgov/executionId']).toBe('exec-42');
+    });
+
+    it('[SARIF-D2] build: should NOT include gitgov/executionId when not provided', async () => {
+      const sarif = await builder.build(baseOptions);
+      expect(firstResult(sarif).properties).not.toHaveProperty('gitgov/executionId');
+    });
+
+    it('[SARIF-D3] build: should include gitgov/category from finding.category', async () => {
+      const sarif = await builder.build(baseOptions);
+      expect(firstResult(sarif).properties?.['gitgov/category']).toBe('pii-email');
+    });
+
+    it('[SARIF-D4] build: should include gitgov/legalReference when finding has legalReference', async () => {
+      const sarif = await builder.build(baseOptions);
+      expect(firstResult(sarif).properties?.['gitgov/legalReference']).toBe('GDPR Art. 5(1)(f)');
+    });
+
+    it('[SARIF-D5] build: should include gitgov/policyDecision in run.properties when provided', async () => {
+      const sarif = await builder.build({ ...baseOptions, policyDecision: 'block' });
+      expect(firstRun(sarif).properties?.['gitgov/policyDecision']).toBe('block');
+    });
+  });
+
+  describe('4.5. Invocations (SARIF-E1 to E4)', () => {
+
+    it('[SARIF-E1] build: should set startTimeUtc in invocations when provided', async () => {
+      const sarif = await builder.build({ ...baseOptions, startTimeUtc: '2026-03-03T10:00:00Z' });
+      const inv = firstRun(sarif).invocations;
+      expect(inv).toBeDefined();
+      expect(inv![0]!.startTimeUtc).toBe('2026-03-03T10:00:00Z');
+    });
+
+    it('[SARIF-E2] build: should include gitgov/executionId in invocations.properties', async () => {
+      const sarif = await builder.build({ ...baseOptions, executionId: 'exec-99', startTimeUtc: '2026-03-03T10:00:00Z' });
+      const inv = firstRun(sarif).invocations;
+      expect(inv![0]!.properties?.['gitgov/executionId']).toBe('exec-99');
+    });
+
+    it('[SARIF-E3] build: should NOT include invocations when no invocation fields provided', async () => {
+      const sarif = await builder.build(baseOptions);
+      expect(firstRun(sarif).invocations).toBeUndefined();
+    });
+
+    it('[SARIF-E4] build: executionSuccessful should default to true when not provided', async () => {
+      const sarif = await builder.build({ ...baseOptions, startTimeUtc: '2026-03-03T10:00:00Z' });
+      const inv = firstRun(sarif).invocations;
+      expect(inv![0]!.executionSuccessful).toBe(true);
+    });
+  });
+
+  describe('4.6. Suppressions (SARIF-F1 to F5)', () => {
+
+    it('[SARIF-F1] build: matching waiver should produce suppression with kind inSource', async () => {
+      const opts: SarifBuilderOptions = {
+        ...baseOptions,
+        getLineContent: async () => 'const email = user.email;',
+        activeWaivers: [],
+      };
+      // Compute fingerprint first to build the waiver
+      const sarifNoWaiver = await builder.build({ ...opts, activeWaivers: [] });
+      const fp = firstResult(sarifNoWaiver).partialFingerprints?.['primaryLocationLineHash/v1'] ?? '';
+
+      const waiver: SarifActiveWaiver = {
+        fingerprint: fp,
+        feedbackId: 'feedback-2026-001',
+        content: 'Approved for test environment only',
+        expiresAt: '2026-12-31T00:00:00Z',
+        approvedBy: 'human:ciso',
+      };
+
+      const sarif = await builder.build({ ...opts, activeWaivers: [waiver] });
+      const sup = firstResult(sarif).suppressions;
+      expect(sup).toBeDefined();
+      expect(sup![0]!.kind).toBe('inSource');
+    });
+
+    it('[SARIF-F2] build: matching waiver should produce suppression with status accepted', async () => {
+      const opts: SarifBuilderOptions = {
+        ...baseOptions,
+        getLineContent: async () => 'const email = user.email;',
+        activeWaivers: [],
+      };
+      const sarifNoWaiver = await builder.build(opts);
+      const fp = firstResult(sarifNoWaiver).partialFingerprints?.['primaryLocationLineHash/v1'] ?? '';
+      const waiver: SarifActiveWaiver = { fingerprint: fp, feedbackId: 'fb-1', content: 'ok' };
+      const sarif = await builder.build({ ...opts, activeWaivers: [waiver] });
+      const sup = firstResult(sarif).suppressions;
+      expect(sup![0]!.status).toBe('accepted');
+    });
+
+    it('[SARIF-F3] build: suppression should include gitgov/feedbackId', async () => {
+      const opts: SarifBuilderOptions = {
+        ...baseOptions,
+        getLineContent: async () => 'const email = user.email;',
+        activeWaivers: [],
+      };
+      const sarifNoWaiver = await builder.build(opts);
+      const fp = firstResult(sarifNoWaiver).partialFingerprints?.['primaryLocationLineHash/v1'] ?? '';
+      const waiver: SarifActiveWaiver = { fingerprint: fp, feedbackId: 'feedback-xyz', content: 'ok' };
+      const sarif = await builder.build({ ...opts, activeWaivers: [waiver] });
+      const sup = firstResult(sarif).suppressions;
+      expect(sup![0]!.properties?.['gitgov/feedbackId']).toBe('feedback-xyz');
+    });
+
+    it('[SARIF-F4] build: result without matching waiver should NOT have suppressions', async () => {
+      const opts: SarifBuilderOptions = {
+        ...baseOptions,
+        getLineContent: async () => 'const email = user.email;',
+        activeWaivers: [{ fingerprint: 'no-match', feedbackId: 'fb', content: 'ok' }],
+      };
+      const sarif = await builder.build(opts);
+      expect(firstResult(sarif).suppressions).toBeUndefined();
+    });
+
+    it('[SARIF-F5] build: empty activeWaivers should produce no suppressions', async () => {
+      const sarif = await builder.build({ ...baseOptions, activeWaivers: [] });
+      expect(firstResult(sarif).suppressions).toBeUndefined();
+    });
+  });
+
+  describe('4.7. Validation (SARIF-G1 to G3)', () => {
+
+    it('[SARIF-G1] validate: output from build() should pass validation', async () => {
+      const sarif = await builder.build(baseOptions);
+      const result = builder.validate(sarif);
+      expect(result.valid).toBe(true);
+    });
+
+    it('[SARIF-G2] validate: sarif missing version field should fail validation', () => {
+      const invalid = { $schema: 'x', runs: [] } as unknown as SarifLog;
+      const result = builder.validate(invalid);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.length).toBeGreaterThan(0);
+    });
+
+    it('[SARIF-G3] validate: result with invalid level value should fail validation', async () => {
+      const sarif = await builder.build(baseOptions);
+      // Inject invalid level
+      (firstResult(sarif) as Record<string, unknown>)['level'] = 'critical';
+      const result = builder.validate(sarif);
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('4.10. Redaction metadata tag (SARIF-J1)', () => {
+
+    it('[SARIF-J1] build: should include gitgov/redactionLevel in run.properties when provided', async () => {
+      const sarif = await builder.build({ ...baseOptions, redactionLevel: 'l1' });
+      expect(firstRun(sarif).properties?.['gitgov/redactionLevel']).toBe('l1');
+    });
+  });
+
+  describe('4.11. toSarifWaiver mapping (SARIF-K1 to K4)', () => {
+
+    it('[SARIF-K1] toSarifWaiver: should map feedback.id to feedbackId', () => {
+      const result = toSarifWaiver({
+        fingerprint: 'abc123',
+        feedback: { id: 'fb-001', content: 'Approved' },
+      });
+      expect(result.feedbackId).toBe('fb-001');
+      expect(result.fingerprint).toBe('abc123');
+    });
+
+    it('[SARIF-K2] toSarifWaiver: should default content to empty string when feedback.content is undefined', () => {
+      const result = toSarifWaiver({
+        fingerprint: 'abc123',
+        feedback: { id: 'fb-002' },
+      });
+      expect(result.content).toBe('');
+    });
+
+    it('[SARIF-K3] toSarifWaiver: should convert expiresAt Date to ISO string', () => {
+      const date = new Date('2026-12-31T00:00:00Z');
+      const result = toSarifWaiver({
+        fingerprint: 'abc123',
+        feedback: { id: 'fb-003', content: 'ok' },
+        expiresAt: date,
+      });
+      expect(result.expiresAt).toBe('2026-12-31T00:00:00.000Z');
+    });
+
+    it('[SARIF-K4] toSarifWaiver: should propagate approvedBy when provided', () => {
+      const result = toSarifWaiver({
+        fingerprint: 'abc123',
+        feedback: { id: 'fb-004', content: 'ok' },
+        approvedBy: 'human:ciso',
+      });
+      expect(result.approvedBy).toBe('human:ciso');
+    });
+  });
+});

--- a/packages/core/src/sarif/sarif_builder.test.ts
+++ b/packages/core/src/sarif/sarif_builder.test.ts
@@ -78,7 +78,7 @@ describe('SarifBuilder', () => {
     });
   });
 
-  describe('4.3. Build core (SARIF-C1 to C8)', () => {
+  describe('4.3. Build core (SARIF-C1 to C9)', () => {
 
     it('[SARIF-C1] build: should populate location with correct line and column', async () => {
       const sarif = await builder.build(baseOptions);
@@ -142,6 +142,15 @@ describe('SarifBuilder', () => {
       const loc = firstResult(sarif).locations[0];
       // Empty string snippet should be omitted (falsy)
       expect(loc!.physicalLocation.region.snippet).toBeUndefined();
+    });
+
+    it('[SARIF-C9] build: rule with suggestion should include fullDescription.text', async () => {
+      const sarif = await builder.build(baseOptions);
+      const rules = firstRun(sarif).tool.driver.rules ?? [];
+      const rule = rules.find(r => r.id === 'PII-001');
+      expect(rule).toBeDefined();
+      expect(rule!.fullDescription).toBeDefined();
+      expect(rule!.fullDescription!.text).toBe('Remove email from source');
     });
   });
 

--- a/packages/core/src/sarif/sarif_builder.ts
+++ b/packages/core/src/sarif/sarif_builder.ts
@@ -1,0 +1,306 @@
+import Ajv from 'ajv-draft-04';
+import addFormats from 'ajv-formats';
+import type {
+  SarifBuilder,
+  SarifBuilderOptions,
+  SarifLog,
+  SarifRun,
+  SarifResult,
+  SarifInvocation,
+  SarifReportingDescriptor,
+  SarifSuppression,
+  SarifResultProperties,
+  SarifRunProperties,
+  ValidationResult,
+  SarifActiveWaiver,
+} from './sarif.types';
+import type { Finding } from '../finding_detector/types';
+import {
+  buildPartialFingerprints,
+  createOccurrenceContext,
+} from './sarif_hash';
+import sarifSchema from './fixtures/sarif-schema-2.1.0.json';
+
+/** Official SARIF 2.1.0 Errata 01 schema URL */
+const SARIF_SCHEMA_URL =
+  'https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json';
+
+/**
+ * Maps GitGov FindingSeverity to SARIF level.
+ * §3.27.10 level property
+ */
+function mapSeverityToLevel(severity: Finding['severity']): SarifResult['level'] {
+  switch (severity) {
+    case 'critical': return 'error';
+    case 'high':     return 'error';
+    case 'medium':   return 'warning';
+    case 'low':      return 'note';
+    case 'info':     return 'none';
+  }
+}
+
+/**
+ * Extracts unique rule descriptors from findings.
+ * Deduplicates by ruleId — first finding with a given ruleId wins
+ * (its message becomes shortDescription).
+ */
+function extractRules(findings: Finding[]): SarifReportingDescriptor[] {
+  const seen = new Set<string>();
+  const rules: SarifReportingDescriptor[] = [];
+
+  for (const f of findings) {
+    if (!seen.has(f.ruleId)) {
+      seen.add(f.ruleId);
+      rules.push({
+        id: f.ruleId,
+        shortDescription: { text: f.message },
+        ...(f.suggestion && { fullDescription: { text: f.suggestion } }),
+        ...(f.legalReference && { helpUri: `https://gitgovernance.com/rules/${f.ruleId}` }),
+      });
+    }
+  }
+
+  return rules;
+}
+
+/**
+ * Finds a waiver matching the given fingerprint.
+ * Matching is by partialFingerprint (primaryLocationLineHash/v1).
+ */
+function findMatchingWaiver(
+  fingerprint: string | undefined,
+  waivers: SarifActiveWaiver[] | undefined
+): SarifActiveWaiver | undefined {
+  if (!fingerprint || !waivers || waivers.length === 0) {
+    return undefined;
+  }
+  return waivers.find(w => w.fingerprint === fingerprint);
+}
+
+/**
+ * Builds a SARIF suppression from a SarifActiveWaiver.
+ * FeedbackRecord type: "approval" → kind: "inSource", status: "accepted"
+ */
+function buildSuppression(waiver: SarifActiveWaiver): SarifSuppression {
+  return {
+    kind: 'inSource',
+    status: 'accepted',
+    ...(waiver.content && { justification: waiver.content }),
+    properties: {
+      'gitgov/feedbackId': waiver.feedbackId,
+      ...(waiver.expiresAt && { 'gitgov/expiresAt': waiver.expiresAt }),
+      ...(waiver.approvedBy && { 'gitgov/approvedBy': waiver.approvedBy }),
+    },
+  };
+}
+
+/**
+ * Builds the invocations array if any invocation fields are present.
+ * Note: executionId triggers invocations because it populates
+ * invocations[0].properties["gitgov/executionId"] — an invocation-scoped field.
+ */
+function buildInvocations(options: SarifBuilderOptions): SarifInvocation[] | undefined {
+  const hasInvocationData =
+    options.executionId !== undefined ||
+    options.startTimeUtc !== undefined ||
+    options.endTimeUtc !== undefined ||
+    options.commandLine !== undefined ||
+    options.exitCode !== undefined;
+
+  if (!hasInvocationData) {
+    return undefined;
+  }
+
+  const invocation: SarifInvocation = {
+    executionSuccessful: options.executionSuccessful ?? true,
+    ...(options.startTimeUtc && { startTimeUtc: options.startTimeUtc }),
+    ...(options.endTimeUtc && { endTimeUtc: options.endTimeUtc }),
+    ...(options.commandLine && { commandLine: options.commandLine }),
+    ...(options.exitCode !== undefined && { exitCode: options.exitCode }),
+    ...(options.executionId && {
+      properties: { 'gitgov/executionId': options.executionId },
+    }),
+  };
+
+  return [invocation];
+}
+
+class SarifBuilderImpl implements SarifBuilder {
+  private readonly ajv: Ajv;
+
+  constructor() {
+    this.ajv = new Ajv({ allErrors: true, strict: false });
+    addFormats(this.ajv);
+  }
+
+  async build(options: SarifBuilderOptions): Promise<SarifLog> {
+    const rules = extractRules(options.findings);
+
+    // Build partialFingerprints per finding
+    // IMPORTANT: Process sequentially to avoid race conditions on occurrence counters.
+    // Promise.all + shared Map = corrupted occurrence counts.
+    const fileContexts = new Map<string, Map<string, number>>();
+    const results: SarifResult[] = [];
+
+    for (const finding of options.findings) {
+        // Get or create occurrence context for this file
+        if (!fileContexts.has(finding.file)) {
+          fileContexts.set(finding.file, createOccurrenceContext());
+        }
+        const context = fileContexts.get(finding.file)!;
+
+        const partial = await buildPartialFingerprints(
+          finding.file,
+          finding.line,
+          options.getLineContent,
+          context
+        );
+
+        // Note: if getLineContent is not provided, partial is {} and fingerprint is undefined,
+        // so waivers cannot match. Callers MUST provide getLineContent for waiver matching to work.
+        const waiver = findMatchingWaiver(
+          partial['primaryLocationLineHash/v1'],
+          options.activeWaivers
+        );
+
+        // result.properties — only defined keys (no undefined values)
+        const props: SarifResultProperties = {
+          'gitgov/category': finding.category,
+          'gitgov/detector': finding.detector,
+          'gitgov/confidence': finding.confidence,
+        };
+        if (options.executionId)     props['gitgov/executionId']     = options.executionId;
+        if (options.taskId)          props['gitgov/taskId']          = options.taskId;
+        if (options.actorId)         props['gitgov/actorId']         = options.actorId;
+        if (options.payloadChecksum) props['gitgov/payloadChecksum'] = options.payloadChecksum;
+        if (options.protocolVersion) props['gitgov/protocolVersion'] = options.protocolVersion;
+        if (finding.legalReference)  props['gitgov/legalReference']  = finding.legalReference;
+
+        const region: SarifResult['locations'][0]['physicalLocation']['region'] = {
+          startLine: finding.line,
+        };
+        if (finding.column !== undefined) {
+          region.startColumn = finding.column;
+        }
+        // Finding.snippet is string (required) but empty string means "no snippet" — omit from SARIF
+        if (finding.snippet) {
+          region.snippet = { text: finding.snippet };
+        }
+
+        const result: SarifResult = {
+          ruleId: finding.ruleId,
+          level: mapSeverityToLevel(finding.severity),
+          message: { text: finding.message },
+          locations: [{
+            physicalLocation: {
+              artifactLocation: { uri: finding.file },
+              region,
+            },
+          }],
+          properties: props,
+        };
+
+        if (Object.keys(partial).length > 0) {
+          result.partialFingerprints = partial;
+        }
+        if (waiver) {
+          result.suppressions = [buildSuppression(waiver)];
+        }
+
+        results.push(result);
+    }
+
+    // run.properties — only defined keys
+    const runProps: SarifRunProperties = {};
+    if (options.policyDecision !== undefined)  runProps['gitgov/policyDecision']  = options.policyDecision;
+    if (options.signatureCount !== undefined)  runProps['gitgov/signatureCount']  = options.signatureCount;
+    if (options.agentId)                       runProps['gitgov/agentId']          = options.agentId;
+    if (options.scanScope)                     runProps['gitgov/scanScope']        = options.scanScope;
+    if (options.scannedFiles !== undefined)    runProps['gitgov/scannedFiles']     = options.scannedFiles;
+    if (options.scannedLines !== undefined)    runProps['gitgov/scannedLines']     = options.scannedLines;
+    if (options.redactionLevel)                runProps['gitgov/redactionLevel']   = options.redactionLevel;
+
+    const invocations = buildInvocations(options);
+
+    const run: SarifRun = {
+      tool: {
+        driver: {
+          name: options.toolName,
+          version: options.toolVersion,
+          informationUri: options.informationUri,
+          rules,
+        },
+      },
+      results,
+    };
+
+    if (invocations) {
+      run.invocations = invocations;
+    }
+    if (Object.keys(runProps).length > 0) {
+      run.properties = runProps;
+    }
+
+    return {
+      $schema: SARIF_SCHEMA_URL,
+      version: '2.1.0',
+      runs: [run],
+    };
+  }
+
+  validate(sarif: SarifLog): ValidationResult {
+    const validate = this.ajv.compile(sarifSchema);
+    const valid = validate(sarif);
+
+    if (valid) {
+      return { valid: true };
+    }
+
+    const errors = (validate.errors ?? []).map(
+      (e) => `${e.instancePath || '/'} ${e.message ?? 'unknown error'}`
+    );
+
+    return { valid: false, errors };
+  }
+}
+
+/**
+ * Factory function for SarifBuilder.
+ * Creates a new instance with embedded JSON Schema validator.
+ *
+ * Why factory instead of direct functions (buildSarif/validateSarif):
+ * The constructor pre-compiles the SARIF JSON Schema with ajv (~50ms).
+ * Reusing the instance between calls avoids re-compilation on each validate().
+ * The builder has internal state (compiled ajv instance) — that justifies the factory pattern.
+ */
+export function createSarifBuilder(): SarifBuilder {
+  return new SarifBuilderImpl();
+}
+
+/**
+ * Maps ActiveWaiver (from WaiverReader in source_auditor) to SarifActiveWaiver.
+ *
+ * ActiveWaiver has: fingerprint, ruleId, expiresAt (Date), feedback (FeedbackRecord complete).
+ * SarifActiveWaiver has: fingerprint, feedbackId (string), content (string), expiresAt (ISO string), approvedBy.
+ *
+ * The caller (orchestrator) uses it when building the final consolidated SARIF with --output sarif.
+ */
+export function toSarifWaiver(waiver: {
+  fingerprint: string;
+  feedback: { id: string; content?: string; };
+  expiresAt?: Date;
+  approvedBy?: string;
+}): SarifActiveWaiver {
+  const result: SarifActiveWaiver = {
+    fingerprint: waiver.fingerprint,
+    feedbackId: waiver.feedback.id,
+    content: waiver.feedback.content ?? '',
+  };
+  if (waiver.expiresAt !== undefined) {
+    result.expiresAt = waiver.expiresAt.toISOString();
+  }
+  if (waiver.approvedBy !== undefined) {
+    result.approvedBy = waiver.approvedBy;
+  }
+  return result;
+}

--- a/packages/core/src/sarif/sarif_builder.ts
+++ b/packages/core/src/sarif/sarif_builder.ts
@@ -126,11 +126,12 @@ function buildInvocations(options: SarifBuilderOptions): SarifInvocation[] | und
 }
 
 class SarifBuilderImpl implements SarifBuilder {
-  private readonly ajv: Ajv;
+  private readonly validateFn: ReturnType<Ajv['compile']>;
 
   constructor() {
-    this.ajv = new Ajv({ allErrors: true, strict: false });
-    addFormats(this.ajv);
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    addFormats(ajv);
+    this.validateFn = ajv.compile(sarifSchema);
   }
 
   async build(options: SarifBuilderOptions): Promise<SarifLog> {
@@ -249,14 +250,13 @@ class SarifBuilderImpl implements SarifBuilder {
   }
 
   validate(sarif: SarifLog): ValidationResult {
-    const validate = this.ajv.compile(sarifSchema);
-    const valid = validate(sarif);
+    const valid = this.validateFn(sarif);
 
     if (valid) {
       return { valid: true };
     }
 
-    const errors = (validate.errors ?? []).map(
+    const errors = (this.validateFn.errors ?? []).map(
       (e) => `${e.instancePath || '/'} ${e.message ?? 'unknown error'}`
     );
 

--- a/packages/core/src/sarif/sarif_hash.test.ts
+++ b/packages/core/src/sarif/sarif_hash.test.ts
@@ -11,10 +11,14 @@ describe('SarifHash', () => {
 
     it('[SARIF-B1] normalizeLineContent: should trim leading and trailing whitespace', () => {
       expect(normalizeLineContent('  const x = 1;  ')).toBe('const x = 1;');
+      // Tabs are also whitespace
+      expect(normalizeLineContent('\tconst x = 1;\t')).toBe('const x = 1;');
     });
 
     it('[SARIF-B2] normalizeLineContent: should collapse multiple spaces to single space', () => {
       expect(normalizeLineContent('const  x =   1;')).toBe('const x = 1;');
+      // Mixed whitespace (tabs + spaces) collapsed
+      expect(normalizeLineContent('const\t\tx =\t  1;')).toBe('const x = 1;');
     });
 
     it('[SARIF-B3] computePrimaryLocationLineHash: should return string matching format hexHash:N', () => {
@@ -34,6 +38,10 @@ describe('SarifHash', () => {
       const context = createOccurrenceContext();
       const result = await buildPartialFingerprints('src/file.ts', 10, async () => null, context);
       expect(result).toEqual({});
+      // Empty string is NOT null — produces a real fingerprint (empty line is still a line)
+      const ctxEmpty = createOccurrenceContext();
+      const emptyResult = await buildPartialFingerprints('src/file.ts', 10, async () => '', ctxEmpty);
+      expect(emptyResult['primaryLocationLineHash/v1']).toMatch(/^[0-9a-f]{16}:1$/);
     });
 
     it('[SARIF-B5] buildPartialFingerprints: should return empty object when getLineContent is undefined', async () => {

--- a/packages/core/src/sarif/sarif_hash.test.ts
+++ b/packages/core/src/sarif/sarif_hash.test.ts
@@ -1,0 +1,81 @@
+// All EARS prefixes map to sarif_module.md
+import {
+  normalizeLineContent,
+  computePrimaryLocationLineHash,
+  buildPartialFingerprints,
+  createOccurrenceContext,
+} from './sarif_hash';
+
+describe('SarifHash', () => {
+  describe('4.2. Hash centralizado (SARIF-B1 a B8)', () => {
+
+    it('[SARIF-B1] normalizeLineContent: should trim leading and trailing whitespace', () => {
+      expect(normalizeLineContent('  const x = 1;  ')).toBe('const x = 1;');
+    });
+
+    it('[SARIF-B2] normalizeLineContent: should collapse multiple spaces to single space', () => {
+      expect(normalizeLineContent('const  x =   1;')).toBe('const x = 1;');
+    });
+
+    it('[SARIF-B3] computePrimaryLocationLineHash: should return string matching format hexHash:N', () => {
+      const result = computePrimaryLocationLineHash('const x = 1;', 1);
+      expect(result).toMatch(/^[0-9a-f]{16}:1$/);
+      // Verify deterministic SHA256: different input must produce different hash
+      const other = computePrimaryLocationLineHash('const y = 2;', 1);
+      expect(other).toMatch(/^[0-9a-f]{16}:1$/);
+      expect(other.split(':')[0]).not.toBe(result.split(':')[0]);
+      // Verify occurrence is embedded correctly
+      const withOcc3 = computePrimaryLocationLineHash('const x = 1;', 3);
+      expect(withOcc3).toMatch(/^[0-9a-f]{16}:3$/);
+      expect(withOcc3.split(':')[0]).toBe(result.split(':')[0]);
+    });
+
+    it('[SARIF-B4] buildPartialFingerprints: should return empty object when getLineContent returns null', async () => {
+      const context = createOccurrenceContext();
+      const result = await buildPartialFingerprints('src/file.ts', 10, async () => null, context);
+      expect(result).toEqual({});
+    });
+
+    it('[SARIF-B5] buildPartialFingerprints: should return empty object when getLineContent is undefined', async () => {
+      const context = createOccurrenceContext();
+      const result = await buildPartialFingerprints('src/file.ts', 10, undefined, context);
+      expect(result).toEqual({});
+    });
+
+    it('[SARIF-B6] buildPartialFingerprints: second finding with same line content should have occurrence=2', async () => {
+      const context = createOccurrenceContext();
+      const getLineContent = async (_file: string, _line: number) => 'const email = user.email;';
+
+      const first = await buildPartialFingerprints('src/file.ts', 5, getLineContent, context);
+      const second = await buildPartialFingerprints('src/file.ts', 10, getLineContent, context);
+
+      expect(first['primaryLocationLineHash/v1']).toMatch(/:1$/);
+      expect(second['primaryLocationLineHash/v1']).toMatch(/:2$/);
+    });
+
+    it('[SARIF-B7] buildPartialFingerprints: separate contexts for different files should each start at occurrence=1', async () => {
+      const getLineContent = async () => 'const email = user.email;';
+      const ctxFileA = createOccurrenceContext();
+      const ctxFileB = createOccurrenceContext();
+
+      const resultA = await buildPartialFingerprints('src/a.ts', 5, getLineContent, ctxFileA);
+      const resultB = await buildPartialFingerprints('src/b.ts', 5, getLineContent, ctxFileB);
+
+      expect(resultA['primaryLocationLineHash/v1']).toMatch(/:1$/);
+      expect(resultB['primaryLocationLineHash/v1']).toMatch(/:1$/);
+      expect(resultA['primaryLocationLineHash/v1']).toBe(resultB['primaryLocationLineHash/v1']);
+    });
+
+    it('[SARIF-B8] buildPartialFingerprints: same input should produce same hash (determinism)', async () => {
+      const getLine = async () => 'const email = user.email;';
+
+      const ctx1 = createOccurrenceContext();
+      const ctx2 = createOccurrenceContext();
+
+      const r1 = await buildPartialFingerprints('src/file.ts', 5, getLine, ctx1);
+      const r2 = await buildPartialFingerprints('src/file.ts', 5, getLine, ctx2);
+
+      expect(r1['primaryLocationLineHash/v1']).toBe(r2['primaryLocationLineHash/v1']);
+    });
+  });
+});

--- a/packages/core/src/sarif/sarif_hash.ts
+++ b/packages/core/src/sarif/sarif_hash.ts
@@ -1,0 +1,75 @@
+import { createHash } from 'node:crypto';
+import type { GetLineContentFn, OccurrenceContext } from './sarif.types';
+
+/**
+ * Normalizes line content for stable hashing.
+ * - Trims leading/trailing whitespace
+ * - Collapses consecutive whitespace to a single space
+ * @param line - Raw line content
+ * @returns Normalized line (deterministic)
+ */
+export function normalizeLineContent(line: string): string {
+  return line.trim().replace(/\s+/g, ' ');
+}
+
+/**
+ * Computes the primaryLocationLineHash for a normalized line.
+ * Format: "hexHash:occurrence" (e.g., "39fa2ee980eb94b0:1")
+ * Uses first 16 hex chars of SHA256 for compactness.
+ *
+ * @param normalizedLine - Line content after normalizeLineContent()
+ * @param occurrence - 1-based counter for same hash in same file
+ * @returns Hash string in format "hexHash:occurrence"
+ */
+export function computePrimaryLocationLineHash(
+  normalizedLine: string,
+  occurrence: number
+): string {
+  const hash = createHash('sha256').update(normalizedLine, 'utf8').digest('hex').slice(0, 16);
+  return `${hash}:${occurrence}`;
+}
+
+/**
+ * Builds partialFingerprints for a finding by fetching line content.
+ * Returns an empty object if getLineContent is not provided or returns null.
+ *
+ * IMPORTANT: The `context` parameter MUST be shared across all findings
+ * within the same file to correctly track occurrence counts.
+ *
+ * @param file - File path
+ * @param line - 1-based line number
+ * @param getLineContent - Callback to get line content
+ * @param context - Shared occurrence context for this file
+ * @returns Record with "primaryLocationLineHash/v1" or empty object
+ */
+export async function buildPartialFingerprints(
+  file: string,
+  line: number,
+  getLineContent: GetLineContentFn | undefined,
+  context: OccurrenceContext
+): Promise<Record<string, string>> {
+  if (!getLineContent) {
+    return {};
+  }
+
+  const rawContent = await getLineContent(file, line);
+  if (rawContent === null) {
+    return {};
+  }
+
+  const normalized = normalizeLineContent(rawContent);
+  const current = context.get(normalized) ?? 0;
+  const occurrence = current + 1;
+  context.set(normalized, occurrence);
+
+  const hash = computePrimaryLocationLineHash(normalized, occurrence);
+  return { 'primaryLocationLineHash/v1': hash };
+}
+
+/**
+ * Creates a new OccurrenceContext for a file.
+ * Must be created per-file, not shared across files.
+ */
+export function createOccurrenceContext(): OccurrenceContext {
+  return new Map<string, number>();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
+      ajv-draft-04:
+        specifier: ^1.0.0
+        version: 1.0.0(ajv@8.17.1)
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.17.1)
@@ -1576,6 +1579,14 @@ packages:
     resolution: {integrity: sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==}
     engines: {node: '>=18'}
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -2435,7 +2446,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globby@14.1.0:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
@@ -5714,6 +5725,10 @@ snapshots:
     dependencies:
       clean-stack: 5.3.0
       indent-string: 5.0.0
+
+  ajv-draft-04@1.0.0(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:


### PR DESCRIPTION
## Summary

#108 

Creates `@gitgov/core/sarif` — the canonical SARIF 2.1.0 module for GitGovernance:

- **SarifBuilder** (`createSarifBuilder()`): builds SARIF 2.1.0 logs from `Finding[]` with GitGov governance property bags
- **sarif_hash**: content-based `primaryLocationLineHash/v1` — stable fingerprints that survive line insertions
- **Suppressions**: maps FeedbackRecord waivers to native SARIF suppressions (`kind: "inSource"`)
- **Invocations**: correlates SARIF runs with ExecutionRecord metadata
- **Validation**: embedded OASIS Errata 01 JSON Schema via ajv
- **toSarifWaiver**: maps `ActiveWaiver` to `SarifActiveWaiver`

## Metrics

- **38 EARS** formal requirements (A1-A3, B1-B8, C1-C8, D1-D5, E1-E4, F1-F5, G1-G3, J1, K1-K4)
- **41 tests**, 100% EARS coverage, all real assertions (no trivial/empty)
- **8 parallel audits** passed (ears, coverage, coherence x2 modules)
- **73/73 acceptance criteria** verified by `/audit-cycle`
- `tsc --noEmit`: clean
- `jest src/sarif/`: 41/41 pass

## Files

```
packages/core/src/sarif/
├── index.ts               — public exports
├── sarif.types.ts         — SarifLog, SarifResult, SarifActiveWaiver, etc.
├── sarif_builder.ts       — SarifBuilderImpl + createSarifBuilder + toSarifWaiver
├── sarif_builder.test.ts  — 33 tests (A, C, D, E, F, G, J, K blocks)
├── sarif_hash.ts          — normalizeLineContent, computePrimaryLocationLineHash
├── sarif_hash.test.ts     — 8 tests (B block)
└── fixtures/
    └── sarif-schema-2.1.0.json  — OASIS Errata 01 schema
```

## Key decisions

| Decision | Resolution |
|---|---|
| Fingerprint algorithm | `primaryLocationLineHash/v1` (SHA256 of normalized line content + occurrence counter) |
| Waiver → Suppression | `kind: "inSource"`, `status: "accepted"`, traceability via `gitgov/feedbackId` |
| Factory pattern | `createSarifBuilder()` pre-compiles ajv schema (~50ms), reusable across calls |
| Redaction | Tag only (`gitgov/redactionLevel`), actual redaction delegated to separate module |
| Sequential processing | Findings processed in order (not `Promise.all`) to maintain occurrence counters |

## Test plan

- [x] `pnpm --filter @gitgov/core exec tsc --noEmit` — 0 errors
- [x] `pnpm --filter @gitgov/core test -- src/sarif/` — 41/41 pass
- [x] `/audit sarif_builder sarif_hash` — 8 audits, 0 findings after fixes
- [x] `/audit-cycle sarif_compliance_spec 1` — 73/73 criteria pass
- [ ] CI pipeline