### PR TITLE
feat(core/agents): Audit Orchestration — Cycle 1

### DIFF
--- a/packages/agents/security-audit/agent-record.example.json
+++ b/packages/agents/security-audit/agent-record.example.json
@@ -1,0 +1,27 @@
+{
+  "header": {
+    "version": "1.0",
+    "type": "agent",
+    "payloadChecksum": "",
+    "signatures": []
+  },
+  "payload": {
+    "id": "agent:gitgov:security-audit",
+    "status": "active",
+    "engine": {
+      "type": "local",
+      "entrypoint": "packages/agents/security-audit/dist/index.mjs",
+      "function": "runAgent"
+    },
+    "triggers": [{ "type": "manual" }],
+    "metadata": {
+      "purpose": "audit",
+      "description": "Security audit: PII, secrets, API keys",
+      "audit": {
+        "target": "code",
+        "outputFormat": "sarif",
+        "supportedScopes": ["diff", "full", "baseline"]
+      }
+    }
+  }
+}

--- a/packages/agents/security-audit/agent.test.ts
+++ b/packages/agents/security-audit/agent.test.ts
@@ -1,0 +1,186 @@
+import { runAgent } from './src/agent';
+import { DEFAULT_CONFIG } from './src/config';
+
+type SarifLog = {
+  $schema: string;
+  version: '2.1.0';
+  runs: Array<{
+    tool: { driver: { name: string; version: string; informationUri: string; rules: unknown[] } };
+    results: unknown[];
+  }>;
+};
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockAuditResult = {
+  findings: [
+    {
+      id: 'f1',
+      ruleId: 'PII-001',
+      category: 'pii-email' as const,
+      severity: 'high' as const,
+      file: 'src/app.ts',
+      line: 10,
+      snippet: 'const email = "user@test.com"',
+      message: 'Hardcoded email address detected',
+      detector: 'regex' as const,
+      fingerprint: 'abc123',
+      confidence: 0.95,
+    },
+  ],
+  summary: {
+    total: 1,
+    bySeverity: { critical: 0, high: 1, medium: 0, low: 0, info: 0 },
+    byCategory: { 'pii-email': 1 },
+    byDetector: { regex: 1, heuristic: 0, llm: 0 },
+  },
+  scannedFiles: 5,
+  scannedLines: 200,
+  duration: 42,
+  detectors: ['regex' as const],
+  waivers: { acknowledged: 0, new: 1 },
+};
+
+const mockAuditFn = jest.fn().mockResolvedValue(mockAuditResult);
+
+// Mock @gitgov/core
+jest.mock('@gitgov/core', () => ({
+  SourceAuditor: {
+    SourceAuditorModule: jest.fn().mockImplementation(() => ({
+      audit: mockAuditFn,
+    })),
+  },
+  FindingDetector: {
+    FindingDetectorModule: jest.fn().mockImplementation(() => ({})),
+  },
+  Sarif: {
+    createSarifBuilder: jest.fn().mockReturnValue({
+      build: jest.fn().mockImplementation(async (opts: Record<string, unknown>) => ({
+        $schema: 'https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json',
+        version: '2.1.0' as const,
+        runs: [{
+          tool: {
+            driver: {
+              name: opts['toolName'] as string,
+              version: opts['toolVersion'] as string,
+              informationUri: opts['informationUri'] as string,
+              rules: [],
+            },
+          },
+          results: [],
+        }],
+      })),
+    }),
+  },
+}));
+
+// Mock @gitgov/core/fs
+jest.mock('@gitgov/core/fs', () => ({
+  findProjectRoot: jest.fn().mockReturnValue('/mock/project'),
+  FsFileLister: jest.fn().mockImplementation(() => ({})),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function createCtx(input: Record<string, unknown>) {
+  return {
+    agentId: 'agent:gitgov:security-audit',
+    actorId: 'actor:agent:security-audit',
+    taskId: 'task-001',
+    runId: 'run-001',
+    input,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SecurityAuditAgent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('4.1. Agent Execution (AORCH-B9)', () => {
+    it('[AORCH-B9] should run SourceAuditorModule.audit() with scope from ctx.input', async () => {
+      const ctx = createCtx({
+        scope: 'diff',
+        include: ['src/**/*.ts'],
+        exclude: ['**/*.test.ts'],
+        taskId: 'task-001',
+      });
+
+      await runAgent(ctx);
+
+      // Verify SourceAuditorModule was instantiated
+      const { SourceAuditor } = jest.requireMock('@gitgov/core') as {
+        SourceAuditor: { SourceAuditorModule: jest.Mock };
+      };
+      expect(SourceAuditor.SourceAuditorModule).toHaveBeenCalledTimes(1);
+
+      // Verify audit() was called with the correct scope from input
+      expect(mockAuditFn).toHaveBeenCalledTimes(1);
+      const auditOptions = mockAuditFn.mock.calls[0]![0] as {
+        baseDir: string;
+        scope: { include: string[]; exclude: string[] };
+      };
+      expect(auditOptions.scope.include).toEqual(['src/**/*.ts']);
+      expect(auditOptions.scope.exclude).toEqual(['**/*.test.ts']);
+    });
+  });
+
+  describe('4.2. SARIF Output (AORCH-B10)', () => {
+    it('[AORCH-B10] should return AgentOutput with metadata.kind sarif and valid SarifLog', async () => {
+      const ctx = createCtx({
+        scope: 'full',
+        taskId: 'task-002',
+      });
+
+      const output = await runAgent(ctx);
+
+      // Verify metadata shape
+      expect(output.metadata).toBeDefined();
+      expect(output.metadata!['kind']).toBe('sarif');
+      expect(output.metadata!['version']).toBe('2.1.0');
+
+      // Verify data is a valid SarifLog structure
+      const sarifLog = output.metadata!['data'] as SarifLog;
+      expect(sarifLog.version).toBe('2.1.0');
+      expect(sarifLog.$schema).toContain('sarif-schema-2.1.0');
+      expect(Array.isArray(sarifLog.runs)).toBe(true);
+      expect(sarifLog.runs.length).toBeGreaterThan(0);
+
+      // Verify message is present
+      expect(output.message).toContain('Security audit completed');
+    });
+  });
+
+  describe('4.3. Internal Configuration (AORCH-B11)', () => {
+    it('[AORCH-B11] should use detectors from internal config.ts without external --detector param', async () => {
+      // Input has NO detector field — only scope and taskId
+      const ctx = createCtx({
+        scope: 'diff',
+        taskId: 'task-003',
+      });
+
+      await runAgent(ctx);
+
+      // Verify FindingDetectorModule was created with the internal config
+      const { FindingDetector } = jest.requireMock('@gitgov/core') as {
+        FindingDetector: { FindingDetectorModule: jest.Mock };
+      };
+      expect(FindingDetector.FindingDetectorModule).toHaveBeenCalledTimes(1);
+      expect(FindingDetector.FindingDetectorModule).toHaveBeenCalledWith(
+        DEFAULT_CONFIG.detectorConfig
+      );
+
+      // Verify audit was still called (agent works without external detector config)
+      expect(mockAuditFn).toHaveBeenCalledTimes(1);
+
+      // Verify default include/exclude from config were used (no include/exclude in input)
+      const auditOptions = mockAuditFn.mock.calls[0]![0] as {
+        scope: { include: string[]; exclude: string[] };
+      };
+      expect(auditOptions.scope.include).toEqual(DEFAULT_CONFIG.defaultInclude);
+      expect(auditOptions.scope.exclude).toEqual(DEFAULT_CONFIG.defaultExclude);
+    });
+  });
+});

--- a/packages/agents/security-audit/jest.config.cjs
+++ b/packages/agents/security-audit/jest.config.cjs
@@ -1,0 +1,11 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  testTimeout: 30000,
+  moduleNameMapper: {
+    '^@gitgov/core$': '<rootDir>/node_modules/@gitgov/core/dist/src/index.js',
+    '^@gitgov/core/fs$': '<rootDir>/node_modules/@gitgov/core/dist/src/fs.js',
+  },
+};

--- a/packages/agents/security-audit/package.json
+++ b/packages/agents/security-audit/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@gitgov/agent-security-audit",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.mjs",
+  "scripts": {
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.mjs --external:@gitgov/core",
+    "clean": "rm -rf dist",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@gitgov/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.0.0",
+    "@types/node": "^20.0.0",
+    "esbuild": "^0.19.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/agents/security-audit/src/agent.ts
+++ b/packages/agents/security-audit/src/agent.ts
@@ -1,0 +1,127 @@
+import {
+  SourceAuditor,
+  FindingDetector,
+  Sarif,
+} from '@gitgov/core';
+import {
+  findProjectRoot,
+  FsFileLister,
+} from '@gitgov/core/fs';
+import { DEFAULT_CONFIG } from './config';
+
+type SarifLog = Sarif.SarifLog;
+
+/**
+ * Input received via ctx.input, constructed by AuditOrchestrator.
+ */
+type SecurityAuditInput = {
+  /** Scan scope: diff (changed files), full (all files), baseline (full + save) */
+  scope: 'diff' | 'full' | 'baseline';
+  /** Glob patterns to include in scan */
+  include?: string[];
+  /** Glob patterns to exclude from scan */
+  exclude?: string[];
+  /** TaskRecord ID for traceability */
+  taskId: string;
+};
+
+/**
+ * Execution context passed to the agent by AgentRunner.
+ */
+type AgentExecutionContext = {
+  agentId: string;
+  actorId: string;
+  taskId: string;
+  runId: string;
+  input?: unknown;
+};
+
+/**
+ * Structured output returned by the agent.
+ */
+type AgentOutput = {
+  data?: unknown;
+  message?: string;
+  artifacts?: string[];
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Entry point of the security-audit agent.
+ *
+ * Executes SourceAuditorModule with the scope received from the orchestrator
+ * and returns a SARIF 2.1.0 log as output metadata.
+ *
+ * The agent does NOT apply waivers — the orchestrator handles that
+ * post-consolidation.
+ *
+ * @param ctx - Execution context provided by AgentRunner
+ * @returns AgentOutput with metadata.kind === 'sarif' and metadata.data containing SarifLog
+ */
+export async function runAgent(
+  ctx: AgentExecutionContext
+): Promise<AgentOutput> {
+  // Step 1: Cast input
+  const input = ctx.input as SecurityAuditInput;
+
+  // Step 2: Load internal config (AORCH-B11 — no external --detector param)
+  const config = DEFAULT_CONFIG;
+
+  // Step 3: Map input to SourceAuditor options
+  const projectRoot = findProjectRoot() || process.cwd();
+  const include = input.include ?? config.defaultInclude;
+  const exclude = input.exclude ?? config.defaultExclude;
+
+  // Step 4: Create dependencies and run audit (AORCH-B9)
+  const findingDetector = new FindingDetector.FindingDetectorModule(
+    config.detectorConfig
+  );
+
+  const fileLister = new FsFileLister({ cwd: projectRoot });
+
+  const noOpWaiverReader: SourceAuditor.IWaiverReader = {
+    loadActiveWaivers: async () => [],
+    hasActiveWaiver: async () => false,
+  };
+
+  const sourceAuditor = new SourceAuditor.SourceAuditorModule({
+    findingDetector,
+    waiverReader: noOpWaiverReader,
+    fileLister,
+  });
+
+  const auditResult = await sourceAuditor.audit({
+    baseDir: projectRoot,
+    scope: {
+      include,
+      exclude,
+    },
+  });
+
+  // Step 5: Build SARIF from findings (AORCH-B10)
+  const sarifBuilder = Sarif.createSarifBuilder();
+
+  const sarifLog: SarifLog = await sarifBuilder.build({
+    toolName: 'gitgov-security-audit',
+    toolVersion: '1.0.0',
+    informationUri: 'https://gitgovernance.com/agents/security-audit',
+    findings: auditResult.findings,
+    taskId: input.taskId,
+    agentId: ctx.agentId,
+    scanScope: input.scope,
+    scannedFiles: auditResult.scannedFiles,
+    scannedLines: auditResult.scannedLines,
+  });
+
+  // Step 6: Return AgentOutput with SARIF metadata
+  const findingsCount = auditResult.findings.length;
+
+  return {
+    message: `Security audit completed: ${findingsCount} finding(s) in ${auditResult.scannedFiles} files`,
+    metadata: {
+      kind: 'sarif',
+      version: '2.1.0',
+      data: sarifLog,
+    },
+  };
+}

--- a/packages/agents/security-audit/src/config.ts
+++ b/packages/agents/security-audit/src/config.ts
@@ -1,0 +1,50 @@
+import type { FindingDetector } from '@gitgov/core';
+
+type FindingDetectorConfig = FindingDetector.FindingDetectorConfig;
+
+/**
+ * Internal detector configuration for the security-audit agent.
+ * Defines which detectors are enabled and their settings.
+ *
+ * This config is NOT received as an external parameter.
+ * The agent always uses this internal config (AORCH-B11).
+ */
+
+export type DetectorStage = {
+  detector: 'regex' | 'heuristic' | 'llm';
+  conditional: boolean;
+};
+
+export type SecurityAuditConfig = {
+  /** Ordered pipeline of detector stages */
+  pipeline: DetectorStage[];
+  /** FindingDetectorConfig for SourceAuditorModule */
+  detectorConfig: FindingDetectorConfig;
+  /** Default exclude patterns for file scanning */
+  defaultExclude: string[];
+  /** Default include patterns for file scanning */
+  defaultInclude: string[];
+};
+
+/**
+ * Default configuration for MVP.
+ * Only regex detector enabled — heuristic and llm stages come in Epic 3.
+ */
+export const DEFAULT_CONFIG: SecurityAuditConfig = {
+  pipeline: [
+    { detector: 'regex', conditional: false },
+  ],
+  detectorConfig: {
+    regex: { enabled: true },
+  },
+  defaultExclude: [
+    '**/node_modules/**',
+    '**/.git/**',
+    '**/dist/**',
+    '**/build/**',
+    '**/*.min.js',
+    '**/package-lock.json',
+    '**/pnpm-lock.yaml',
+  ],
+  defaultInclude: ['**/*'],
+};

--- a/packages/agents/security-audit/src/index.ts
+++ b/packages/agents/security-audit/src/index.ts
@@ -1,0 +1,1 @@
+export { runAgent } from './agent';

--- a/packages/agents/security-audit/tsconfig.json
+++ b/packages/agents/security-audit/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src", "agent.test.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -208,6 +208,9 @@ Adapters are orchestrators that compose modules. All receive dependencies via co
 | `project_initializer/` | GitGovernance project setup |
 | `finding_detector/` | Finding detection (regex, heuristic, LLM) |
 | `source_auditor/` | Cross-system audit (code, Jira, gitgov) |
+| `sarif/` | SARIF 2.1.0 builder, hash, validation (42 EARS) |
+| `audit_orchestrator/` | Multi-agent audit orchestration, SARIF consolidation, waiver application (10 EARS) |
+| `policy_evaluator/` | Pass/block evaluation by severity threshold (stub — Epic 5 formalizes) |
 | `diagram_generator/` | Mermaid diagram generation |
 | `logger/` | Centralized logging |
 | `utils/` | ID generation/parsing, array utils, signature utils |

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.test.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.test.ts
@@ -1,0 +1,677 @@
+import { createAuditOrchestrator } from "./audit_orchestrator";
+import type {
+  AuditOrchestratorDeps,
+  AuditOrchestrationOptions,
+  PolicyDecisionStub,
+} from "./audit_orchestrator.types";
+import type { SarifLog, SarifResult } from "../sarif/sarif.types";
+import type { RecordStore } from "../record_store/record_store";
+import type { GitGovAgentRecord } from "../record_types";
+import type { IAgentRunner } from "../agent_runner/agent_runner";
+import type { RunOptions, AgentResponse } from "../agent_runner/agent_runner.types";
+import type { IWaiverReader, ActiveWaiver } from "../source_auditor/types";
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+/**
+ * Creates a valid SarifLog with given results.
+ * Uses `as SarifResult[]` to bypass strict SarifResultProperties typing
+ * since tests use arbitrary property values.
+ */
+function makeSarifLog(results: Record<string, unknown>[] = []): SarifLog {
+  return {
+    $schema:
+      "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
+    version: "2.1.0",
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: "test-tool",
+            version: "1.0.0",
+            informationUri: "https://example.com",
+          },
+        },
+        results: results as SarifResult[],
+      },
+    ],
+  };
+}
+
+function makeAgentRecord(
+  id: string,
+  purpose: string,
+): GitGovAgentRecord {
+  return {
+    header: {
+      version: "1.0",
+      type: "agent",
+      payloadChecksum: "abc123",
+      signatures: [
+        {
+          keyId: "agent:test",
+          role: "author",
+          notes: "test signature",
+          signature: "dGVzdA==".padEnd(88, "="),
+          timestamp: Date.now(),
+        },
+      ],
+    },
+    payload: {
+      id,
+      engine: { type: "local" },
+      metadata: { purpose },
+    },
+  };
+}
+
+function makeAgentResponse(
+  agentId: string,
+  sarif: SarifLog,
+  executionRecordId: string = "exec-001",
+): AgentResponse {
+  return {
+    runId: "run-" + agentId,
+    agentId,
+    status: "success",
+    output: {
+      message: "Scan completed",
+      metadata: {
+        kind: "sarif",
+        version: "2.1.0",
+        data: sarif,
+      },
+    },
+    executionRecordId,
+    startedAt: new Date().toISOString(),
+    completedAt: new Date().toISOString(),
+    durationMs: 100,
+  };
+}
+
+function makePolicyStub(
+  decision: "pass" | "block" = "pass",
+  reason: string = "No issues",
+): PolicyDecisionStub {
+  return {
+    decision,
+    reason,
+    executionRecordId: "exec-policy-001",
+  };
+}
+
+function createMockDeps(overrides?: Partial<AuditOrchestratorDeps>): AuditOrchestratorDeps {
+  const recordStore: RecordStore<GitGovAgentRecord> = {
+    list: jest.fn().mockResolvedValue([]),
+    get: jest.fn().mockResolvedValue(null),
+    put: jest.fn().mockResolvedValue(undefined),
+    putMany: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+    exists: jest.fn().mockResolvedValue(false),
+  };
+
+  const agentRunner: IAgentRunner = {
+    runOnce: jest.fn().mockResolvedValue(makeAgentResponse("test", makeSarifLog())),
+  };
+
+  const waiverReader: IWaiverReader = {
+    loadActiveWaivers: jest.fn().mockResolvedValue([]),
+    hasActiveWaiver: jest.fn().mockResolvedValue(false),
+  };
+
+  const policyEvaluator = {
+    evaluate: jest.fn().mockResolvedValue(makePolicyStub()),
+  };
+
+  return {
+    recordStore,
+    agentRunner,
+    waiverReader,
+    policyEvaluator,
+    ...overrides,
+  };
+}
+
+const defaultOptions: AuditOrchestrationOptions = {
+  scope: "full",
+  taskId: "1234567890-task-test",
+};
+
+function makeSarifResult(overrides: {
+  ruleId: string;
+  level: "error" | "warning" | "note" | "none";
+  message: string;
+  file: string;
+  startLine: number;
+  fingerprint?: string;
+  category?: string;
+}): Record<string, unknown> {
+  const result: Record<string, unknown> = {
+    ruleId: overrides.ruleId,
+    level: overrides.level,
+    message: { text: overrides.message },
+    locations: [
+      {
+        physicalLocation: {
+          artifactLocation: { uri: overrides.file },
+          region: { startLine: overrides.startLine },
+        },
+      },
+    ],
+    properties: {
+      "gitgov/category": overrides.category ?? "unknown-risk",
+      "gitgov/detector": "regex",
+      "gitgov/confidence": 0.9,
+    },
+  };
+
+  if (overrides.fingerprint) {
+    result["partialFingerprints"] = {
+      "primaryLocationLineHash/v1": overrides.fingerprint,
+    };
+  }
+
+  return result;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("AuditOrchestrator", () => {
+  describe("4.1. Agent Discovery (AORCH-A1)", () => {
+    it("[AORCH-A1] should pass scope, include, exclude, and taskId in ctx.input to AgentRunner", async () => {
+      const agentRecord = makeAgentRecord("agent:security-audit", "audit");
+      const sarif = makeSarifLog();
+
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue(["agent:security-audit"]);
+      (deps.recordStore.get as jest.Mock).mockResolvedValue(agentRecord);
+      (deps.agentRunner.runOnce as jest.Mock).mockResolvedValue(
+        makeAgentResponse("agent:security-audit", sarif, "exec-scan-001"),
+      );
+
+      const orchestrator = createAuditOrchestrator(deps);
+      await orchestrator.run({
+        scope: "diff",
+        include: ["src/**/*.ts"],
+        exclude: ["node_modules/**"],
+        taskId: "1234567890-task-audit",
+      });
+
+      expect(deps.agentRunner.runOnce).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "agent:security-audit",
+          taskId: "1234567890-task-audit",
+          input: {
+            scope: "diff",
+            include: ["src/**/*.ts"],
+            exclude: ["node_modules/**"],
+            taskId: "1234567890-task-audit",
+          },
+        }),
+      );
+    });
+  });
+
+  describe("4.2. Agent Execution (AORCH-B1 to B5, B8)", () => {
+    it("[AORCH-B1] should read AgentRecords from RecordStore and filter by metadata.purpose === audit", async () => {
+      const auditAgent = makeAgentRecord("agent:security-audit", "audit");
+      const nonAuditAgent = makeAgentRecord("agent:deployment", "deploy");
+
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue([
+        "agent:security-audit",
+        "agent:deployment",
+      ]);
+      (deps.recordStore.get as jest.Mock).mockImplementation(async (id: string) => {
+        if (id === "agent:security-audit") return auditAgent;
+        if (id === "agent:deployment") return nonAuditAgent;
+        return null;
+      });
+      (deps.agentRunner.runOnce as jest.Mock).mockResolvedValue(
+        makeAgentResponse("agent:security-audit", makeSarifLog(), "exec-001"),
+      );
+
+      const orchestrator = createAuditOrchestrator(deps);
+      const result = await orchestrator.run(defaultOptions);
+
+      // Only the audit agent should be executed
+      expect(deps.agentRunner.runOnce).toHaveBeenCalledTimes(1);
+      expect(deps.agentRunner.runOnce).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "agent:security-audit" }),
+      );
+      expect(result.agentResults).toHaveLength(1);
+      const firstResult = result.agentResults[0]!;
+      expect(firstResult).toBeDefined();
+      expect(firstResult.agentId).toBe("agent:security-audit");
+    });
+
+    it("[AORCH-B2] should filter discovered agents to only the specified agentId when --agent is provided", async () => {
+      const agent1 = makeAgentRecord("agent:security-audit", "audit");
+      const agent2 = makeAgentRecord("agent:pii-scan", "audit");
+
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue([
+        "agent:security-audit",
+        "agent:pii-scan",
+      ]);
+      (deps.recordStore.get as jest.Mock).mockImplementation(async (id: string) => {
+        if (id === "agent:security-audit") return agent1;
+        if (id === "agent:pii-scan") return agent2;
+        return null;
+      });
+      (deps.agentRunner.runOnce as jest.Mock).mockResolvedValue(
+        makeAgentResponse("agent:pii-scan", makeSarifLog(), "exec-001"),
+      );
+
+      const orchestrator = createAuditOrchestrator(deps);
+      const result = await orchestrator.run({
+        ...defaultOptions,
+        agentId: "agent:pii-scan",
+      });
+
+      expect(deps.agentRunner.runOnce).toHaveBeenCalledTimes(1);
+      expect(deps.agentRunner.runOnce).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "agent:pii-scan" }),
+      );
+      expect(result.agentResults).toHaveLength(1);
+      const firstResult = result.agentResults[0]!;
+      expect(firstResult).toBeDefined();
+      expect(firstResult.agentId).toBe("agent:pii-scan");
+    });
+
+    it("[AORCH-B3] should return empty findings and warning when no audit agents are found", async () => {
+      const nonAuditAgent = makeAgentRecord("agent:deployment", "deploy");
+
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue(["agent:deployment"]);
+      (deps.recordStore.get as jest.Mock).mockResolvedValue(nonAuditAgent);
+
+      const orchestrator = createAuditOrchestrator(deps);
+      const result = await orchestrator.run(defaultOptions);
+
+      expect(result.findings).toHaveLength(0);
+      expect(result.agentResults).toHaveLength(0);
+      expect(result.summary.total).toBe(0);
+      expect(result.summary.agentsRun).toBe(0);
+      expect(deps.agentRunner.runOnce).not.toHaveBeenCalled();
+      expect(result.warning).toBe('No audit agents found');
+    });
+
+    it("[AORCH-B4] should collect SarifLog and include in agentResults with status success when agent succeeds", async () => {
+      const agentRecord = makeAgentRecord("agent:security-audit", "audit");
+      const sarif = makeSarifLog([
+        makeSarifResult({
+          ruleId: "SEC-001",
+          level: "error",
+          message: "Hardcoded secret found",
+          file: "src/config.ts",
+          startLine: 10,
+          fingerprint: "hash-sec-001",
+          category: "hardcoded-secret",
+        }),
+      ]);
+
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue(["agent:security-audit"]);
+      (deps.recordStore.get as jest.Mock).mockResolvedValue(agentRecord);
+      (deps.agentRunner.runOnce as jest.Mock).mockResolvedValue(
+        makeAgentResponse("agent:security-audit", sarif, "exec-scan-001"),
+      );
+
+      const orchestrator = createAuditOrchestrator(deps);
+      const result = await orchestrator.run(defaultOptions);
+
+      expect(result.agentResults).toHaveLength(1);
+      const firstResult = result.agentResults[0]!;
+      expect(firstResult).toBeDefined();
+      expect(firstResult.status).toBe("success");
+      const firstRun = firstResult.sarif.runs[0]!;
+      expect(firstRun).toBeDefined();
+      expect(firstRun.results).toHaveLength(1);
+      expect(firstResult.executionId).toBe("exec-scan-001");
+    });
+
+    it("[AORCH-B5] should include result with status error and continue with remaining agents when agent fails", async () => {
+      const agent1 = makeAgentRecord("agent:failing-audit", "audit");
+      const agent2 = makeAgentRecord("agent:working-audit", "audit");
+
+      const workingSarif = makeSarifLog([
+        makeSarifResult({
+          ruleId: "PII-001",
+          level: "warning",
+          message: "PII detected",
+          file: "src/user.ts",
+          startLine: 5,
+          fingerprint: "hash-pii-001",
+          category: "pii-email",
+        }),
+      ]);
+
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue([
+        "agent:failing-audit",
+        "agent:working-audit",
+      ]);
+      (deps.recordStore.get as jest.Mock).mockImplementation(async (id: string) => {
+        if (id === "agent:failing-audit") return agent1;
+        if (id === "agent:working-audit") return agent2;
+        return null;
+      });
+      (deps.agentRunner.runOnce as jest.Mock).mockImplementation(
+        async (opts: RunOptions) => {
+          if (opts.agentId === "agent:failing-audit") {
+            throw new Error("Agent crashed");
+          }
+          return makeAgentResponse("agent:working-audit", workingSarif, "exec-002");
+        },
+      );
+
+      const orchestrator = createAuditOrchestrator(deps);
+      const result = await orchestrator.run(defaultOptions);
+
+      // Both agents should appear in results
+      expect(result.agentResults).toHaveLength(2);
+
+      const failedResult = result.agentResults.find(
+        (r) => r.agentId === "agent:failing-audit",
+      );
+      expect(failedResult).toBeDefined();
+      expect(failedResult?.status).toBe("error");
+      expect(failedResult?.errorMessage).toBe("Agent crashed");
+
+      const successResult = result.agentResults.find(
+        (r) => r.agentId === "agent:working-audit",
+      );
+      expect(successResult).toBeDefined();
+      expect(successResult?.status).toBe("success");
+
+      // Findings from the working agent should still be consolidated
+      expect(result.findings).toHaveLength(1);
+      const firstFinding = result.findings[0]!;
+      expect(firstFinding).toBeDefined();
+      expect(firstFinding.ruleId).toBe("PII-001");
+
+      // Summary should reflect both
+      expect(result.summary.agentsRun).toBe(1);
+      expect(result.summary.agentsFailed).toBe(1);
+    });
+
+    it("[AORCH-B8] should create one ExecutionRecord of type analysis per agent via AgentRunner", async () => {
+      const agent1 = makeAgentRecord("agent:security-audit", "audit");
+      const agent2 = makeAgentRecord("agent:pii-scan", "audit");
+
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue([
+        "agent:security-audit",
+        "agent:pii-scan",
+      ]);
+      (deps.recordStore.get as jest.Mock).mockImplementation(async (id: string) => {
+        if (id === "agent:security-audit") return agent1;
+        if (id === "agent:pii-scan") return agent2;
+        return null;
+      });
+      (deps.agentRunner.runOnce as jest.Mock)
+        .mockResolvedValueOnce(
+          makeAgentResponse("agent:security-audit", makeSarifLog(), "exec-scan-001"),
+        )
+        .mockResolvedValueOnce(
+          makeAgentResponse("agent:pii-scan", makeSarifLog(), "exec-scan-002"),
+        );
+
+      const orchestrator = createAuditOrchestrator(deps);
+      const result = await orchestrator.run(defaultOptions);
+
+      // AgentRunner was called once per agent
+      expect(deps.agentRunner.runOnce).toHaveBeenCalledTimes(2);
+
+      // ExecutionRecord IDs are captured from AgentRunner responses
+      expect(result.executionIds.scans).toEqual(["exec-scan-001", "exec-scan-002"]);
+      const result0 = result.agentResults[0]!;
+      const result1 = result.agentResults[1]!;
+      expect(result0).toBeDefined();
+      expect(result1).toBeDefined();
+      expect(result0.executionId).toBe("exec-scan-001");
+      expect(result1.executionId).toBe("exec-scan-002");
+    });
+  });
+
+  describe("4.3. Consolidation and Dedup (AORCH-B6, B12)", () => {
+    it("[AORCH-B6] should deduplicate findings that share the same fingerprint across agents", async () => {
+      const agent1 = makeAgentRecord("agent:security-audit", "audit");
+      const agent2 = makeAgentRecord("agent:pii-scan", "audit");
+
+      const sharedResult = makeSarifResult({
+        ruleId: "SEC-001",
+        level: "error",
+        message: "Hardcoded secret",
+        file: "src/config.ts",
+        startLine: 10,
+        fingerprint: "shared-hash-001",
+        category: "hardcoded-secret",
+      });
+
+      const sarif1 = makeSarifLog([sharedResult]);
+      const sarif2 = makeSarifLog([sharedResult]);
+
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue([
+        "agent:security-audit",
+        "agent:pii-scan",
+      ]);
+      (deps.recordStore.get as jest.Mock).mockImplementation(async (id: string) => {
+        if (id === "agent:security-audit") return agent1;
+        if (id === "agent:pii-scan") return agent2;
+        return null;
+      });
+      (deps.agentRunner.runOnce as jest.Mock)
+        .mockResolvedValueOnce(
+          makeAgentResponse("agent:security-audit", sarif1, "exec-001"),
+        )
+        .mockResolvedValueOnce(
+          makeAgentResponse("agent:pii-scan", sarif2, "exec-002"),
+        );
+
+      const orchestrator = createAuditOrchestrator(deps);
+      const result = await orchestrator.run(defaultOptions);
+
+      // Only one consolidated finding despite two agents reporting it
+      expect(result.findings).toHaveLength(1);
+      const finding = result.findings[0]!;
+      expect(finding).toBeDefined();
+      expect(finding.fingerprint).toBe("shared-hash-001");
+      expect(finding.reportedBy).toEqual([
+        "agent:security-audit",
+        "agent:pii-scan",
+      ]);
+    });
+
+    it("[AORCH-B12] should deduplicate using ruleId + file + startLine when primaryLocationLineHash is missing", async () => {
+      const agent1 = makeAgentRecord("agent:security-audit", "audit");
+      const agent2 = makeAgentRecord("agent:external-tool", "audit");
+
+      // No fingerprint -- fallback dedup
+      const resultWithoutFingerprint = makeSarifResult({
+        ruleId: "EXT-001",
+        level: "warning",
+        message: "External finding",
+        file: "src/app.ts",
+        startLine: 42,
+        category: "unknown-risk",
+      });
+
+      const sarif1 = makeSarifLog([resultWithoutFingerprint]);
+      const sarif2 = makeSarifLog([resultWithoutFingerprint]);
+
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue([
+        "agent:security-audit",
+        "agent:external-tool",
+      ]);
+      (deps.recordStore.get as jest.Mock).mockImplementation(async (id: string) => {
+        if (id === "agent:security-audit") return agent1;
+        if (id === "agent:external-tool") return agent2;
+        return null;
+      });
+      (deps.agentRunner.runOnce as jest.Mock)
+        .mockResolvedValueOnce(
+          makeAgentResponse("agent:security-audit", sarif1, "exec-001"),
+        )
+        .mockResolvedValueOnce(
+          makeAgentResponse("agent:external-tool", sarif2, "exec-002"),
+        );
+
+      const orchestrator = createAuditOrchestrator(deps);
+      const result = await orchestrator.run(defaultOptions);
+
+      // Deduplicated by fallback: ruleId + file + startLine
+      expect(result.findings).toHaveLength(1);
+      const finding = result.findings[0]!;
+      expect(finding).toBeDefined();
+      expect(finding.fingerprint).toBe("fallback:EXT-001:src/app.ts:42");
+      expect(finding.reportedBy).toEqual([
+        "agent:security-audit",
+        "agent:external-tool",
+      ]);
+    });
+  });
+
+  describe("4.4. Waiver Application (AORCH-B7)", () => {
+    it("[AORCH-B7] should continue with unsuppressed findings when WaiverReader fails", async () => {
+      const agentRecord = makeAgentRecord("agent:security-audit", "audit");
+      const sarif = makeSarifLog([
+        makeSarifResult({
+          ruleId: "SEC-001",
+          level: "error",
+          message: "Hardcoded secret",
+          file: "src/config.ts",
+          startLine: 10,
+          fingerprint: "hash-sec-001",
+          category: "hardcoded-secret",
+        }),
+      ]);
+
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue(["agent:security-audit"]);
+      (deps.recordStore.get as jest.Mock).mockResolvedValue(agentRecord);
+      (deps.agentRunner.runOnce as jest.Mock).mockResolvedValue(
+        makeAgentResponse("agent:security-audit", sarif, "exec-001"),
+      );
+      (deps.waiverReader.loadActiveWaivers as jest.Mock).mockRejectedValue(
+        new Error("WaiverReader connection failed"),
+      );
+
+      const orchestrator = createAuditOrchestrator(deps);
+      // Should not throw
+      const result = await orchestrator.run(defaultOptions);
+
+      // Findings should be returned unsuppressed
+      expect(result.findings).toHaveLength(1);
+      const finding = result.findings[0]!;
+      expect(finding).toBeDefined();
+      expect(finding.isWaived).toBe(false);
+      expect(finding.waiver).toBeUndefined();
+    });
+
+    it("[AORCH-B7] should mark finding as suppressed when active waiver exists for its fingerprint", async () => {
+      const agentRecord = makeAgentRecord("agent:security-audit", "audit");
+      const sarif = makeSarifLog([
+        makeSarifResult({
+          ruleId: "SEC-001",
+          level: "error",
+          message: "Hardcoded secret",
+          file: "src/config.ts",
+          startLine: 10,
+          fingerprint: "waived-hash-001",
+          category: "hardcoded-secret",
+        }),
+        makeSarifResult({
+          ruleId: "SEC-002",
+          level: "warning",
+          message: "Weak crypto",
+          file: "src/crypto.ts",
+          startLine: 20,
+          fingerprint: "not-waived-hash-002",
+          category: "unknown-risk",
+        }),
+      ]);
+
+      const activeWaiver: ActiveWaiver = {
+        fingerprint: "waived-hash-001",
+        ruleId: "SEC-001",
+        feedback: {
+          id: "1234567890-feedback-waiver-sec001",
+          entityType: "execution",
+          entityId: "exec-previous",
+          type: "approval",
+          status: "acknowledged",
+          content: "Risk accepted per security review",
+          metadata: {
+            fingerprint: "waived-hash-001",
+            ruleId: "SEC-001",
+            file: "src/config.ts",
+            line: 10,
+          },
+        },
+      };
+
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue(["agent:security-audit"]);
+      (deps.recordStore.get as jest.Mock).mockResolvedValue(agentRecord);
+      (deps.agentRunner.runOnce as jest.Mock).mockResolvedValue(
+        makeAgentResponse("agent:security-audit", sarif, "exec-001"),
+      );
+      (deps.waiverReader.loadActiveWaivers as jest.Mock).mockResolvedValue([
+        activeWaiver,
+      ]);
+
+      const orchestrator = createAuditOrchestrator(deps);
+      const result = await orchestrator.run(defaultOptions);
+
+      expect(result.findings).toHaveLength(2);
+
+      const waivedFinding = result.findings.find(
+        (f) => f.fingerprint === "waived-hash-001",
+      );
+      expect(waivedFinding).toBeDefined();
+      expect(waivedFinding?.isWaived).toBe(true);
+      expect(waivedFinding?.waiver).toBe(activeWaiver);
+
+      const notWaivedFinding = result.findings.find(
+        (f) => f.fingerprint === "not-waived-hash-002",
+      );
+      expect(notWaivedFinding).toBeDefined();
+      expect(notWaivedFinding?.isWaived).toBe(false);
+      expect(notWaivedFinding?.waiver).toBeUndefined();
+
+      // Summary should count suppressed
+      expect(result.summary.suppressed).toBe(1);
+    });
+  });
+
+  describe("4.5. Error Handling", () => {
+    it("[AORCH-B3] should propagate error when PolicyEvaluator throws", async () => {
+      const agentRecord = makeAgentRecord("agent:security-audit", "audit");
+      const sarif = makeSarifLog();
+
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue(["agent:security-audit"]);
+      (deps.recordStore.get as jest.Mock).mockResolvedValue(agentRecord);
+      (deps.agentRunner.runOnce as jest.Mock).mockResolvedValue(
+        makeAgentResponse("agent:security-audit", sarif, "exec-001"),
+      );
+      (deps.policyEvaluator.evaluate as jest.Mock).mockRejectedValue(
+        new Error("PolicyEvaluator internal error"),
+      );
+
+      const orchestrator = createAuditOrchestrator(deps);
+
+      await expect(orchestrator.run(defaultOptions)).rejects.toThrow(
+        "PolicyEvaluator internal error",
+      );
+    });
+  });
+});

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.ts
@@ -1,0 +1,360 @@
+import type { SarifLog, SarifPhysicalLocation } from "../sarif/sarif.types";
+import type { IAgentRunner } from "../agent_runner/agent_runner";
+import type { RecordStore } from "../record_store/record_store";
+import type { GitGovAgentRecord } from "../record_types";
+import type { ActiveWaiver } from "../source_auditor/types";
+import type { RunOptions } from "../agent_runner/agent_runner.types";
+import type {
+  AuditOrchestratorDeps,
+  AuditOrchestrationOptions,
+  AuditOrchestrationResult,
+  AgentAuditResult,
+  AgentAuditInput,
+  ConsolidatedFinding,
+  AuditSummary,
+  FindingSeverity,
+} from "./audit_orchestrator.types";
+
+/**
+ * Creates an empty SarifLog (used for error cases).
+ */
+function emptySarif(): SarifLog {
+  return {
+    $schema:
+      "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
+    version: "2.1.0",
+    runs: [],
+  };
+}
+
+/**
+ * Maps SARIF level to GitGov severity.
+ */
+function levelToSeverity(level: string | undefined): FindingSeverity {
+  switch (level) {
+    case "error":
+      return "critical";
+    case "warning":
+      return "high";
+    case "note":
+      return "medium";
+    default:
+      return "low";
+  }
+}
+
+/**
+ * Discovers AgentRecords with metadata.purpose === "audit".
+ * If agentId is provided, filters to only that agent.
+ *
+ * RecordStore.list() returns string[] (IDs).
+ * RecordStore.get(id) returns the full record with payload.metadata.
+ */
+async function discoverAuditAgents(
+  agentStore: RecordStore<GitGovAgentRecord>,
+  agentId?: string,
+): Promise<string[]> {
+  const agentIds = await agentStore.list();
+  const auditAgentIds: string[] = [];
+
+  for (const id of agentIds) {
+    const record = await agentStore.get(id);
+    if (!record) continue;
+    const meta = record.payload.metadata as
+      | Record<string, unknown>
+      | undefined;
+    if (meta && meta["purpose"] === "audit") {
+      auditAgentIds.push(record.payload.id);
+    }
+  }
+
+  if (agentId) {
+    return auditAgentIds.includes(agentId) ? [agentId] : [];
+  }
+
+  return auditAgentIds;
+}
+
+/**
+ * Executes a single agent via AgentRunner and returns its result.
+ * AgentRunner creates the ExecutionRecord automatically (AORCH-B8).
+ */
+async function executeAgent(
+  agentRunner: IAgentRunner,
+  agentId: string,
+  options: AuditOrchestrationOptions,
+): Promise<AgentAuditResult> {
+  const startMs = Date.now();
+
+  const input: AgentAuditInput = {
+    scope: options.scope,
+    ...(options.include !== undefined ? { include: options.include } : {}),
+    ...(options.exclude !== undefined ? { exclude: options.exclude } : {}),
+    taskId: options.taskId,
+  };
+
+  const runOpts: RunOptions = {
+    agentId,
+    taskId: options.taskId,
+    input,
+  };
+
+  const response = await agentRunner.runOnce(runOpts);
+
+  // Agent output contains SARIF in metadata.data
+  const metadata = response.output?.metadata as
+    | Record<string, unknown>
+    | undefined;
+  const sarif = (metadata?.["data"] as SarifLog | undefined) ?? emptySarif();
+
+  return {
+    agentId,
+    sarif,
+    executionId: response.executionRecordId,
+    status: "success",
+    durationMs: Date.now() - startMs,
+  };
+}
+
+/**
+ * Fallback fingerprint for SARIF results without primaryLocationLineHash/v1.
+ * Format: "fallback:{ruleId}:{file}:{startLine}"
+ */
+function buildFallbackFingerprint(
+  ruleId: string | undefined,
+  location: SarifPhysicalLocation | undefined,
+): string | undefined {
+  const file = location?.artifactLocation?.uri;
+  const line = location?.region?.startLine;
+  if (!ruleId || !file) return undefined;
+  return `fallback:${ruleId}:${file}:${line ?? 0}`;
+}
+
+/**
+ * Consolidates findings from multiple SarifLogs with dedup by fingerprint.
+ * If two agents report the same fingerprint, both agentIds are included in reportedBy.
+ */
+function consolidateFindings(
+  agentResults: AgentAuditResult[],
+): ConsolidatedFinding[] {
+  const byFingerprint = new Map<string, ConsolidatedFinding>();
+
+  for (const result of agentResults) {
+    if (result.status !== "success") continue;
+
+    for (const run of result.sarif.runs) {
+      for (const sarifResult of run.results) {
+        // Primary: use standardized primaryLocationLineHash/v1 from SarifBuilder
+        // Fallback: ruleId + file + startLine (for external tools without GitGov fingerprinting)
+        const location = sarifResult.locations?.[0]?.physicalLocation;
+        const fingerprint =
+          sarifResult.partialFingerprints?.["primaryLocationLineHash/v1"] ??
+          buildFallbackFingerprint(sarifResult.ruleId, location);
+        if (!fingerprint) continue;
+
+        const existing = byFingerprint.get(fingerprint);
+
+        if (existing) {
+          // Dedup: add agent to reportedBy
+          if (!existing.reportedBy.includes(result.agentId)) {
+            existing.reportedBy.push(result.agentId);
+          }
+        } else {
+          // Read severity from properties['gitgov/category'] or infer from level
+          const props = sarifResult.properties as
+            | Record<string, unknown>
+            | undefined;
+          const category =
+            (props?.["gitgov/category"] as string | undefined) ?? "unknown";
+
+          const finding: ConsolidatedFinding = {
+            fingerprint,
+            ruleId: sarifResult.ruleId,
+            message: sarifResult.message.text,
+            severity: levelToSeverity(sarifResult.level),
+            file: location?.artifactLocation?.uri ?? "",
+            line: location?.region?.startLine ?? 0,
+            category,
+            reportedBy: [result.agentId],
+            isWaived: false,
+          };
+          const col = location?.region?.startColumn;
+          if (col !== undefined) {
+            finding.column = col;
+          }
+          byFingerprint.set(fingerprint, finding);
+        }
+      }
+    }
+  }
+
+  return Array.from(byFingerprint.values());
+}
+
+/**
+ * Applies active waivers as suppressions on consolidated findings.
+ * A waiver is a FeedbackRecord with type: "approval" and metadata.fingerprint.
+ * Matching is by fingerprint (primaryLocationLineHash/v1).
+ */
+function applyWaivers(
+  findings: ConsolidatedFinding[],
+  waivers: ActiveWaiver[],
+): ConsolidatedFinding[] {
+  const waiverByFingerprint = new Map(
+    waivers.filter((w) => w.fingerprint).map((w) => [w.fingerprint, w]),
+  );
+
+  return findings.map((finding) => {
+    const waiver = waiverByFingerprint.get(finding.fingerprint);
+    if (waiver) {
+      return {
+        ...finding,
+        isWaived: true,
+        waiver,
+      };
+    }
+    return finding;
+  });
+}
+
+/**
+ * Builds the summary counts for CLI display.
+ */
+function buildSummary(
+  findings: ConsolidatedFinding[],
+  agentResults: AgentAuditResult[],
+): AuditSummary {
+  const active = findings.filter((f) => !f.isWaived);
+  return {
+    total: findings.length,
+    critical: active.filter((f) => f.severity === "critical").length,
+    high: active.filter((f) => f.severity === "high").length,
+    medium: active.filter((f) => f.severity === "medium").length,
+    low: active.filter((f) => f.severity === "low").length,
+    suppressed: findings.filter((f) => f.isWaived).length,
+    agentsRun: agentResults.filter((r) => r.status === "success").length,
+    agentsFailed: agentResults.filter((r) => r.status === "error").length,
+  };
+}
+
+/**
+ * Factory: creates an AuditOrchestrator with injected dependencies.
+ * Uses DI for full testability -- all external interactions are mockable.
+ */
+export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
+  return {
+    /**
+     * Executes the full orchestration pipeline:
+     * 1. Discover audit agents from RecordStore
+     * 2. Filter by agentId if specified
+     * 3. Execute via AgentRunner (Promise.allSettled)
+     * 4. Consolidate SARIF findings, dedup by fingerprint
+     * 5. Apply waivers
+     * 6. Evaluate policy
+     * 7. Return AuditOrchestrationResult
+     */
+    async run(
+      options: AuditOrchestrationOptions,
+    ): Promise<AuditOrchestrationResult> {
+      // 1. Discover audit agents
+      const auditAgents = await discoverAuditAgents(
+        deps.recordStore,
+        options.agentId,
+      );
+
+      // 2. If no agents found, return empty result with warning (AORCH-B3)
+      if (auditAgents.length === 0) {
+        const policyOpts: { failOn?: FindingSeverity; taskId: string } = {
+          taskId: options.taskId,
+        };
+        if (options.failOn !== undefined) {
+          policyOpts.failOn = options.failOn;
+        }
+        const policyDecision = await deps.policyEvaluator.evaluate(
+          [],
+          policyOpts,
+        );
+
+        return {
+          findings: [],
+          agentResults: [],
+          policyDecision,
+          summary: {
+            total: 0,
+            critical: 0,
+            high: 0,
+            medium: 0,
+            low: 0,
+            suppressed: 0,
+            agentsRun: 0,
+            agentsFailed: 0,
+          },
+          executionIds: {
+            scans: [],
+            policy: policyDecision.executionRecordId,
+          },
+          warning: 'No audit agents found',
+        };
+      }
+
+      // 3. Execute each agent (allSettled: one failure doesn't abort batch -- AORCH-B5)
+      const settled = await Promise.allSettled(
+        auditAgents.map((agentId) =>
+          executeAgent(deps.agentRunner, agentId, options),
+        ),
+      );
+
+      const agentResults: AgentAuditResult[] = settled.map((s, i) =>
+        s.status === "fulfilled"
+          ? s.value
+          : {
+              agentId: auditAgents[i] ?? "unknown",
+              sarif: emptySarif(),
+              executionId: "",
+              status: "error" as const,
+              durationMs: 0,
+              errorMessage:
+                s.reason instanceof Error
+                  ? s.reason.message
+                  : String(s.reason),
+            },
+      );
+
+      // 4. Consolidate findings with dedup by fingerprint
+      const rawFindings = consolidateFindings(agentResults);
+
+      // 5. Load active waivers and apply as suppressions
+      // Graceful degradation: if WaiverReader fails, continue with findings unsuppressed (AORCH-B7)
+      let waivers: ActiveWaiver[] = [];
+      try {
+        waivers = await deps.waiverReader.loadActiveWaivers();
+      } catch {
+        // WaiverReader failure is non-fatal: findings remain unsuppressed
+      }
+      const findings = applyWaivers(rawFindings, waivers);
+
+      // 6. Evaluate policy
+      const policyOpts2: { failOn?: FindingSeverity; taskId: string } = {
+        taskId: options.taskId,
+      };
+      if (options.failOn !== undefined) {
+        policyOpts2.failOn = options.failOn;
+      }
+      const policyDecision = await deps.policyEvaluator.evaluate(
+        findings,
+        policyOpts2,
+      );
+
+      return {
+        findings,
+        agentResults,
+        policyDecision,
+        summary: buildSummary(findings, agentResults),
+        executionIds: {
+          scans: agentResults.map((r) => r.executionId),
+          policy: policyDecision.executionRecordId,
+        },
+      };
+    },
+  };
+}

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.types.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.types.ts
@@ -1,0 +1,192 @@
+import type { SarifLog } from "../sarif/sarif.types";
+import type { RecordStore } from "../record_store/record_store";
+import type { GitGovAgentRecord } from "../record_types";
+import type { IAgentRunner } from "../agent_runner/agent_runner";
+import type { IWaiverReader, ActiveWaiver } from "../source_auditor/types";
+
+// ============================================================================
+// ORCHESTRATION INPUT/OUTPUT
+// ============================================================================
+
+/**
+ * Severity levels for findings.
+ */
+export type FindingSeverity = "critical" | "high" | "medium" | "low";
+
+/**
+ * Options passed to AuditOrchestrator.run().
+ */
+export type AuditOrchestrationOptions = {
+  /** Scan scope: diff (changed files), full (all files), baseline (full + save baseline) */
+  scope: "diff" | "full" | "baseline";
+  /** Optional: run only this specific agent */
+  agentId?: string;
+  /** Glob patterns to include in scan */
+  include?: string[];
+  /** Glob patterns to exclude from scan */
+  exclude?: string[];
+  /** TaskRecord ID for traceability */
+  taskId: string;
+  /** Minimum severity to block on (optional) */
+  failOn?: FindingSeverity;
+};
+
+/**
+ * Complete result of an orchestrated audit run.
+ */
+export type AuditOrchestrationResult = {
+  /** Consolidated, deduplicated findings from all agents */
+  findings: ConsolidatedFinding[];
+  /** Per-agent execution results */
+  agentResults: AgentAuditResult[];
+  /** Policy evaluation decision */
+  policyDecision: PolicyDecisionStub;
+  /** Aggregated summary */
+  summary: AuditSummary;
+  /** ExecutionRecord IDs created during this run */
+  executionIds: {
+    /** One per agent scan */
+    scans: string[];
+    /** Policy evaluation execution */
+    policy: string;
+  };
+  /** Warning message (e.g. when no audit agents are found) */
+  warning?: string;
+};
+
+// ============================================================================
+// AGENT RESULTS
+// ============================================================================
+
+/**
+ * Result from a single agent execution.
+ */
+export type AgentAuditResult = {
+  /** Agent identifier */
+  agentId: string;
+  /** SARIF log produced by the agent */
+  sarif: SarifLog;
+  /** ExecutionRecord ID for this agent run */
+  executionId: string;
+  /** Whether the agent succeeded or failed */
+  status: "success" | "error";
+  /** Execution duration in milliseconds */
+  durationMs: number;
+  /** Error message if status is "error" */
+  errorMessage?: string;
+};
+
+/**
+ * Input passed to each audit agent via AgentRunner ctx.input.
+ */
+export type AgentAuditInput = {
+  /** Scan scope */
+  scope: "diff" | "full" | "baseline";
+  /** Glob patterns to include */
+  include?: string[];
+  /** Glob patterns to exclude */
+  exclude?: string[];
+  /** TaskRecord ID for traceability */
+  taskId: string;
+  /** Base directory for scanning (resolved by orchestrator from project root) */
+  baseDir?: string;
+};
+
+// ============================================================================
+// CONSOLIDATED FINDINGS
+// ============================================================================
+
+/**
+ * A finding consolidated across multiple agents, deduplicated by fingerprint.
+ */
+export type ConsolidatedFinding = {
+  /** Content-based fingerprint (primaryLocationLineHash/v1 or fallback) */
+  fingerprint: string;
+  /** Rule ID from SARIF (e.g., "PII-001") */
+  ruleId?: string;
+  /** Human-readable finding message */
+  message: string;
+  /** Finding severity */
+  severity: FindingSeverity;
+  /** Finding category (e.g., "pii", "secret") */
+  category: string;
+  /** File path where finding was detected */
+  file: string;
+  /** Line number (1-based) */
+  line: number;
+  /** Column number (optional, 1-based) */
+  column?: number;
+  /** Agent IDs that reported this finding */
+  reportedBy: string[];
+  /** Whether this finding is suppressed by a waiver */
+  isWaived: boolean;
+  /** Active waiver details if suppressed */
+  waiver?: ActiveWaiver;
+};
+
+// ============================================================================
+// SUMMARY AND POLICY
+// ============================================================================
+
+/**
+ * Aggregated summary of the orchestration run.
+ */
+export type AuditSummary = {
+  /** Total consolidated findings */
+  total: number;
+  /** Count of critical findings */
+  critical: number;
+  /** Count of high findings */
+  high: number;
+  /** Count of medium findings */
+  medium: number;
+  /** Count of low findings */
+  low: number;
+  /** Count of suppressed (waived) findings */
+  suppressed: number;
+  /** Number of agents executed */
+  agentsRun: number;
+  /** Number of agents that failed */
+  agentsFailed: number;
+};
+
+/**
+ * Policy evaluation result (stub in Cycle 1, formal in Cycle 2).
+ */
+export type PolicyDecisionStub = {
+  /** Pass or block */
+  decision: "pass" | "block";
+  /** Human-readable reason for decision */
+  reason: string;
+  /** ExecutionRecord ID for the policy evaluation */
+  executionRecordId: string;
+};
+
+// ============================================================================
+// DEPENDENCY INJECTION
+// ============================================================================
+
+/**
+ * Dependencies injected into createAuditOrchestrator().
+ */
+export type AuditOrchestratorDeps = {
+  /** RecordStore for reading AgentRecords (typed for agent records) */
+  recordStore: RecordStore<GitGovAgentRecord>;
+  /** AgentRunner interface for executing agents */
+  agentRunner: IAgentRunner;
+  /** WaiverReader for loading active waivers */
+  waiverReader: IWaiverReader;
+  /** PolicyEvaluator for pass/block decision */
+  policyEvaluator: PolicyEvaluator;
+};
+
+/**
+ * PolicyEvaluator interface.
+ * Stub in Cycle 1 -- formal implementation in Cycle 2.
+ */
+export interface PolicyEvaluator {
+  evaluate(
+    findings: ConsolidatedFinding[],
+    options: { failOn?: FindingSeverity; taskId: string },
+  ): Promise<PolicyDecisionStub>;
+}

