### PR TITLE
fix(agents): security-audit Cycle 2 fixtures and test paths

### DIFF
--- a/packages/agents/security-audit/actor-record.example.json
+++ b/packages/agents/security-audit/actor-record.example.json
@@ -1,0 +1,18 @@
+{
+  "header": {
+    "version": "1.0",
+    "type": "actor",
+    "payloadChecksum": "b56ec458debb1e17125a9d16140c3892cd92053be64d526856b95442dad5bb47",
+    "signatures": []
+  },
+  "payload": {
+    "id": "agent:gitgov:security-audit",
+    "type": "agent",
+    "displayName": "Security Audit Agent",
+    "publicKey": "f2KDakrcn5NyNveEad5QB0c3zBBvx5bAKyYwf/lK/Bw=",
+    "roles": [
+      "executor"
+    ],
+    "status": "active"
+  }
+}

--- a/packages/agents/security-audit/agent-record.example.json
+++ b/packages/agents/security-audit/agent-record.example.json
@@ -2,7 +2,7 @@
   "header": {
     "version": "1.0",
     "type": "agent",
-    "payloadChecksum": "",
+    "payloadChecksum": "9a7988137c5d63eb0c6d32d01c6c010573dfdeee5f1fe718e0745c94ade1be3e",
     "signatures": []
   },
   "payload": {
@@ -14,7 +14,11 @@
       "entrypoint": "packages/agents/security-audit/dist/index.mjs",
       "function": "runAgent"
     },
-    "triggers": [{ "type": "manual" }],
+    "triggers": [
+      {
+        "type": "manual"
+      }
+    ],
     "knowledge_dependencies": [],
     "prompt_engine_requirements": {},
     "metadata": {
@@ -23,11 +27,19 @@
       "audit": {
         "target": "code",
         "outputFormat": "sarif",
-        "supportedScopes": ["diff", "full", "baseline"]
+        "supportedScopes": [
+          "diff",
+          "full",
+          "baseline"
+        ]
       },
       "version": "2.0.0",
       "replaces": "agent:source-audit (PoC)",
-      "evolves_epic2_ears": ["AORCH-B9", "AORCH-B10", "AORCH-B11"]
+      "evolves_epic2_ears": [
+        "AORCH-B9",
+        "AORCH-B10",
+        "AORCH-B11"
+      ]
     }
   }
 }

--- a/packages/agents/security-audit/agent_runner.integration.test.ts
+++ b/packages/agents/security-audit/agent_runner.integration.test.ts
@@ -21,8 +21,8 @@ import type { SecurityAuditInput, AgentDetectorConfig } from './src/types';
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
-const AGENT_RECORD_PATH = path.resolve(__dirname, '../../../.gitgov/agents/agent-security-audit.json');
-const ACTOR_RECORD_PATH = path.resolve(__dirname, '../../../.gitgov/actors/actor-security-audit.json');
+const AGENT_RECORD_PATH = path.resolve(__dirname, 'agent-record.example.json');
+const ACTOR_RECORD_PATH = path.resolve(__dirname, 'actor-record.example.json');
 
 function loadJson(filePath: string): Record<string, unknown> {
   return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<string, unknown>;

--- a/packages/agents/security-audit/tsconfig.json
+++ b/packages/agents/security-audit/tsconfig.json
@@ -15,7 +15,12 @@
     "moduleDetection": "force",
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "paths": {
+      "@gitgov/core": ["../../core/src/index.ts"],
+      "@gitgov/core/*": ["../../core/src/*"]
+    },
+    "baseUrl": "."
   },
   "include": ["src", "*.test.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Create `actor-record.example.json` with Ed25519 public key and valid `payloadChecksum` — enables AAV2-E2 and AAV2-G3 tests
- Compute real `payloadChecksum` (SHA-256) in `agent-record.example.json` (was empty string) — fixes AAV2-E1
- Update integration test paths from `.gitgov/` (gitignored) to local fixture files — tests are now self-contained
- Add `tsconfig.json` paths for `@gitgov/core` resolution — `tsc --noEmit` clean

## Test plan

- [x] 28/28 tests passing (`npx jest --no-cache`)
- [x] `tsc --noEmit` clean
- [x] All 5 test suites green (agent, config, index, readme, integration)
- [x] EARS AAV2-E1 to E4, F1-F2, G1-G4 verified