### PR TITLE
chore(core): remove FsSyncStateModule legacy references

### DIFF
--- a/packages/core/src/sync_state/fs_worktree/fs_worktree_sync_state.ts
+++ b/packages/core/src/sync_state/fs_worktree/fs_worktree_sync_state.ts
@@ -38,7 +38,7 @@ import { promises as fsPromises, existsSync } from 'fs';
 const logger = createLogger('[WorktreeSyncState] ');
 
 // ═══════════════════════════════════════════════════════════
-// Standalone helpers (same logic as FsSyncStateModule)
+// Standalone helpers for worktree sync operations
 // ═══════════════════════════════════════════════════════════
 
 /**

--- a/packages/core/src/sync_state/fs_worktree/fs_worktree_sync_state.types.ts
+++ b/packages/core/src/sync_state/fs_worktree/fs_worktree_sync_state.types.ts
@@ -1,7 +1,7 @@
 import type { SyncStateModuleDependencies } from '../sync_state.types';
 
 /**
- * Reutiliza las mismas dependencias que FsSyncStateModule.
+ * Worktree-based sync state dependencies.
  * No requiere dependencias adicionales.
  */
 export type FsWorktreeSyncStateDependencies = SyncStateModuleDependencies;

--- a/packages/core/src/sync_state/sync_state.ts
+++ b/packages/core/src/sync_state/sync_state.ts
@@ -3,8 +3,8 @@
  *
  * Defines the contract for state synchronization between local working tree
  * and a shared state branch. Implementations handle the I/O specifics:
- * - FsSyncStateModule: Uses local filesystem + git CLI (packages/core/src/sync_state/fs/)
- * - GithubSyncStateModule: Uses GitHub API via Octokit (packages/core/src/sync_state/github_sync_state/)
+ * - FsWorktreeSyncStateModule: Uses worktree path (~/.gitgov/worktrees/) + git CLI
+ * - GithubSyncStateModule: Uses GitHub API via Octokit
  *
  * @module sync_state
  */


### PR DESCRIPTION
Comment cleanup — 3 files, 4 lines changed. Removes references to deleted FsSyncStateModule.