--- a/packages/core/src/audit_orchestrator/index.ts
+++ b/packages/core/src/audit_orchestrator/index.ts
@@ -1,0 +1,13 @@
+export { createAuditOrchestrator } from "./audit_orchestrator";
+export type {
+  AuditOrchestratorDeps,
+  AuditOrchestrationOptions,
+  AuditOrchestrationResult,
+  AgentAuditResult,
+  AgentAuditInput,
+  ConsolidatedFinding,
+  AuditSummary,
+  PolicyDecisionStub,
+  FindingSeverity,
+  PolicyEvaluator,
+} from "./audit_orchestrator.types";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,6 +110,9 @@ export * as Sarif from "./sarif";
 // Agent runner
 export * as Runner from "./agent_runner";
 
+// Policy evaluator (stub -- formal implementation in Epic 5)
+export * as PolicyEvaluator from "./policy_evaluator";
+
 // Renamed modules (promoted from adapters/)
 export * as RecordProjection from "./record_projection";
 export * as RecordMetrics from "./record_metrics";

--- a/packages/core/src/policy_evaluator/index.ts
+++ b/packages/core/src/policy_evaluator/index.ts
@@ -1,0 +1,7 @@
+export { createPolicyEvaluator } from "./policy_evaluator";
+export type {
+  PolicyEvaluator,
+  PolicyDecisionStub,
+  ConsolidatedFinding,
+  FindingSeverity,
+} from "./policy_evaluator.types";

