### PR TITLE
docs: update public READMEs — test counts, protocol v1.1, new modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
-![License: Apache-2.0](https://img.shields.io/badge/Protocol-Apache--2.0-blue.svg)
-![License: MPL-2.0](https://img.shields.io/badge/Core-MPL--2.0-blue.svg)
-![core npm version](https://img.shields.io/npm/v/@gitgov/core?color=orange&label=Core%20npm)
-![Tests](https://img.shields.io/badge/Core-2628%20tests-success)
-![License: Apache-2.0](https://img.shields.io/badge/CLI-Apache--2.0-blue.svg)
-![cli npm version](https://img.shields.io/npm/v/@gitgov/cli?color=orange&label=CLI%20npm)
-![Tests](https://img.shields.io/badge/CLI-450%20tests-success)
-![License: Apache-2.0](https://img.shields.io/badge/MCP--Server-Apache--2.0-blue.svg)
-![Tests](https://img.shields.io/badge/MCP--Server-199%20tests-success)
-
 # GitGovernance
 
 **An Operating System for Intelligent Work, built on Git.**
@@ -67,12 +57,13 @@ Agent:  "Sprint is 70% done, 3 tasks active, 1 blocked."
 
 ## Packages
 
-| Package | License | Purpose | Documentation |
-|:--------|:--------|:--------|:--------------|
-| **Protocol** | Apache 2.0 | The **Standard** -- RFCs, schemas, and normative specifications. | [`protocol/`](packages/private/packages/blueprints/02_protocol/) |
-| **`@gitgov/core`** | MPL-2.0 | The **Engine** -- Type-safe SDK for business logic, records, validation, storage, adapters. | [`README.md`](packages/core/README.md) |
-| **`@gitgov/cli`** | Apache 2.0 | The **Tool** -- Command-line interface for humans and AI agents. | [`README.md`](packages/cli/README.md) |
-| **`@gitgov/mcp-server`** | Apache 2.0 | The **Bridge** -- MCP server exposing 43 tools for AI agents (Claude Code, Cursor, Windsurf). | [`README.md`](packages/mcp-server/README.md) |
+| Package | Version | Tests | License | Purpose |
+|:--------|:--------|------:|:--------|:--------|
+| **Protocol** | — | — | ![Apache-2.0](https://img.shields.io/badge/Apache--2.0-brightgreen.svg) | The **Standard** — RFCs, schemas, specifications |
+| [`@gitgov/core`](packages/core/README.md) | 2.10.1 | 2,568 | ![MPL-2.0](https://img.shields.io/badge/MPL--2.0-brightgreen.svg) | The **Engine** — SDK for records, validation, storage, adapters |
+| [`@gitgov/cli`](packages/cli/README.md) | 2.1.0 | 475 | ![Apache-2.0](https://img.shields.io/badge/Apache--2.0-brightgreen.svg) | The **Tool** — CLI for humans and AI agents |
+| [`@gitgov/mcp-server`](packages/mcp-server/README.md) | — | 199 | ![Apache-2.0](https://img.shields.io/badge/Apache--2.0-brightgreen.svg) | The **Bridge** — 43 MCP tools for AI agents |
+| [`@gitgov/e2e`](packages/e2e/README.md) | — | 36 | ![Apache-2.0](https://img.shields.io/badge/Apache--2.0-brightgreen.svg) | The **Validation** — Cross-package E2E tests (CLI + core + GitHub) |
 
 ## Community
 
@@ -86,8 +77,9 @@ Agent:  "Sprint is 70% done, 3 tasks active, 1 blocked."
 - **`@gitgov/core`**: [Mozilla Public License 2.0 (MPL-2.0)](https://opensource.org/licenses/MPL-2.0)
 - **`@gitgov/cli`**: [Apache License 2.0](https://opensource.org/licenses/Apache-2.0)
 - **`@gitgov/mcp-server`**: [Apache License 2.0](https://opensource.org/licenses/Apache-2.0)
+- **`@gitgov/e2e`**: [Apache License 2.0](https://opensource.org/licenses/Apache-2.0)
 
-The protocol specification is licensed permissively to maximize adoption as an open standard. The core SDK uses weak copyleft to protect shared improvements while allowing commercial integration. The CLI and MCP server are permissively licensed to maximize distribution as adoption tools.
+The protocol specification is licensed permissively to maximize adoption as an open standard. The core SDK uses weak copyleft to protect shared improvements while allowing commercial integration. The CLI, MCP server, and E2E tests are permissively licensed to maximize distribution as adoption tools.
 
 ---
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -145,7 +145,7 @@ graph LR
 |--------|----------|-----|
 | `@gitgov/core` | Interfaces, types, pure logic, factories, validators | No |
 | `@gitgov/core/fs` | Filesystem implementations (FsRecordStore, FsRecordProjection, LocalGitModule, FsLintModule, ...) | Local |
-| `@gitgov/core/github` | GitHub API implementations (GitHubRecordStore, GitHubGitModule, GitHubConfigStore, GitHubFileLister, GithubSyncStateModule) | Remote |
+| `@gitgov/core/github` | GitHub API implementations (GitHubRecordStore, GitHubGitModule, GitHubConfigStore, GitHubFileLister, GithubSyncStateModule, GithubWebhookHandler) | Remote |
 | `@gitgov/core/memory` | In-memory implementations for testing (MemoryRecordStore, MemoryRecordProjection, MemoryGitModule, ...) | No |
 | `@gitgov/core/prisma` | Database-backed implementations via Prisma-compatible client (PrismaRecordProjection) | Remote |
 
@@ -162,7 +162,7 @@ Every record type has 4 parallel artifacts:
 | Validator | `record_validations/` | Business rules on the record |
 | Schema | `record_schemas/generated/` | JSON Schema for AJV validation |
 
-The 8 records: **Actor, Agent, Task, Cycle, Execution, Changelog, Feedback, Workflow**
+The 6 records: **Actor, Agent, Task, Cycle, Execution, Feedback**
 
 ## Adapters
 
@@ -175,7 +175,6 @@ Adapters are orchestrators that compose modules. All receive dependencies via co
 | `BacklogAdapter` | Task and cycle lifecycle, workflow validation |
 | `ExecutionAdapter` | Execution audit log tracking |
 | `FeedbackAdapter` | Structured feedback and blocking resolution |
-| `ChangelogAdapter` | Automatic changelog entries |
 | `MetricsAdapter` | System status and productivity metrics |
 | `IndexerAdapter` | Local cache generation and integrity checks |
 | `WorkflowAdapter` | State transitions with signatures and custom rules |
@@ -196,7 +195,9 @@ Adapters are orchestrators that compose modules. All receive dependencies via co
 | `config_manager/` | Typed access to config.json (versioned in git) |
 | `session_store/` | Storage for .session.json |
 | `session_manager/` | Typed access to .session.json (ephemeral, not versioned) |
-| `sync_state/` | Push/pull/resolve synchronization state |
+| `sync_state/` | Push/pull/resolve synchronization (FsWorktreeSyncStateModule, GithubSyncStateModule, GithubWebhookHandler, PullScheduler) |
+| `record_projection/` | RecordProjector engine — generates IndexData, persists to sinks (FS, Prisma, Memory) |
+| `sarif/` | SarifBuilder — generates SARIF 2.1.0 with content-based fingerprints, suppressions, validation |
 | `git/` | `IGitModule` interface + local/memory implementations |
 | `crypto/` | Checksums, digital signatures, verification |
 | `key_provider/` | Key storage abstraction (fs/memory) |

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -78,7 +78,7 @@ Each block is independent and self-contained. No block depends on another having
 | B     | `projection.test.ts`       | CB1-CB8 | CLI + PostgreSQL          | Records projected to DB via RecordProjector                    |
 | C     | `github.test.ts`           | CC1-CC5 | GitHub token              | GitHubRecordStore against real GitHub API                      |
 | D     | `cross_path.test.ts`       | CD1-CD5 | CLI + PostgreSQL + GitHub | Records created by CLI readable via GitHub and vice versa      |
-| E     | `parity.test.ts`           | CE1     | CLI + PostgreSQL          | FS projection vs Prisma projection produce identical IndexData |
+| E     | `parity.test.ts`           | CE1-CE2 | CLI + PostgreSQL + GitHub | FS vs Prisma parity (CE1) + FS vs GitHub parity (CE2)         |
 | F     | `change_detection.test.ts` | CF1-CF7 | CLI + PostgreSQL + GitHub | GithubSyncStateModule: delta detection, pushState, concurrency, audit |
 
 ## Architecture


### PR DESCRIPTION
## Summary

Updates public READMEs to reflect changes from PRs #93-#112:

- **README.md**: Core 2628→2568 tests, CLI 450→475 tests (badge accuracy)
- **core/README.md**: 6 active records (Changelog+Workflow deprecated), +GithubWebhookHandler, +record_projection, +sarif modules
- **e2e/README.md**: Block E CE1→CE1-CE2, Block F description updated

## Test plan

- [ ] No code changes — documentation only