--- a/packages/core/src/policy_evaluator/policy_evaluator.test.ts
+++ b/packages/core/src/policy_evaluator/policy_evaluator.test.ts
@@ -1,0 +1,126 @@
+import { createPolicyEvaluator } from "./policy_evaluator";
+import type { ConsolidatedFinding } from "./policy_evaluator.types";
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function makeFinding(
+  overrides: Partial<ConsolidatedFinding> = {},
+): ConsolidatedFinding {
+  return {
+    fingerprint: `fp-${Math.random().toString(36).slice(2, 8)}`,
+    message: "test finding",
+    severity: "high",
+    category: "test",
+    file: "src/foo.ts",
+    line: 10,
+    reportedBy: ["agent-1"],
+    isWaived: false,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// PolicyEvaluator stub tests (AORCH-C7 to C10)
+// ============================================================================
+
+describe("PolicyEvaluator", () => {
+  describe("Cycle 2: Stub evaluation (AORCH-C7 to C10)", () => {
+    const evaluator = createPolicyEvaluator();
+
+    it("[AORCH-C7] should return pass when failOn is critical and no critical findings exist", async () => {
+      const findings = [
+        makeFinding({ severity: "high" }),
+        makeFinding({ severity: "medium" }),
+        makeFinding({ severity: "low" }),
+      ];
+
+      const result = await evaluator.evaluate(findings, {
+        failOn: "critical",
+        taskId: "task-1",
+      });
+
+      expect(result.decision).toBe("pass");
+      expect(result.reason).toContain("No findings at or above critical");
+    });
+
+    it("[AORCH-C8] should return block when findings at or above failOn severity exist", async () => {
+      const findings = [
+        makeFinding({ severity: "high" }),
+        makeFinding({ severity: "medium" }),
+      ];
+
+      const result = await evaluator.evaluate(findings, {
+        failOn: "high",
+        taskId: "task-2",
+      });
+
+      expect(result.decision).toBe("block");
+      expect(result.reason).toContain("Found findings at or above high");
+    });
+
+    it("[AORCH-C9] should return executionRecordId as empty string (stub -- Epic 5 creates real ExecutionRecord)", async () => {
+      const findings = [makeFinding({ severity: "critical" })];
+
+      const result = await evaluator.evaluate(findings, {
+        failOn: "critical",
+        taskId: "task-3",
+      });
+
+      expect(result.executionRecordId).toBe("");
+    });
+
+    it("[AORCH-C10] should not count waived findings toward threshold", async () => {
+      const findings = [
+        makeFinding({ severity: "critical", isWaived: true }),
+        makeFinding({ severity: "high", isWaived: true }),
+        makeFinding({ severity: "low", isWaived: false }),
+      ];
+
+      const result = await evaluator.evaluate(findings, {
+        failOn: "critical",
+        taskId: "task-4",
+      });
+
+      expect(result.decision).toBe("pass");
+      expect(result.reason).toContain("No findings at or above critical");
+    });
+  });
+
+  describe("Edge cases", () => {
+    const evaluator = createPolicyEvaluator();
+
+    it("should default to critical when failOn is not specified", async () => {
+      const findings = [makeFinding({ severity: "high" })];
+
+      const result = await evaluator.evaluate(findings, {
+        taskId: "task-5",
+      });
+
+      expect(result.decision).toBe("pass");
+      expect(result.reason).toContain("No findings at or above critical");
+    });
+
+    it("should return pass with empty findings", async () => {
+      const result = await evaluator.evaluate([], {
+        failOn: "low",
+        taskId: "task-6",
+      });
+
+      expect(result.decision).toBe("pass");
+    });
+
+    it("should block when failOn is low and any active finding exists", async () => {
+      const findings = [makeFinding({ severity: "low" })];
+
+      const result = await evaluator.evaluate(findings, {
+        failOn: "low",
+        taskId: "task-7",
+      });
+
+      expect(result.decision).toBe("block");
+      expect(result.reason).toContain("Found findings at or above low");
+    });
+  });
+});

--- a/packages/core/src/policy_evaluator/policy_evaluator.ts
+++ b/packages/core/src/policy_evaluator/policy_evaluator.ts
@@ -1,0 +1,49 @@
+import type {
+  PolicyEvaluator,
+  ConsolidatedFinding,
+  FindingSeverity,
+  PolicyDecisionStub,
+} from "./policy_evaluator.types";
+
+/**
+ * Severity order for threshold comparison.
+ * Higher number = more severe.
+ */
+const severityOrder: Record<FindingSeverity, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+/**
+ * Creates a stub PolicyEvaluator.
+ *
+ * This is a minimal implementation for Cycle 2 of audit_orchestration.
+ * It checks active (non-waived) findings against a severity threshold
+ * and returns pass/block. No ExecutionRecord is created (deferred to Epic 5).
+ */
+export function createPolicyEvaluator(): PolicyEvaluator {
+  return {
+    async evaluate(
+      findings: ConsolidatedFinding[],
+      options: { failOn?: FindingSeverity; taskId: string },
+    ): Promise<PolicyDecisionStub> {
+      const failOn = options.failOn ?? "critical";
+      const threshold = severityOrder[failOn];
+
+      const activeFindings = findings.filter((f) => !f.isWaived);
+      const hasBlocking = activeFindings.some(
+        (f) => severityOrder[f.severity] >= threshold,
+      );
+
+      return {
+        decision: hasBlocking ? "block" : "pass",
+        reason: hasBlocking
+          ? `Found findings at or above ${failOn} severity`
+          : `No findings at or above ${failOn} severity`,
+        executionRecordId: "", // Stub -- Epic 5 creates real ExecutionRecord
+      };
+    },
+  };
+}

--- a/packages/core/src/policy_evaluator/policy_evaluator.types.ts
+++ b/packages/core/src/policy_evaluator/policy_evaluator.types.ts
@@ -1,0 +1,16 @@
+/**
+ * PolicyEvaluator types.
+ *
+ * Re-exports the interface and related types from audit_orchestrator.types
+ * for convenience. The canonical definition lives in audit_orchestrator.types.ts
+ * since PolicyEvaluator is a dependency of AuditOrchestrator.
+ *
+ * This file exists to follow the module folder convention and provide
+ * a place for future policy-specific types (Epic 5: policy_evaluation).
+ */
+export type {
+  PolicyEvaluator,
+  PolicyDecisionStub,
+  ConsolidatedFinding,
+  FindingSeverity,
+} from "../audit_orchestrator/audit_orchestrator.types";

--- a/packages/e2e/tests/audit_orchestration.test.ts
+++ b/packages/e2e/tests/audit_orchestration.test.ts
@@ -1,0 +1,551 @@
+/**
+ * Block G: Audit Orchestration Pipeline (CG1 to CG8)
+ *
+ * Integration tests for the complete audit pipeline:
+ *   AuditOrchestrator -> AgentRunner (mock calling real modules) -> SARIF -> Waivers -> Policy
+ *
+ * Real modules: SourceAuditorModule, FindingDetectorModule, SarifBuilder, PolicyEvaluator
+ * Mocked: IAgentRunner (wraps real detection pipeline), IWaiverReader (for CG4/CG5)
+ *
+ * IMPORTANT: All imports use @gitgov/core public API where available.
+ * AuditOrchestrator/PolicyEvaluator use relative imports because they are not yet
+ * exported from the main @gitgov/core entry point (added in this epic).
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+// === @gitgov/core public API ===
+import {
+  SourceAuditor,
+  FindingDetector,
+  Sarif,
+} from '@gitgov/core';
+import { MemoryRecordStore } from '@gitgov/core/memory';
+import { FsFileLister } from '@gitgov/core/fs';
+import type { IAgentRunner, RunOptions, AgentResponse, GitGovAgentRecord } from '@gitgov/core';
+
+// === Modules not yet in @gitgov/core public API (added in audit_orchestration epic) ===
+import { createAuditOrchestrator } from '../../core/src/audit_orchestrator';
+import { createPolicyEvaluator } from '../../core/src/policy_evaluator';
+import type {
+  AuditOrchestrationResult,
+} from '../../core/src/audit_orchestrator';
+import type { IWaiverReader, ActiveWaiver } from '../../core/src/source_auditor/types';
+
+// ============================================================================
+// Fixture setup
+// ============================================================================
+
+const FIXTURE_LOGIN_TS = `// src/auth/login.ts — authentication handler
+import { db } from '../config/database';
+
+const adminEmail = "admin@company.com";
+const supportEmail = "support@company.com";
+
+export async function login(username: string, password: string) {
+  const user = await db.query('SELECT * FROM users WHERE email = $1', [username]);
+  if (!user) {
+    console.log('Login failed for', username);
+    return { success: false };
+  }
+  return { success: true, token: 'jwt-token' };
+}
+`;
+
+const FIXTURE_DATABASE_TS = `// src/config/database.ts — database configuration
+const dbHost = 'localhost';
+const dbPort = 5432;
+const dbPassword = "supersecret123";
+const api_key = "sk-1234567890abcdefghijklmnopqrstuvwxyz";
+
+export const dbConfig = {
+  host: dbHost,
+  port: dbPort,
+  password: dbPassword,
+};
+`;
+
+/**
+ * Creates a temp directory with PII fixture files.
+ */
+function createFixtureDir(): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitgov-e2e-audit-'));
+
+  const authDir = path.join(tempDir, 'src', 'auth');
+  fs.mkdirSync(authDir, { recursive: true });
+  fs.writeFileSync(path.join(authDir, 'login.ts'), FIXTURE_LOGIN_TS);
+
+  const configDir = path.join(tempDir, 'src', 'config');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'database.ts'), FIXTURE_DATABASE_TS);
+
+  return tempDir;
+}
+
+/**
+ * Creates a GitGovAgentRecord for the security-audit agent.
+ */
+function makeAgentRecord(): GitGovAgentRecord {
+  return {
+    header: {
+      version: '1.0',
+      type: 'agent',
+      payloadChecksum: 'e2e-test-checksum',
+      signatures: [
+        {
+          keyId: 'agent:gitgov:security-audit',
+          role: 'author',
+          notes: 'E2E test fixture',
+          signature: 'dGVzdA=='.padEnd(88, '='),
+          timestamp: Date.now(),
+        },
+      ],
+    },
+    payload: {
+      id: 'agent:gitgov:security-audit',
+      status: 'active',
+      engine: {
+        type: 'local' as const,
+        entrypoint: 'packages/agents/security-audit/dist/index.mjs',
+        function: 'runAgent',
+      },
+      metadata: {
+        purpose: 'audit',
+        audit: {
+          target: 'code',
+          outputFormat: 'sarif',
+          supportedScopes: ['diff', 'full', 'baseline'],
+        },
+      },
+    },
+  };
+}
+
+type SarifLog = Sarif.SarifLog;
+
+/**
+ * Creates a mock IAgentRunner that internally runs real detection modules.
+ *
+ * Instead of spawning a process, this runner:
+ * 1. Creates a real FindingDetectorModule (regex-only)
+ * 2. Creates a real SourceAuditorModule with FsFileLister
+ * 3. Runs the audit on the fixture directory
+ * 4. Builds real SARIF via SarifBuilder
+ * 5. Returns the result in AgentResponse format
+ */
+function createIntegrationAgentRunner(fixtureDir: string): IAgentRunner {
+  return {
+    async runOnce(opts: RunOptions): Promise<AgentResponse> {
+      const startedAt = new Date().toISOString();
+      const startMs = Date.now();
+
+      const input = opts.input as {
+        scope: 'diff' | 'full' | 'baseline';
+        include?: string[];
+        exclude?: string[];
+        taskId: string;
+      };
+
+      // Real modules — same wiring as the security-audit agent
+      const findingDetector = new FindingDetector.FindingDetectorModule({
+        regex: { enabled: true },
+      });
+
+      const fileLister = new FsFileLister({ cwd: fixtureDir });
+
+      const noOpWaiverReader: SourceAuditor.IWaiverReader = {
+        loadActiveWaivers: async () => [],
+        hasActiveWaiver: async () => false,
+      };
+
+      const sourceAuditor = new SourceAuditor.SourceAuditorModule({
+        findingDetector,
+        waiverReader: noOpWaiverReader,
+        fileLister,
+      });
+
+      const include = input.include ?? ['**/*'];
+      const exclude = input.exclude ?? [
+        '**/node_modules/**',
+        '**/.git/**',
+        '**/dist/**',
+      ];
+
+      const auditResult = await sourceAuditor.audit({
+        baseDir: fixtureDir,
+        scope: { include, exclude },
+      });
+
+      // Build SARIF with real SarifBuilder
+      const sarifBuilder = Sarif.createSarifBuilder();
+      const sarifLog: SarifLog = await sarifBuilder.build({
+        toolName: 'gitgov-security-audit',
+        toolVersion: '1.0.0',
+        informationUri: 'https://gitgovernance.com/agents/security-audit',
+        findings: auditResult.findings,
+        taskId: input.taskId,
+        agentId: opts.agentId,
+        scanScope: input.scope,
+        scannedFiles: auditResult.scannedFiles,
+        scannedLines: auditResult.scannedLines,
+      });
+
+      const completedAt = new Date().toISOString();
+      const durationMs = Date.now() - startMs;
+      const executionRecordId = `exec-e2e-${Date.now()}`;
+
+      return {
+        runId: `run-e2e-${Date.now()}`,
+        agentId: opts.agentId,
+        status: 'success',
+        output: {
+          message: `Security audit completed: ${auditResult.findings.length} finding(s) in ${auditResult.scannedFiles} files`,
+          metadata: {
+            kind: 'sarif',
+            version: '2.1.0',
+            data: sarifLog,
+          },
+        },
+        executionRecordId,
+        startedAt,
+        completedAt,
+        durationMs,
+      };
+    },
+  };
+}
+
+/**
+ * Creates a no-op IWaiverReader (no waivers).
+ */
+function createNoOpWaiverReader(): IWaiverReader {
+  return {
+    loadActiveWaivers: async () => [],
+    hasActiveWaiver: async () => false,
+  };
+}
+
+// ============================================================================
+// Test suite
+// ============================================================================
+
+describe('Block G: Audit Orchestration Pipeline (CG1 to CG8)', () => {
+  let tempDir: string;
+  let agentStore: MemoryRecordStore<GitGovAgentRecord>;
+
+  beforeAll(async () => {
+    tempDir = createFixtureDir();
+
+    agentStore = new MemoryRecordStore<GitGovAgentRecord>();
+    const agentRecord = makeAgentRecord();
+    await agentStore.put('agent:gitgov:security-audit', agentRecord);
+  });
+
+  afterAll(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * Helper: creates orchestrator with default deps.
+   */
+  function createOrchestrator(overrides?: {
+    waiverReader?: IWaiverReader;
+  }) {
+    const agentRunner = createIntegrationAgentRunner(tempDir);
+    const policyEvaluator = createPolicyEvaluator();
+    const waiverReader = overrides?.waiverReader ?? createNoOpWaiverReader();
+
+    return createAuditOrchestrator({
+      recordStore: agentStore,
+      agentRunner,
+      waiverReader,
+      policyEvaluator,
+    });
+  }
+
+  // ==========================================================================
+  // 4.1. Pipeline Completo (CG1 to CG3)
+  // ==========================================================================
+
+  describe('4.1. Pipeline Completo (CG1 to CG3)', () => {
+    let result: AuditOrchestrationResult;
+
+    beforeAll(async () => {
+      const orchestrator = createOrchestrator();
+      result = await orchestrator.run({
+        scope: 'full',
+        taskId: '1234567890-task-e2e-pipeline',
+      });
+    });
+
+    it('[CG1] should return findings matching PII in fixture files', () => {
+      // The fixtures contain emails (PII-001) and hardcoded api_key (SEC-001)
+      expect(result.findings.length).toBeGreaterThanOrEqual(2);
+
+      // Verify email findings exist
+      const emailFindings = result.findings.filter(
+        (f) => f.ruleId === 'PII-001',
+      );
+      expect(emailFindings.length).toBeGreaterThanOrEqual(1);
+
+      // Verify at least one finding comes from the fixture files
+      const fixtureFiles = result.findings.map((f) => f.file);
+      const hasLoginFile = fixtureFiles.some((f) => f.includes('login.ts'));
+      const hasDatabaseFile = fixtureFiles.some((f) => f.includes('database.ts'));
+      expect(hasLoginFile || hasDatabaseFile).toBe(true);
+    });
+
+    it('[CG2] should produce findings with valid fingerprints', () => {
+      // Each finding must have a non-empty fingerprint
+      for (const finding of result.findings) {
+        expect(finding.fingerprint).toBeTruthy();
+        expect(typeof finding.fingerprint).toBe('string');
+        expect(finding.fingerprint.length).toBeGreaterThan(0);
+      }
+
+      // Fingerprints should be unique across findings (dedup already applied)
+      const fingerprints = result.findings.map((f) => f.fingerprint);
+      const uniqueFingerprints = new Set(fingerprints);
+      expect(uniqueFingerprints.size).toBe(fingerprints.length);
+    });
+
+    it('[CG3] should include agentResults with status success and valid SarifLog', () => {
+      expect(result.agentResults).toHaveLength(1);
+
+      const agentResult = result.agentResults[0]!;
+      expect(agentResult.status).toBe('success');
+      expect(agentResult.agentId).toBe('agent:gitgov:security-audit');
+      expect(agentResult.executionId).toBeTruthy();
+      expect(agentResult.durationMs).toBeGreaterThanOrEqual(0);
+
+      // Validate SARIF structure
+      const sarif = agentResult.sarif;
+      expect(sarif.version).toBe('2.1.0');
+      expect(sarif.$schema).toContain('sarif-schema-2.1.0');
+      expect(sarif.runs).toHaveLength(1);
+
+      const run = sarif.runs[0]!;
+      expect(run.tool.driver.name).toBe('gitgov-security-audit');
+      expect(run.results.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ==========================================================================
+  // 4.2. Waiver Integration (CG4 to CG5)
+  // ==========================================================================
+
+  describe('4.2. Waiver Integration (CG4 to CG5)', () => {
+    let baselineResult: AuditOrchestrationResult;
+
+    beforeAll(async () => {
+      const orchestrator = createOrchestrator();
+      baselineResult = await orchestrator.run({
+        scope: 'full',
+        taskId: '1234567890-task-e2e-baseline',
+      });
+    });
+
+    it('[CG4] should mark finding as isWaived when active waiver matches fingerprint', async () => {
+      expect(baselineResult.findings.length).toBeGreaterThanOrEqual(1);
+      const targetFinding = baselineResult.findings[0]!;
+
+      const waiver: ActiveWaiver = {
+        fingerprint: targetFinding.fingerprint,
+        ruleId: targetFinding.ruleId ?? 'UNKNOWN',
+        feedback: {
+          id: '1234567890-feedback-waiver-e2e',
+          entityType: 'execution',
+          entityId: 'exec-e2e-previous',
+          type: 'approval',
+          status: 'acknowledged',
+          content: 'Risk accepted for E2E test',
+          metadata: {
+            fingerprint: targetFinding.fingerprint,
+            ruleId: targetFinding.ruleId ?? 'UNKNOWN',
+            file: targetFinding.file,
+            line: targetFinding.line,
+          },
+        },
+      };
+
+      const mockWaiverReader: IWaiverReader = {
+        loadActiveWaivers: async () => [waiver],
+        hasActiveWaiver: async (fp: string) => fp === targetFinding.fingerprint,
+      };
+
+      const orchestrator = createOrchestrator({ waiverReader: mockWaiverReader });
+      const result = await orchestrator.run({
+        scope: 'full',
+        taskId: '1234567890-task-e2e-waiver',
+      });
+
+      // The waived finding should be marked
+      const waivedFinding = result.findings.find(
+        (f) => f.fingerprint === targetFinding.fingerprint,
+      );
+      expect(waivedFinding).toBeDefined();
+      expect(waivedFinding!.isWaived).toBe(true);
+      expect(waivedFinding!.waiver).toBeDefined();
+      expect(waivedFinding!.waiver!.fingerprint).toBe(targetFinding.fingerprint);
+
+      // Other findings should NOT be waived
+      const nonWaivedFindings = result.findings.filter(
+        (f) => f.fingerprint !== targetFinding.fingerprint,
+      );
+      for (const f of nonWaivedFindings) {
+        expect(f.isWaived).toBe(false);
+      }
+    });
+
+    it('[CG5] should not count waived finding toward failOn threshold', async () => {
+      // Verify baseline has high-severity findings
+      const highFinding = baselineResult.findings.find(
+        (f) => f.severity === 'critical' || f.severity === 'high',
+      );
+      expect(highFinding).toBeDefined();
+
+      // Waive ALL findings so nothing is active
+      const waivers: ActiveWaiver[] = baselineResult.findings.map((f) => ({
+        fingerprint: f.fingerprint,
+        ruleId: f.ruleId ?? 'UNKNOWN',
+        feedback: {
+          id: `1234567890-feedback-waiver-${f.fingerprint.slice(0, 8)}`,
+          entityType: 'execution' as const,
+          entityId: 'exec-e2e-previous',
+          type: 'approval' as const,
+          status: 'acknowledged' as const,
+          content: 'Risk accepted for E2E test',
+          metadata: {
+            fingerprint: f.fingerprint,
+            ruleId: f.ruleId ?? 'UNKNOWN',
+            file: f.file,
+            line: f.line,
+          },
+        },
+      }));
+
+      const mockWaiverReader: IWaiverReader = {
+        loadActiveWaivers: async () => waivers,
+        hasActiveWaiver: async (fp: string) =>
+          waivers.some((w) => w.fingerprint === fp),
+      };
+
+      const orchestrator = createOrchestrator({ waiverReader: mockWaiverReader });
+      const result = await orchestrator.run({
+        scope: 'full',
+        taskId: '1234567890-task-e2e-waiver-policy',
+        failOn: 'low',
+      });
+
+      // All findings should be waived
+      for (const f of result.findings) {
+        expect(f.isWaived).toBe(true);
+      }
+
+      // Policy should PASS because waived findings are excluded from threshold
+      expect(result.policyDecision.decision).toBe('pass');
+    });
+  });
+
+  // ==========================================================================
+  // 4.3. Policy Evaluation (CG6 to CG8)
+  // ==========================================================================
+
+  describe('4.3. Policy Evaluation (CG6 to CG8)', () => {
+    it('[CG6] should return policyDecision block when findings above failOn severity', async () => {
+      const orchestrator = createOrchestrator();
+      const result = await orchestrator.run({
+        scope: 'full',
+        taskId: '1234567890-task-e2e-policy-block',
+        failOn: 'low',
+      });
+
+      expect(result.findings.length).toBeGreaterThanOrEqual(1);
+      expect(result.policyDecision.decision).toBe('block');
+      expect(result.policyDecision.reason).toBeTruthy();
+    });
+
+    it('[CG7] should return policyDecision pass when no findings above failOn severity', async () => {
+      // First get baseline findings, then waive them all
+      const baseOrchestrator = createOrchestrator();
+      const baseResult = await baseOrchestrator.run({
+        scope: 'full',
+        taskId: '1234567890-task-e2e-baseline-for-pass',
+      });
+
+      const waivers: ActiveWaiver[] = baseResult.findings.map((f) => ({
+        fingerprint: f.fingerprint,
+        ruleId: f.ruleId ?? 'UNKNOWN',
+        feedback: {
+          id: `1234567890-feedback-waiver-${f.fingerprint.slice(0, 8)}`,
+          entityType: 'execution' as const,
+          entityId: 'exec-e2e-previous',
+          type: 'approval' as const,
+          status: 'acknowledged' as const,
+          content: 'All waived for pass test',
+          metadata: {
+            fingerprint: f.fingerprint,
+            ruleId: f.ruleId ?? 'UNKNOWN',
+            file: f.file,
+            line: f.line,
+          },
+        },
+      }));
+
+      const mockWaiverReader: IWaiverReader = {
+        loadActiveWaivers: async () => waivers,
+        hasActiveWaiver: async (fp: string) =>
+          waivers.some((w) => w.fingerprint === fp),
+      };
+
+      const orchestrator = createOrchestrator({ waiverReader: mockWaiverReader });
+      const result = await orchestrator.run({
+        scope: 'full',
+        taskId: '1234567890-task-e2e-policy-pass',
+        failOn: 'critical',
+      });
+
+      expect(result.policyDecision.decision).toBe('pass');
+    });
+
+    it('[CG8] should return summary with accurate counts by severity', async () => {
+      const orchestrator = createOrchestrator();
+      const result = await orchestrator.run({
+        scope: 'full',
+        taskId: '1234567890-task-e2e-summary',
+      });
+
+      const { summary, findings } = result;
+
+      // Summary.total should equal findings count
+      expect(summary.total).toBe(findings.length);
+
+      // Manually count severities from findings (no waivers in this test)
+      const active = findings.filter((f) => !f.isWaived);
+      const expectedCritical = active.filter((f) => f.severity === 'critical').length;
+      const expectedHigh = active.filter((f) => f.severity === 'high').length;
+      const expectedMedium = active.filter((f) => f.severity === 'medium').length;
+      const expectedLow = active.filter((f) => f.severity === 'low').length;
+      const expectedSuppressed = findings.filter((f) => f.isWaived).length;
+
+      expect(summary.critical).toBe(expectedCritical);
+      expect(summary.high).toBe(expectedHigh);
+      expect(summary.medium).toBe(expectedMedium);
+      expect(summary.low).toBe(expectedLow);
+      expect(summary.suppressed).toBe(expectedSuppressed);
+
+      // Verify agents ran
+      expect(summary.agentsRun).toBe(1);
+      expect(summary.agentsFailed).toBe(0);
+
+      // Severity counts should sum to total (no waivers = no suppressed)
+      expect(
+        summary.critical + summary.high + summary.medium + summary.low + summary.suppressed,
+      ).toBe(summary.total);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,31 @@ importers:
         specifier: ^4.16.2
         version: 4.20.3
 
+  packages/agents/security-audit:
+    dependencies:
+      '@gitgov/core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.0.0
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.13
+      esbuild:
+        specifier: ^0.19.0
+        version: 0.19.12
+      jest:
+        specifier: ^29.0.0
+        version: 29.7.0(@types/node@20.19.13)
+      ts-jest:
+        specifier: ^29.0.0
+        version: 29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.13))(typescript@5.9.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.2
+
   packages/agents/source-audit:
     dependencies:
       '@gitgov/core':


### PR DESCRIPTION
## Summary

- **Cycle 1:** AuditOrchestrator + security-audit agent MVP (13 EARS, 15 tests)
- **Cycle 2:** PolicyEvaluator stub (4 EARS, 7 tests) + E2E Block G (8 EARS, 8 tests)
- 3 new modules: `audit_orchestrator`, `policy_evaluator`, `security-audit` agent
- README updated with new modules

## Modules

| Module | Package | EARS | Tests |
|--------|---------|------|-------|
| `audit_orchestrator` | `@gitgov/core` | 10 (AORCH-A1, B1-B8, B12) | 12 |
| `policy_evaluator` | `@gitgov/core` | 4 (AORCH-C7-C10) | 7 |
| `security-audit` agent | `packages/agents/security-audit` | 3 (AORCH-B9-B11) | 3 |
| E2E Block G | `packages/e2e` | 8 (CG1-CG8) | 8 |

## Test plan

- [x] `pnpm --filter @gitgov/core test -- audit_orchestrator` (12/12)
- [x] `pnpm --filter @gitgov/core test -- policy_evaluator` (7/7)
- [x] Agent tests via `npx jest` in `packages/agents/security-audit` (3/3)
- [x] E2E Block G via vitest (8/8)
- [x] `tsc --noEmit` (0 errors)
- [x] `/audit audit_orchestrator` — 4 audits PASS (87/87 EARS across all modules)
- [x] `/audit-cycle 1` — 26/26 criteria verified

## Deferred (requires CLI DI wiring)

- CLI refactor: `--agent` flag, remove `--detector`/`--target` (AORCH-C1-C6)
- CLI E2E tests (AORCH-C11-C14)
- ExecutionRecord type:"decision" (Epic 5 — policy_evaluation)

Part of #115