### PR TITLE
feat(core): policy evaluation engine with OPA integration — Cycle 1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,6 +77,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^22.0.1",
+    "@open-policy-agent/opa-wasm": "^1.10.0",
     "ajv": "^8.17.1",
     "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^3.0.1",

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.test.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.test.ts
@@ -2,7 +2,6 @@ import { createAuditOrchestrator } from "./audit_orchestrator";
 import type {
   AuditOrchestratorDeps,
   AuditOrchestrationOptions,
-  PolicyDecisionStub,
 } from "./audit_orchestrator.types";
 import type { SarifLog, SarifResult } from "../sarif/sarif.types";
 import type { RecordStore } from "../record_store/record_store";
@@ -10,6 +9,11 @@ import type { GitGovAgentRecord } from "../record_types";
 import type { IAgentRunner } from "../agent_runner/agent_runner";
 import type { RunOptions, AgentResponse } from "../agent_runner/agent_runner.types";
 import type { IWaiverReader, ActiveWaiver } from "../source_auditor/types";
+import type {
+  PolicyEvaluator,
+  PolicyEvaluationResult,
+  PolicyDecision,
+} from "../policy_evaluator/policy_evaluator.types";
 
 // ============================================================================
 // Test helpers
@@ -91,14 +95,40 @@ function makeAgentResponse(
   };
 }
 
-function makePolicyStub(
+function makePolicyDecision(
   decision: "pass" | "block" = "pass",
   reason: string = "No issues",
-): PolicyDecisionStub {
+): PolicyDecision {
   return {
     decision,
     reason,
-    executionRecordId: "exec-policy-001",
+    blockingFindings: [],
+    waivedFindings: [],
+    summary: { critical: 0, high: 0, medium: 0, low: 0 },
+    rulesEvaluated: [],
+    evaluatedAt: new Date().toISOString(),
+  };
+}
+
+function makePolicyResult(
+  decision: "pass" | "block" = "pass",
+  reason: string = "No issues",
+): PolicyEvaluationResult {
+  const policyDecision = makePolicyDecision(decision, reason);
+  return {
+    decision: policyDecision,
+    executionRecord: {
+      id: `exec-policy-test-${Date.now()}`,
+      type: "decision",
+      title: "Policy evaluation",
+      result: decision === "pass" ? "PASS" : "BLOCK",
+      references: [],
+      metadata: {
+        kind: "policy-decision",
+        version: "1.0.0",
+        data: policyDecision,
+      },
+    },
   };
 }
 
@@ -121,8 +151,8 @@ function createMockDeps(overrides?: Partial<AuditOrchestratorDeps>): AuditOrches
     hasActiveWaiver: jest.fn().mockResolvedValue(false),
   };
 
-  const policyEvaluator = {
-    evaluate: jest.fn().mockResolvedValue(makePolicyStub()),
+  const policyEvaluator: PolicyEvaluator = {
+    evaluate: jest.fn().mockResolvedValue(makePolicyResult()),
   };
 
   return {
@@ -298,7 +328,7 @@ describe("AuditOrchestrator", () => {
       expect(result.summary.total).toBe(0);
       expect(result.summary.agentsRun).toBe(0);
       expect(deps.agentRunner.runOnce).not.toHaveBeenCalled();
-      expect(result.warning).toBe('No audit agents found');
+      expect(result.warning).toBe("No audit agents found");
     });
 
     it("[AORCH-B4] should collect SarifLog and include in agentResults with status success when agent succeeds", async () => {
@@ -618,6 +648,38 @@ describe("AuditOrchestrator", () => {
         },
       };
 
+      // Set up policy evaluator mock to return waived finding in decision
+      // (orchestrator now derives waiver state from policy decision, not independently)
+      const waivedConsolidatedFinding = {
+        fingerprint: "waived-hash-001",
+        ruleId: "SEC-001",
+        message: "Hardcoded secret",
+        severity: "critical" as const,
+        category: "hardcoded-secret",
+        file: "src/config.ts",
+        line: 10,
+        reportedBy: ["agent:security-audit"],
+        isWaived: true,
+        waiver: activeWaiver,
+      };
+      const policyDecision = makePolicyDecision("pass", "All waived");
+      policyDecision.waivedFindings = [waivedConsolidatedFinding];
+      const policyResult: PolicyEvaluationResult = {
+        decision: policyDecision,
+        executionRecord: {
+          id: `exec-policy-test-${Date.now()}`,
+          type: "decision",
+          title: "Policy evaluation",
+          result: "PASS",
+          references: [],
+          metadata: {
+            kind: "policy-decision",
+            version: "1.0.0",
+            data: policyDecision,
+          },
+        },
+      };
+
       const deps = createMockDeps();
       (deps.recordStore.list as jest.Mock).mockResolvedValue(["agent:security-audit"]);
       (deps.recordStore.get as jest.Mock).mockResolvedValue(agentRecord);
@@ -627,6 +689,7 @@ describe("AuditOrchestrator", () => {
       (deps.waiverReader.loadActiveWaivers as jest.Mock).mockResolvedValue([
         activeWaiver,
       ]);
+      (deps.policyEvaluator.evaluate as jest.Mock).mockResolvedValue(policyResult);
 
       const orchestrator = createAuditOrchestrator(deps);
       const result = await orchestrator.run(defaultOptions);

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.ts
@@ -14,6 +14,7 @@ import type {
   AuditSummary,
   FindingSeverity,
 } from "./audit_orchestrator.types";
+import type { PolicyEvaluationInput } from "../policy_evaluator/policy_evaluator.types";
 
 /**
  * Creates an empty SarifLog (used for error cases).
@@ -192,33 +193,12 @@ function consolidateFindings(
 }
 
 /**
- * Applies active waivers as suppressions on consolidated findings.
- * A waiver is a FeedbackRecord with type: "approval" and metadata.fingerprint.
- * Matching is by fingerprint (primaryLocationLineHash/v1).
- */
-function applyWaivers(
-  findings: ConsolidatedFinding[],
-  waivers: ActiveWaiver[],
-): ConsolidatedFinding[] {
-  const waiverByFingerprint = new Map(
-    waivers.filter((w) => w.fingerprint).map((w) => [w.fingerprint, w]),
-  );
-
-  return findings.map((finding) => {
-    const waiver = waiverByFingerprint.get(finding.fingerprint);
-    if (waiver) {
-      return {
-        ...finding,
-        isWaived: true,
-        waiver,
-      };
-    }
-    return finding;
-  });
-}
-
-/**
  * Builds the summary counts for CLI display.
+ *
+ * NOTE: `total` counts ALL findings (including waived), while severity counts
+ * (critical, high, medium, low) only count non-waived (active) findings.
+ * This asymmetry is intentional: `total` reflects the full scan scope,
+ * severity counts reflect actionable findings for the policy decision.
  */
 function buildSummary(
   findings: ConsolidatedFinding[],
@@ -249,8 +229,8 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
      * 2. Filter by agentId if specified
      * 3. Execute via AgentRunner (Promise.allSettled)
      * 4. Consolidate SARIF findings, dedup by fingerprint
-     * 5. Apply waivers
-     * 6. Evaluate policy
+     * 5. Load active waivers
+     * 6. Pass raw findings + waivers to PolicyEvaluator
      * 7. Return AuditOrchestrationResult
      */
     async run(
@@ -262,23 +242,29 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
         options.agentId,
       );
 
+      // Load waivers upfront (needed for policy evaluation)
+      let waivers: ActiveWaiver[] = [];
+      try {
+        waivers = await deps.waiverReader.loadActiveWaivers();
+      } catch {
+        // WaiverReader failure is non-fatal: findings remain unsuppressed (AORCH-B7)
+      }
+
       // 2. If no agents found, return empty result with warning (AORCH-B3)
       if (auditAgents.length === 0) {
-        const policyOpts: { failOn?: FindingSeverity; taskId: string } = {
+        const policyInput: PolicyEvaluationInput = {
+          findings: [],
+          activeWaivers: waivers,
+          policy: { failOn: options.failOn ?? "critical" },
+          scanExecutionIds: [],
           taskId: options.taskId,
         };
-        if (options.failOn !== undefined) {
-          policyOpts.failOn = options.failOn;
-        }
-        const policyDecision = await deps.policyEvaluator.evaluate(
-          [],
-          policyOpts,
-        );
+        const policyResult = await deps.policyEvaluator.evaluate(policyInput);
 
         return {
           findings: [],
           agentResults: [],
-          policyDecision,
+          policyDecision: policyResult.decision,
           summary: {
             total: 0,
             critical: 0,
@@ -291,9 +277,9 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
           },
           executionIds: {
             scans: [],
-            policy: policyDecision.executionRecordId,
+            policy: "",
           },
-          warning: 'No audit agents found',
+          warning: "No audit agents found",
         };
       }
 
@@ -323,38 +309,48 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
       // 4. Consolidate findings with dedup by fingerprint
       const rawFindings = consolidateFindings(agentResults);
 
-      // 5. Load active waivers and apply as suppressions
-      // Graceful degradation: if WaiverReader fails, continue with findings unsuppressed (AORCH-B7)
-      let waivers: ActiveWaiver[] = [];
-      try {
-        waivers = await deps.waiverReader.loadActiveWaivers();
-      } catch {
-        // WaiverReader failure is non-fatal: findings remain unsuppressed
-      }
-      const findings = applyWaivers(rawFindings, waivers);
-
-      // 6. Evaluate policy
-      const policyOpts2: { failOn?: FindingSeverity; taskId: string } = {
+      // 5-6. Pass raw findings + waivers to PolicyEvaluator (it handles waiver application internally)
+      const scanExecutionIds = agentResults.map((r) => r.executionId);
+      const policyInput: PolicyEvaluationInput = {
+        findings: rawFindings,
+        activeWaivers: waivers,
+        policy: { failOn: options.failOn ?? "critical" },
+        scanExecutionIds,
         taskId: options.taskId,
       };
-      if (options.failOn !== undefined) {
-        policyOpts2.failOn = options.failOn;
-      }
-      const policyDecision = await deps.policyEvaluator.evaluate(
-        findings,
-        policyOpts2,
+      const policyResult = await deps.policyEvaluator.evaluate(policyInput);
+
+      // Derive findings with waiver state from the policy decision to avoid
+      // duplicating waiver application logic (PolicyEvaluator is the single source
+      // of truth for waiver matching — see MEDIA-5).
+      const waivedFingerprints = new Set(
+        policyResult.decision.waivedFindings.map((f) => f.fingerprint),
       );
+      const waiverByFingerprint = new Map<string, ActiveWaiver>();
+      for (const f of policyResult.decision.waivedFindings) {
+        if (f.waiver) {
+          waiverByFingerprint.set(f.fingerprint, f.waiver);
+        }
+      }
+      const findingsWithWaivers = rawFindings.map((f) => {
+        const waiver = waiverByFingerprint.get(f.fingerprint);
+        if (waivedFingerprints.has(f.fingerprint) && waiver) {
+          return { ...f, isWaived: true, waiver };
+        }
+        return f;
+      });
 
       return {
-        findings,
+        findings: findingsWithWaivers,
         agentResults,
-        policyDecision,
-        summary: buildSummary(findings, agentResults),
+        policyDecision: policyResult.decision,
+        summary: buildSummary(findingsWithWaivers, agentResults),
         executionIds: {
-          scans: agentResults.map((r) => r.executionId),
-          policy: policyDecision.executionRecordId,
+          scans: scanExecutionIds,
+          policy: policyResult.executionRecord.id,
         },
       };
     },
   };
 }
+

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.types.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.types.ts
@@ -3,6 +3,13 @@ import type { RecordStore } from "../record_store/record_store";
 import type { GitGovAgentRecord } from "../record_types";
 import type { IAgentRunner } from "../agent_runner/agent_runner";
 import type { IWaiverReader, ActiveWaiver } from "../source_auditor/types";
+import type {
+  PolicyEvaluator,
+  PolicyDecision,
+} from "../policy_evaluator/policy_evaluator.types";
+
+// Re-export PolicyEvaluator types for consumers that import from audit_orchestrator
+export type { PolicyDecision, PolicyEvaluationResult } from "../policy_evaluator/policy_evaluator.types";
 
 // ============================================================================
 // ORCHESTRATION INPUT/OUTPUT
@@ -40,7 +47,7 @@ export type AuditOrchestrationResult = {
   /** Per-agent execution results */
   agentResults: AgentAuditResult[];
   /** Policy evaluation decision */
-  policyDecision: PolicyDecisionStub;
+  policyDecision: PolicyDecision;
   /** Aggregated summary */
   summary: AuditSummary;
   /** ExecutionRecord IDs created during this run */
@@ -150,18 +157,6 @@ export type AuditSummary = {
   agentsFailed: number;
 };
 
-/**
- * Policy evaluation result (stub in Cycle 1, formal in Cycle 2).
- */
-export type PolicyDecisionStub = {
-  /** Pass or block */
-  decision: "pass" | "block";
-  /** Human-readable reason for decision */
-  reason: string;
-  /** ExecutionRecord ID for the policy evaluation */
-  executionRecordId: string;
-};
-
 // ============================================================================
 // DEPENDENCY INJECTION
 // ============================================================================
@@ -179,14 +174,3 @@ export type AuditOrchestratorDeps = {
   /** PolicyEvaluator for pass/block decision */
   policyEvaluator: PolicyEvaluator;
 };
-
-/**
- * PolicyEvaluator interface.
- * Stub in Cycle 1 -- formal implementation in Cycle 2.
- */
-export interface PolicyEvaluator {
-  evaluate(
-    findings: ConsolidatedFinding[],
-    options: { failOn?: FindingSeverity; taskId: string },
-  ): Promise<PolicyDecisionStub>;
-}

--- a/packages/core/src/audit_orchestrator/index.ts
+++ b/packages/core/src/audit_orchestrator/index.ts
@@ -7,7 +7,7 @@ export type {
   AgentAuditInput,
   ConsolidatedFinding,
   AuditSummary,
-  PolicyDecisionStub,
   FindingSeverity,
-  PolicyEvaluator,
+  PolicyDecision,
+  PolicyEvaluationResult,
 } from "./audit_orchestrator.types";

--- a/packages/core/src/policy_evaluator/category_block.test.ts
+++ b/packages/core/src/policy_evaluator/category_block.test.ts
@@ -1,0 +1,102 @@
+/**
+ * CategoryBlock rule tests.
+ *
+ * EARS: PEVAL-C4, PEVAL-C5, PEVAL-C6
+ */
+
+import { categoryBlock } from "./category_block";
+import type {
+  ConsolidatedFinding,
+  PolicyConfig,
+} from "./policy_evaluator.types";
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function makeFinding(
+  overrides: Partial<ConsolidatedFinding> = {},
+): ConsolidatedFinding {
+  return {
+    fingerprint: "fp-test-001",
+    message: "test finding",
+    severity: "high",
+    category: "test",
+    file: "src/foo.ts",
+    line: 10,
+    reportedBy: ["agent-1"],
+    isWaived: false,
+    ...overrides,
+  };
+}
+
+function makeConfig(
+  overrides: Partial<PolicyConfig> = {},
+): PolicyConfig {
+  return {
+    failOn: "critical",
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("CategoryBlock", () => {
+  describe("4.3. Built-in rules (PEVAL-C4 to C6)", () => {
+    it("[PEVAL-C4] should return passed:false when non-waived findings in blocked categories", () => {
+      const findings = [
+        makeFinding({ fingerprint: "fp-1", category: "hardcoded-secret", isWaived: false }),
+        makeFinding({ fingerprint: "fp-2", category: "pii-ssn", isWaived: false }),
+        makeFinding({ fingerprint: "fp-3", category: "low-risk", isWaived: false }),
+      ];
+      const config = makeConfig({
+        blockCategories: ["hardcoded-secret", "pii-ssn"],
+      });
+
+      const result = categoryBlock.evaluate(findings, config);
+
+      expect(result.passed).toBe(false);
+      expect(result.ruleName).toBe("CategoryBlock");
+      expect(result.reason).toContain("2 finding(s) in blocked category");
+      expect(result.reason).toContain("hardcoded-secret");
+      expect(result.reason).toContain("pii-ssn");
+    });
+
+    it("[PEVAL-C5] should return passed:true when blockCategories is empty or undefined", () => {
+      const findings = [
+        makeFinding({ fingerprint: "fp-1", category: "hardcoded-secret", isWaived: false }),
+      ];
+
+      // undefined
+      const result1 = categoryBlock.evaluate(findings, makeConfig());
+      expect(result1.passed).toBe(true);
+      expect(result1.reason).toBe("No blocked categories configured");
+
+      // empty
+      const result2 = categoryBlock.evaluate(
+        findings,
+        makeConfig({ blockCategories: [] }),
+      );
+      expect(result2.passed).toBe(true);
+      expect(result2.reason).toBe("No blocked categories configured");
+    });
+
+    it("[PEVAL-C6] should return passed:true when all blocked-category findings are waived", () => {
+      const findings = [
+        makeFinding({ fingerprint: "fp-1", category: "hardcoded-secret", isWaived: true }),
+        makeFinding({ fingerprint: "fp-2", category: "pii-ssn", isWaived: true }),
+        makeFinding({ fingerprint: "fp-3", category: "low-risk", isWaived: false }),
+      ];
+      const config = makeConfig({
+        blockCategories: ["hardcoded-secret", "pii-ssn"],
+      });
+
+      const result = categoryBlock.evaluate(findings, config);
+
+      expect(result.passed).toBe(true);
+      expect(result.reason).toBe("All blocked-category findings are waived");
+    });
+  });
+});

--- a/packages/core/src/policy_evaluator/category_block.ts
+++ b/packages/core/src/policy_evaluator/category_block.ts
@@ -1,0 +1,53 @@
+/**
+ * CategoryBlock rule -- built-in PolicyRule.
+ *
+ * Blocks when non-waived findings belong to a blocked category.
+ * EARS: PEVAL-C4, PEVAL-C5, PEVAL-C6
+ */
+
+import type {
+  PolicyRule,
+  PolicyRuleResult,
+  ConsolidatedFinding,
+  PolicyConfig,
+} from "./policy_evaluator.types";
+
+export const categoryBlock: PolicyRule = {
+  name: "CategoryBlock",
+
+  evaluate(
+    findings: ConsolidatedFinding[],
+    config: PolicyConfig,
+  ): PolicyRuleResult {
+    if (!config.blockCategories?.length) {
+      return {
+        ruleName: "CategoryBlock",
+        passed: true,
+        reason: "No blocked categories configured",
+      };
+    }
+
+    const blockedSet = new Set(config.blockCategories);
+    const blocking = findings.filter(
+      (f) => !f.isWaived && blockedSet.has(f.category),
+    );
+
+    if (blocking.length === 0) {
+      const inBlocked = findings.filter((f) => blockedSet.has(f.category));
+      const reason =
+        inBlocked.length > 0 && inBlocked.every((f) => f.isWaived)
+          ? "All blocked-category findings are waived"
+          : "No findings in blocked categories";
+      return { ruleName: "CategoryBlock", passed: true, reason };
+    }
+
+    const categories = [...new Set(blocking.map((f) => f.category))].join(
+      ", ",
+    );
+    return {
+      ruleName: "CategoryBlock",
+      passed: false,
+      reason: `${String(blocking.length)} finding(s) in blocked category: ${categories}`,
+    };
+  },
+};

--- a/packages/core/src/policy_evaluator/index.ts
+++ b/packages/core/src/policy_evaluator/index.ts
@@ -1,7 +1,37 @@
+// Factory
 export { createPolicyEvaluator } from "./policy_evaluator";
+
+// Config loader
+export { loadPolicyConfig } from "./policy_config_loader";
+
+// Built-in rules
+export { severityThreshold } from "./severity_threshold";
+export { categoryBlock } from "./category_block";
+
+// OPA rule
+export { createOpaRule } from "./opa_rule";
+
+// Types and constants
+export {
+  SEVERITY_ORDER,
+} from "./policy_evaluator.types";
+
 export type {
+  PolicyEvaluationInput,
+  PolicyConfig,
+  OpaConfig,
+  PolicyConfigFile,
+  WaiverRequirement,
+  PolicyDecision,
+  PolicyRuleResult,
+  PolicyRule,
   PolicyEvaluator,
-  PolicyDecisionStub,
+  PolicyEvaluatorDeps,
+  PolicyEvaluationResult,
+  PolicyExecutionRecordData,
+  // Re-exports from canonical sources
   ConsolidatedFinding,
   FindingSeverity,
+  ActiveWaiver,
+  IWaiverReader,
 } from "./policy_evaluator.types";

--- a/packages/core/src/policy_evaluator/opa_rule.test.ts
+++ b/packages/core/src/policy_evaluator/opa_rule.test.ts
@@ -1,0 +1,247 @@
+/**
+ * OPA rule tests.
+ *
+ * EARS: PEVAL-O1 through PEVAL-O6
+ *
+ * These tests require the `opa` CLI to be installed.
+ * If not available, the suite is skipped.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { execSync } from "node:child_process";
+import { createOpaRule } from "./opa_rule";
+import type {
+  ConsolidatedFinding,
+  PolicyConfig,
+} from "./policy_evaluator.types";
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function makeFinding(
+  overrides: Partial<ConsolidatedFinding> = {},
+): ConsolidatedFinding {
+  return {
+    fingerprint: "fp-test-001",
+    message: "test finding",
+    severity: "high",
+    category: "test",
+    file: "src/foo.ts",
+    line: 10,
+    reportedBy: ["agent-1"],
+    isWaived: false,
+    ...overrides,
+  };
+}
+
+function makeConfig(
+  overrides: Partial<PolicyConfig> = {},
+): PolicyConfig {
+  return {
+    failOn: "critical",
+    ...overrides,
+  };
+}
+
+function createTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "peval-opa-test-"));
+}
+
+function isOpaAvailable(): boolean {
+  try {
+    execSync("opa version", { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// OPA v1 Rego syntax
+const BLOCKING_REGO = `package gitgov.policy.test_block
+
+import rego.v1
+
+block contains msg if {
+  some f in input.findings
+  f.category == "hardcoded-secret"
+  not f.isWaived
+  msg := sprintf("Secret found in %s:%d", [f.file, f.line])
+}
+`;
+
+const PASSING_REGO = `package gitgov.policy.test_pass
+
+import rego.v1
+
+block contains msg if {
+  some f in input.findings
+  f.category == "nonexistent-category"
+  msg := sprintf("Should never match: %s", [f.file])
+}
+`;
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+const describeIfOpa = isOpaAvailable() ? describe : describe.skip;
+
+describeIfOpa("OPA Rule", () => {
+  describe("4.9. OPA Integration (PEVAL-O1 to O6)", () => {
+    it("[PEVAL-O1] should load and evaluate .rego policies via OPA WASM runtime", async () => {
+      const dir = createTmpDir();
+      const regoPath = path.join(dir, "test_block.rego");
+      fs.writeFileSync(regoPath, BLOCKING_REGO, "utf-8");
+
+      const rule = await createOpaRule(regoPath, dir);
+
+      expect(rule.name).toBe("opa:test_block");
+
+      const findings = [
+        makeFinding({
+          fingerprint: "fp-1",
+          category: "hardcoded-secret",
+          file: "src/config.ts",
+          line: 10,
+          isWaived: false,
+        }),
+      ];
+
+      const result = rule.evaluate(findings, makeConfig());
+      expect(result.ruleName).toBe("opa:test_block");
+      // The rule should have evaluated (blocking or passing)
+      expect(typeof result.passed).toBe("boolean");
+
+      fs.rmSync(dir, { recursive: true });
+    });
+
+    it("[PEVAL-O2] should map OPA block results to PolicyRuleResult with passed false", async () => {
+      const dir = createTmpDir();
+      const regoPath = path.join(dir, "test_block.rego");
+      fs.writeFileSync(regoPath, BLOCKING_REGO, "utf-8");
+
+      const rule = await createOpaRule(regoPath, dir);
+
+      const findings = [
+        makeFinding({
+          fingerprint: "fp-1",
+          category: "hardcoded-secret",
+          file: "src/config.ts",
+          line: 10,
+          isWaived: false,
+        }),
+      ];
+
+      const result = rule.evaluate(findings, makeConfig());
+
+      expect(result.passed).toBe(false);
+      expect(result.reason).toContain("Secret found in src/config.ts:10");
+
+      fs.rmSync(dir, { recursive: true });
+    });
+
+    it("[PEVAL-O3] should return passed true when OPA policy produces no block results", async () => {
+      const dir = createTmpDir();
+      const regoPath = path.join(dir, "test_pass.rego");
+      fs.writeFileSync(regoPath, PASSING_REGO, "utf-8");
+
+      const rule = await createOpaRule(regoPath, dir);
+
+      const findings = [
+        makeFinding({
+          fingerprint: "fp-1",
+          category: "hardcoded-secret",
+          isWaived: false,
+        }),
+      ];
+
+      const result = rule.evaluate(findings, makeConfig());
+
+      expect(result.passed).toBe(true);
+      expect(result.reason).toBe("OPA policy passed");
+
+      fs.rmSync(dir, { recursive: true });
+    });
+
+    it("[PEVAL-O4] should pass ConsolidatedFinding as input.findings to OPA", async () => {
+      const dir = createTmpDir();
+      const regoPath = path.join(dir, "test_block.rego");
+      fs.writeFileSync(regoPath, BLOCKING_REGO, "utf-8");
+
+      const rule = await createOpaRule(regoPath, dir);
+
+      // Finding with matching category should trigger block
+      const matchingFindings = [
+        makeFinding({
+          fingerprint: "fp-1",
+          category: "hardcoded-secret",
+          file: "src/secrets.ts",
+          line: 42,
+          isWaived: false,
+        }),
+      ];
+
+      const result1 = rule.evaluate(matchingFindings, makeConfig());
+      expect(result1.passed).toBe(false);
+      expect(result1.reason).toContain("src/secrets.ts:42");
+
+      // Finding with non-matching category should pass
+      const nonMatchingFindings = [
+        makeFinding({
+          fingerprint: "fp-2",
+          category: "low-risk",
+          isWaived: false,
+        }),
+      ];
+
+      const result2 = rule.evaluate(nonMatchingFindings, makeConfig());
+      expect(result2.passed).toBe(true);
+
+      fs.rmSync(dir, { recursive: true });
+    });
+
+    it("[PEVAL-O5] should skip OPA evaluation when opa config is undefined", async () => {
+      // This is tested at the evaluator level (policy_evaluator.test.ts).
+      // At the rule level, createOpaRule is only called when policies are configured.
+      // Verify that the rule works correctly when called.
+      const dir = createTmpDir();
+      const regoPath = path.join(dir, "test_pass.rego");
+      fs.writeFileSync(regoPath, PASSING_REGO, "utf-8");
+
+      const rule = await createOpaRule(regoPath, dir);
+      const result = rule.evaluate([], makeConfig());
+
+      expect(result.passed).toBe(true);
+
+      fs.rmSync(dir, { recursive: true });
+    });
+
+    it("[PEVAL-O6] should log warning and skip when rego file does not exist", async () => {
+      const dir = createTmpDir();
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      const rule = await createOpaRule(
+        path.join(dir, "nonexistent.rego"),
+        dir,
+      );
+
+      // Should return a no-op rule
+      const result = rule.evaluate(
+        [makeFinding({ fingerprint: "fp-1" })],
+        makeConfig(),
+      );
+      expect(result.passed).toBe(true);
+      expect(result.reason).toBe("OPA policy skipped");
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+
+      warnSpy.mockRestore();
+      fs.rmSync(dir, { recursive: true });
+    });
+  });
+});

--- a/packages/core/src/policy_evaluator/opa_rule.ts
+++ b/packages/core/src/policy_evaluator/opa_rule.ts
@@ -1,0 +1,256 @@
+/**
+ * OPA rule -- PolicyRule implemented via OPA WASM runtime.
+ *
+ * Compiles .rego files to WASM using `opa build`, then evaluates
+ * using @open-policy-agent/opa-wasm.
+ *
+ * EARS: PEVAL-O1, PEVAL-O2, PEVAL-O3, PEVAL-O4, PEVAL-O5, PEVAL-O6
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execSync } from "node:child_process";
+import * as zlib from "node:zlib";
+import type {
+  PolicyRule,
+  PolicyRuleResult,
+  ConsolidatedFinding,
+  PolicyConfig,
+  ActiveWaiver,
+} from "./policy_evaluator.types";
+
+/**
+ * Input format for OPA evaluation.
+ * OPA receives ConsolidatedFinding[] as input.findings (flat, SARIF-derived).
+ */
+type OpaInput = {
+  findings: ConsolidatedFinding[];
+  waivers: ActiveWaiver[];
+  config: {
+    failOn: string;
+    blockCategories: string[];
+    waiverRequirements: Record<string, { role: string; minApprovals: number }>;
+    opa: { policies: string[] } | null;
+  };
+};
+
+/** Minimal interface for the loaded OPA policy to avoid importing the class type. */
+type LoadedOpaPolicy = {
+  setData(data: object): void;
+  evaluate(input: OpaInput): Array<{ result: unknown }>;
+};
+
+/**
+ * Extracts policy.wasm from the tar.gz bundle produced by `opa build`.
+ * OPA bundles are standard tar.gz containing /policy.wasm and /data.json.
+ */
+function extractWasmFromBundle(bundlePath: string): Buffer {
+  const gzipped = fs.readFileSync(bundlePath);
+  const tar = zlib.gunzipSync(gzipped);
+
+  // Tar format: 512-byte header blocks followed by data blocks
+  let offset = 0;
+  while (offset < tar.length) {
+    // Read filename from header (first 100 bytes, null-terminated)
+    const nameBytes = tar.subarray(offset, offset + 100);
+    const nameEnd = nameBytes.indexOf(0);
+    const name = nameBytes
+      .subarray(0, nameEnd === -1 ? 100 : nameEnd)
+      .toString("utf-8")
+      .replace(/^\.\//, "");
+
+    // Read file size from header (octal, bytes 124-135)
+    const sizeStr = tar
+      .subarray(offset + 124, offset + 136)
+      .toString("utf-8")
+      .trim();
+    const size = parseInt(sizeStr, 8);
+
+    if (isNaN(size) || size === 0) {
+      offset += 512;
+      continue;
+    }
+
+    // Data starts after the 512-byte header
+    const dataStart = offset + 512;
+
+    if (name === "policy.wasm" || name === "/policy.wasm") {
+      return Buffer.from(tar.subarray(dataStart, dataStart + size));
+    }
+
+    // Advance past header + data (rounded up to 512-byte boundary)
+    offset = dataStart + Math.ceil(size / 512) * 512;
+  }
+
+  throw new Error("policy.wasm not found in OPA bundle");
+}
+
+/**
+ * Checks if the `opa` CLI is available.
+ */
+function isOpaCLIAvailable(): boolean {
+  try {
+    execSync("opa version", { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Creates an OPA-based PolicyRule from a .rego file.
+ *
+ * The .rego file is compiled to WASM using `opa build`, then loaded
+ * via @open-policy-agent/opa-wasm for evaluation.
+ *
+ * @param regoPath - Path to the .rego file (absolute or relative to repoRoot)
+ * @param repoRoot - Repository root for resolving relative paths
+ */
+export async function createOpaRule(
+  regoPath: string,
+  repoRoot: string,
+): Promise<PolicyRule> {
+  const filename = path.basename(regoPath, ".rego");
+  const ruleName = `opa:${filename}`;
+
+  // No-op rule factory for error cases (PEVAL-O6)
+  const noOpRule: PolicyRule = {
+    name: ruleName,
+    evaluate(
+      _findings: ConsolidatedFinding[],
+      _config: PolicyConfig,
+    ): PolicyRuleResult {
+      return {
+        ruleName,
+        passed: true,
+        reason: "OPA policy skipped",
+      };
+    },
+  };
+
+  // Check opa CLI availability
+  if (!isOpaCLIAvailable()) {
+    console.warn(`[PolicyEvaluator] opa CLI not available, skipping ${regoPath}`);
+    return noOpRule;
+  }
+
+  // Resolve path
+  const absoluteRegoPath = path.isAbsolute(regoPath)
+    ? regoPath
+    : path.resolve(repoRoot, regoPath);
+
+  // Check if .rego file exists (PEVAL-O6)
+  if (!fs.existsSync(absoluteRegoPath)) {
+    console.warn(
+      `[PolicyEvaluator] .rego file not found: ${absoluteRegoPath}, skipping`,
+    );
+    return noOpRule;
+  }
+
+  // Read .rego to extract package name for entrypoint
+  const regoContent = fs.readFileSync(absoluteRegoPath, "utf-8");
+  const packageMatch = regoContent.match(/^package\s+([\w.]+)/m);
+  if (!packageMatch?.[1]) {
+    console.warn(
+      `[PolicyEvaluator] No package declaration found in ${absoluteRegoPath}, skipping`,
+    );
+    return noOpRule;
+  }
+  const packagePath = packageMatch[1].replace(/\./g, "/");
+  const entrypoint = `${packagePath}/block`;
+
+  // Compile to WASM bundle
+  const bundlePath = path.join(
+    path.dirname(absoluteRegoPath),
+    `${filename}_bundle.tar.gz`,
+  );
+
+  try {
+    execSync(
+      `opa build -t wasm -e "${entrypoint}" -o "${bundlePath}" "${absoluteRegoPath}"`,
+      { stdio: "pipe" },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[PolicyEvaluator] opa build failed for ${regoPath}: ${msg}`);
+    return noOpRule;
+  }
+
+  // Extract policy.wasm from the tar.gz bundle
+  let wasmBuffer: Buffer;
+  try {
+    wasmBuffer = extractWasmFromBundle(bundlePath);
+  } finally {
+    // Cleanup bundle file
+    try {
+      fs.unlinkSync(bundlePath);
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+
+  // Load WASM policy via @open-policy-agent/opa-wasm
+  const { loadPolicy } = await import("@open-policy-agent/opa-wasm");
+  const policy = (await loadPolicy(wasmBuffer)) as LoadedOpaPolicy;
+  policy.setData({});
+
+  return {
+    name: ruleName,
+
+    evaluate(
+      findings: ConsolidatedFinding[],
+      config: PolicyConfig,
+    ): PolicyRuleResult {
+      // Build OPA input (PEVAL-O4)
+      // Waivers are already applied to findings (isWaived flag set), but
+      // we pass the full activeWaivers for OPA policies that need waiver metadata.
+      const activeWaivers = findings
+        .filter((f): f is ConsolidatedFinding & { waiver: ActiveWaiver } => f.isWaived && f.waiver !== undefined)
+        .map((f) => f.waiver);
+      const input: OpaInput = {
+        findings,
+        waivers: activeWaivers,
+        config: {
+          failOn: config.failOn,
+          blockCategories: config.blockCategories ?? [],
+          waiverRequirements: config.waiverRequirements ?? {},
+          opa: config.opa ?? null,
+        },
+      };
+
+      const evalResult = policy.evaluate(input);
+      const firstResult = evalResult[0];
+
+      // Extract block messages from result
+      let blockMessages: string[] = [];
+      if (firstResult?.result) {
+        const result = firstResult.result;
+        if (Array.isArray(result)) {
+          blockMessages = result.filter(
+            (m): m is string => typeof m === "string",
+          );
+        } else if (result instanceof Set) {
+          blockMessages = [...result].filter(
+            (m): m is string => typeof m === "string",
+          );
+        }
+      }
+
+      // PEVAL-O3: No block results -> pass
+      if (blockMessages.length === 0) {
+        return {
+          ruleName,
+          passed: true,
+          reason: "OPA policy passed",
+        };
+      }
+
+      // PEVAL-O2: block results -> fail
+      return {
+        ruleName,
+        passed: false,
+        reason: blockMessages.join("; "),
+      };
+    },
+  };
+}

--- a/packages/core/src/policy_evaluator/policy_config_loader.test.ts
+++ b/packages/core/src/policy_evaluator/policy_config_loader.test.ts
@@ -1,0 +1,137 @@
+/**
+ * PolicyConfigLoader tests.
+ *
+ * EARS: PEVAL-P1, PEVAL-P2, PEVAL-P3, PEVAL-P4
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { loadPolicyConfig } from "./policy_config_loader";
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function createTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "peval-test-"));
+}
+
+function writePolicyYml(dir: string, content: string): void {
+  fs.writeFileSync(path.join(dir, "policy.yml"), content, "utf-8");
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("PolicyConfigLoader", () => {
+  describe("4.0. policy.yml Schema + Loader (PEVAL-P1 to P4)", () => {
+    it("[PEVAL-P1] should load and parse policy.yml into PolicyConfig", async () => {
+      const dir = createTmpDir();
+      writePolicyYml(
+        dir,
+        `
+version: "1.0"
+failOn: high
+blockCategories:
+  - hardcoded-secret
+  - pii-ssn
+`,
+      );
+
+      const config = await loadPolicyConfig(dir);
+
+      expect(config.failOn).toBe("high");
+      expect(config.blockCategories).toEqual(["hardcoded-secret", "pii-ssn"]);
+
+      fs.rmSync(dir, { recursive: true });
+    });
+
+    it("[PEVAL-P2] should validate waiver FeedbackRecords against roles and minApprovals", async () => {
+      const dir = createTmpDir();
+      writePolicyYml(
+        dir,
+        `
+version: "1.0"
+failOn: critical
+waiverRequirements:
+  hardcoded-secret:
+    role: ciso
+    minApprovals: 1
+  pii-ssn:
+    role: security-lead
+    minApprovals: 2
+`,
+      );
+
+      const config = await loadPolicyConfig(dir);
+
+      expect(config.waiverRequirements).toBeDefined();
+      const secretReq = config.waiverRequirements?.["hardcoded-secret"];
+      expect(secretReq).toEqual({ role: "ciso", minApprovals: 1 });
+      const piiReq = config.waiverRequirements?.["pii-ssn"];
+      expect(piiReq).toEqual({ role: "security-lead", minApprovals: 2 });
+
+      // Invalid: minApprovals < 1
+      const dir2 = createTmpDir();
+      writePolicyYml(
+        dir2,
+        `
+version: "1.0"
+failOn: critical
+waiverRequirements:
+  hardcoded-secret:
+    role: ciso
+    minApprovals: 0
+`,
+      );
+
+      await expect(loadPolicyConfig(dir2)).rejects.toThrow(
+        "Invalid waiverRequirement",
+      );
+
+      fs.rmSync(dir, { recursive: true });
+      fs.rmSync(dir2, { recursive: true });
+    });
+
+    it("[PEVAL-P3] should use default PolicyConfig when policy.yml is absent", async () => {
+      const dir = createTmpDir();
+
+      const config = await loadPolicyConfig(dir);
+
+      expect(config.failOn).toBe("critical");
+      expect(config.blockCategories).toBeUndefined();
+      expect(config.waiverRequirements).toBeUndefined();
+
+      fs.rmSync(dir, { recursive: true });
+    });
+
+    it("[PEVAL-P4] should pass blockCategories to CategoryBlock rule", async () => {
+      const dir = createTmpDir();
+      writePolicyYml(
+        dir,
+        `
+version: "1.0"
+failOn: high
+blockCategories:
+  - hardcoded-secret
+  - pii-ssn
+  - weak-crypto
+`,
+      );
+
+      const config = await loadPolicyConfig(dir);
+
+      expect(config.blockCategories).toEqual([
+        "hardcoded-secret",
+        "pii-ssn",
+        "weak-crypto",
+      ]);
+      // blockCategories are available for CategoryBlock rule consumption
+      expect(config.blockCategories).toHaveLength(3);
+
+      fs.rmSync(dir, { recursive: true });
+    });
+  });
+});

--- a/packages/core/src/policy_evaluator/policy_config_loader.ts
+++ b/packages/core/src/policy_evaluator/policy_config_loader.ts
@@ -1,0 +1,83 @@
+/**
+ * Policy config loader.
+ *
+ * Loads and parses .gitgov/policy.yml into PolicyConfig.
+ * Returns default config (failOn: "critical") when file is absent.
+ *
+ * EARS: PEVAL-P1, PEVAL-P2, PEVAL-P3, PEVAL-P4
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as yaml from "js-yaml";
+import type { PolicyConfig, PolicyConfigFile } from "./policy_evaluator.types";
+
+const VALID_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
+
+const DEFAULT_CONFIG: PolicyConfig = {
+  failOn: "critical",
+};
+
+/**
+ * Loads and parses .gitgov/policy.yml into PolicyConfig.
+ * Returns default config (failOn: "critical") when file is absent.
+ */
+export async function loadPolicyConfig(
+  gitgovDir: string,
+): Promise<PolicyConfig> {
+  const policyPath = path.join(gitgovDir, "policy.yml");
+
+  let content: string;
+  try {
+    content = await fs.promises.readFile(policyPath, "utf-8");
+  } catch {
+    // File not found -- return default config (PEVAL-P3)
+    return { ...DEFAULT_CONFIG };
+  }
+
+  const parsed = yaml.load(content) as PolicyConfigFile | undefined;
+
+  if (!parsed || typeof parsed !== "object") {
+    return { ...DEFAULT_CONFIG };
+  }
+
+  // Validate failOn (PEVAL-P1)
+  if (!VALID_SEVERITIES.has(parsed.failOn)) {
+    throw new Error(
+      `Invalid failOn value "${String(parsed.failOn)}" in policy.yml. Must be one of: critical, high, medium, low`,
+    );
+  }
+
+  const config: PolicyConfig = {
+    failOn: parsed.failOn,
+  };
+
+  // blockCategories (PEVAL-P4)
+  if (parsed.blockCategories) {
+    config.blockCategories = parsed.blockCategories;
+  }
+
+  // waiverRequirements (PEVAL-P2)
+  if (parsed.waiverRequirements) {
+    for (const [category, req] of Object.entries(parsed.waiverRequirements)) {
+      if (
+        !req ||
+        typeof req.role !== "string" ||
+        typeof req.minApprovals !== "number" ||
+        req.minApprovals < 1
+      ) {
+        throw new Error(
+          `Invalid waiverRequirement for category "${category}": requires role (string) and minApprovals (number >= 1)`,
+        );
+      }
+    }
+    config.waiverRequirements = parsed.waiverRequirements;
+  }
+
+  // OPA config
+  if (parsed.opa?.policies) {
+    config.opa = { policies: parsed.opa.policies };
+  }
+
+  return config;
+}

--- a/packages/core/src/policy_evaluator/policy_evaluator.test.ts
+++ b/packages/core/src/policy_evaluator/policy_evaluator.test.ts
@@ -1,5 +1,44 @@
+/**
+ * PolicyEvaluator tests -- Epic 5: policy_evaluation.
+ *
+ * Trazabilidad:
+ * | EARS ID   | Test                                                                         | Section  |
+ * |:----------|:-----------------------------------------------------------------------------|:---------|
+ * | PEVAL-A1  | should require all fields in PolicyEvaluationInput                            | 4.1      |
+ * | PEVAL-A2  | should include required fields and optional ruleId in ConsolidatedFinding     | 4.1      |
+ * | PEVAL-A3  | should require failOn in PolicyConfig and allow optional fields               | 4.1      |
+ * | PEVAL-A4  | should include all fields in PolicyDecision                                   | 4.1      |
+ * | PEVAL-A5  | should include ruleName, passed, and reason in PolicyRuleResult               | 4.1      |
+ * | PEVAL-D1  | should apply active waivers to findings before evaluating rules               | 4.4      |
+ * | PEVAL-D2  | should set isWaived:true and attach waiver when fingerprint matches           | 4.4      |
+ * | PEVAL-D3  | should set decision to block when any rule returns passed:false               | 4.4      |
+ * | PEVAL-D4  | should set decision to pass when all rules return passed:true                 | 4.4      |
+ * | PEVAL-D5  | should populate blockingFindings with findings causing rule failure            | 4.4      |
+ * | PEVAL-D6  | should populate waivedFindings with all findings where isWaived is true       | 4.4      |
+ * | PEVAL-D7  | should set evaluatedAt to a valid ISO 8601 timestamp                         | 4.4      |
+ * | PEVAL-D8  | should evaluate custom rules after built-in rules                            | 4.4      |
+ * | PEVAL-D9  | should return decision pass with empty blockingFindings when findings is empty| 4.4      |
+ * | PEVAL-E1  | should create ExecutionRecord with type decision                             | 4.5      |
+ * | PEVAL-E2  | should set result to human-readable string describing decision               | 4.5      |
+ * | PEVAL-E3  | should populate references with scanExecutionIds and waiver feedbackRecordIds | 4.5      |
+ * | PEVAL-E4  | should set metadata kind to policy-decision with version and full decision    | 4.5      |
+ * | PEVAL-E5  | should return ExecutionRecord to caller without persisting                    | 4.5      |
+ * | PEVAL-O5  | should skip OPA evaluation when opa config is undefined                       | 4.9      |
+ */
+
 import { createPolicyEvaluator } from "./policy_evaluator";
-import type { ConsolidatedFinding } from "./policy_evaluator.types";
+import type {
+  PolicyEvaluationInput,
+  PolicyConfig,
+  PolicyRule,
+  PolicyRuleResult,
+  ConsolidatedFinding,
+  PolicyEvaluatorDeps,
+  ActiveWaiver,
+  IWaiverReader,
+} from "./policy_evaluator.types";
+import type { FeedbackRecord } from "../record_types";
+import type { WaiverMetadata } from "../source_auditor/types";
 
 // ============================================================================
 // Test helpers
@@ -9,7 +48,7 @@ function makeFinding(
   overrides: Partial<ConsolidatedFinding> = {},
 ): ConsolidatedFinding {
   return {
-    fingerprint: `fp-${Math.random().toString(36).slice(2, 8)}`,
+    fingerprint: "fp-test-001",
     message: "test finding",
     severity: "high",
     category: "test",
@@ -21,106 +60,491 @@ function makeFinding(
   };
 }
 
+function makeConfig(
+  overrides: Partial<PolicyConfig> = {},
+): PolicyConfig {
+  return {
+    failOn: "critical",
+    ...overrides,
+  };
+}
+
+function makeFeedbackRecord(
+  id: string,
+  fingerprint: string,
+): FeedbackRecord<WaiverMetadata> {
+  return {
+    id,
+    entityType: "execution",
+    entityId: "exec-previous",
+    type: "approval",
+    status: "acknowledged",
+    content: "Risk accepted per security review",
+    metadata: {
+      fingerprint,
+      ruleId: "SEC-001",
+      file: "src/config.ts",
+      line: 10,
+    },
+  };
+}
+
+function makeWaiver(
+  fingerprint: string,
+  feedbackId: string,
+): ActiveWaiver {
+  return {
+    fingerprint,
+    ruleId: "SEC-001",
+    feedback: makeFeedbackRecord(feedbackId, fingerprint),
+  };
+}
+
+function makeDeps(): PolicyEvaluatorDeps {
+  const waiverReader: IWaiverReader = {
+    loadActiveWaivers: jest.fn().mockResolvedValue([]),
+    hasActiveWaiver: jest.fn().mockResolvedValue(false),
+  };
+  return { waiverReader };
+}
+
+function makeInput(
+  overrides: Partial<PolicyEvaluationInput> = {},
+): PolicyEvaluationInput {
+  return {
+    findings: [makeFinding()],
+    activeWaivers: [],
+    policy: makeConfig(),
+    scanExecutionIds: ["exec-scan-001"],
+    taskId: "task-001",
+    ...overrides,
+  };
+}
+
 // ============================================================================
-// PolicyEvaluator stub tests (AORCH-C7 to C10)
+// Tests
 // ============================================================================
 
 describe("PolicyEvaluator", () => {
-  describe("Cycle 2: Stub evaluation (AORCH-C7 to C10)", () => {
-    const evaluator = createPolicyEvaluator();
+  describe("4.1. Types and structure (PEVAL-A1 to A5)", () => {
+    it("[PEVAL-A1] should require all fields in PolicyEvaluationInput", () => {
+      const input: PolicyEvaluationInput = {
+        findings: [],
+        activeWaivers: [],
+        policy: { failOn: "critical" },
+        scanExecutionIds: ["exec-001"],
+        taskId: "task-001",
+      };
 
-    it("[AORCH-C7] should return pass when failOn is critical and no critical findings exist", async () => {
-      const findings = [
-        makeFinding({ severity: "high" }),
-        makeFinding({ severity: "medium" }),
-        makeFinding({ severity: "low" }),
-      ];
-
-      const result = await evaluator.evaluate(findings, {
-        failOn: "critical",
-        taskId: "task-1",
-      });
-
-      expect(result.decision).toBe("pass");
-      expect(result.reason).toContain("No findings at or above critical");
+      expect(input.findings).toBeDefined();
+      expect(input.activeWaivers).toBeDefined();
+      expect(input.policy).toBeDefined();
+      expect(input.scanExecutionIds).toBeDefined();
+      expect(input.taskId).toBeDefined();
     });
 
-    it("[AORCH-C8] should return block when findings at or above failOn severity exist", async () => {
-      const findings = [
-        makeFinding({ severity: "high" }),
-        makeFinding({ severity: "medium" }),
-      ];
+    it("[PEVAL-A2] should include required fields and optional ruleId in ConsolidatedFinding", () => {
+      // With ruleId
+      const withRuleId = makeFinding({ ruleId: "SEC-001" });
+      expect(withRuleId.fingerprint).toBeDefined();
+      expect(withRuleId.severity).toBeDefined();
+      expect(withRuleId.category).toBeDefined();
+      expect(withRuleId.file).toBeDefined();
+      expect(withRuleId.line).toBeDefined();
+      expect(withRuleId.reportedBy).toBeDefined();
+      expect(withRuleId.isWaived).toBeDefined();
+      expect(withRuleId.message).toBeDefined();
+      expect(withRuleId.ruleId).toBe("SEC-001");
 
-      const result = await evaluator.evaluate(findings, {
+      // Without ruleId
+      const withoutRuleId = makeFinding();
+      expect(withoutRuleId.ruleId).toBeUndefined();
+    });
+
+    it("[PEVAL-A3] should require failOn in PolicyConfig and allow optional fields", () => {
+      const minimal: PolicyConfig = { failOn: "critical" };
+      expect(minimal.failOn).toBe("critical");
+      expect(minimal.blockCategories).toBeUndefined();
+      expect(minimal.rules).toBeUndefined();
+
+      const full: PolicyConfig = {
         failOn: "high",
-        taskId: "task-2",
-      });
-
-      expect(result.decision).toBe("block");
-      expect(result.reason).toContain("Found findings at or above high");
+        blockCategories: ["secret"],
+        rules: [],
+      };
+      expect(full.failOn).toBe("high");
+      expect(full.blockCategories).toEqual(["secret"]);
     });
 
-    it("[AORCH-C9] should return executionRecordId as empty string (stub -- Epic 5 creates real ExecutionRecord)", async () => {
-      const findings = [makeFinding({ severity: "critical" })];
+    it("[PEVAL-A4] should include all fields in PolicyDecision", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
 
-      const result = await evaluator.evaluate(findings, {
-        failOn: "critical",
-        taskId: "task-3",
-      });
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [makeFinding({ fingerprint: "fp-1", severity: "low" })],
+          policy: makeConfig({ failOn: "critical" }),
+        }),
+      );
 
-      expect(result.executionRecordId).toBe("");
+      const decision = result.decision;
+      expect(decision.decision).toBeDefined();
+      expect(decision.reason).toBeDefined();
+      expect(decision.blockingFindings).toBeDefined();
+      expect(decision.waivedFindings).toBeDefined();
+      expect(decision.summary).toBeDefined();
+      expect(decision.rulesEvaluated).toBeDefined();
+      expect(decision.evaluatedAt).toBeDefined();
     });
 
-    it("[AORCH-C10] should not count waived findings toward threshold", async () => {
-      const findings = [
-        makeFinding({ severity: "critical", isWaived: true }),
-        makeFinding({ severity: "high", isWaived: true }),
-        makeFinding({ severity: "low", isWaived: false }),
-      ];
+    it("[PEVAL-A5] should include ruleName, passed, and reason in PolicyRuleResult", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
 
-      const result = await evaluator.evaluate(findings, {
-        failOn: "critical",
-        taskId: "task-4",
-      });
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [makeFinding({ fingerprint: "fp-1", severity: "low" })],
+          policy: makeConfig({ failOn: "critical" }),
+        }),
+      );
 
-      expect(result.decision).toBe("pass");
-      expect(result.reason).toContain("No findings at or above critical");
+      expect(result.decision.rulesEvaluated.length).toBeGreaterThan(0);
+      const firstRule = result.decision.rulesEvaluated[0];
+      expect(firstRule).toBeDefined();
+      expect(firstRule!.ruleName).toBeDefined();
+      expect(typeof firstRule!.passed).toBe("boolean");
+      expect(firstRule!.reason).toBeDefined();
     });
   });
 
-  describe("Edge cases", () => {
-    const evaluator = createPolicyEvaluator();
+  describe("4.4. Evaluator principal (PEVAL-D1 to D9)", () => {
+    it("[PEVAL-D1] should apply active waivers to findings before evaluating rules", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
 
-    it("should default to critical when failOn is not specified", async () => {
-      const findings = [makeFinding({ severity: "high" })];
+      const waiver = makeWaiver("fp-critical-001", "feedback-waiver-001");
 
-      const result = await evaluator.evaluate(findings, {
-        taskId: "task-5",
-      });
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [
+            makeFinding({
+              fingerprint: "fp-critical-001",
+              severity: "critical",
+              isWaived: false,
+            }),
+          ],
+          activeWaivers: [waiver],
+          policy: makeConfig({ failOn: "critical" }),
+        }),
+      );
 
-      expect(result.decision).toBe("pass");
-      expect(result.reason).toContain("No findings at or above critical");
+      // The critical finding should be waived, so decision should be pass
+      expect(result.decision.decision).toBe("pass");
+      expect(result.decision.waivedFindings).toHaveLength(1);
     });
 
-    it("should return pass with empty findings", async () => {
-      const result = await evaluator.evaluate([], {
-        failOn: "low",
-        taskId: "task-6",
-      });
+    it("[PEVAL-D2] should set isWaived:true and attach waiver when fingerprint matches", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
 
-      expect(result.decision).toBe("pass");
+      const waiver = makeWaiver("fp-match-001", "feedback-waiver-002");
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [
+            makeFinding({ fingerprint: "fp-match-001", severity: "critical" }),
+          ],
+          activeWaivers: [waiver],
+          policy: makeConfig({ failOn: "critical" }),
+        }),
+      );
+
+      const waivedFinding = result.decision.waivedFindings[0];
+      expect(waivedFinding).toBeDefined();
+      expect(waivedFinding!.isWaived).toBe(true);
+      expect(waivedFinding!.waiver).toBe(waiver);
     });
 
-    it("should block when failOn is low and any active finding exists", async () => {
-      const findings = [makeFinding({ severity: "low" })];
+    it("[PEVAL-D3] should set decision to block when any rule returns passed:false", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
 
-      const result = await evaluator.evaluate(findings, {
-        failOn: "low",
-        taskId: "task-7",
-      });
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [
+            makeFinding({ fingerprint: "fp-1", severity: "critical" }),
+          ],
+          policy: makeConfig({ failOn: "critical" }),
+        }),
+      );
 
-      expect(result.decision).toBe("block");
-      expect(result.reason).toContain("Found findings at or above low");
+      expect(result.decision.decision).toBe("block");
+    });
+
+    it("[PEVAL-D4] should set decision to pass when all rules return passed:true", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [makeFinding({ fingerprint: "fp-1", severity: "low" })],
+          policy: makeConfig({ failOn: "critical" }),
+        }),
+      );
+
+      expect(result.decision.decision).toBe("pass");
+      expect(result.decision.rulesEvaluated.every((r) => r.passed)).toBe(true);
+    });
+
+    it("[PEVAL-D5] should populate blockingFindings with findings causing rule failure", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [
+            makeFinding({ fingerprint: "fp-crit", severity: "critical" }),
+            makeFinding({ fingerprint: "fp-low", severity: "low" }),
+          ],
+          policy: makeConfig({ failOn: "critical" }),
+        }),
+      );
+
+      expect(result.decision.decision).toBe("block");
+      expect(result.decision.blockingFindings).toHaveLength(1);
+      expect(result.decision.blockingFindings[0]!.fingerprint).toBe("fp-crit");
+    });
+
+    it("[PEVAL-D6] should populate waivedFindings with all findings where isWaived is true", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      const waiver1 = makeWaiver("fp-waived-1", "feedback-1");
+      const waiver2 = makeWaiver("fp-waived-2", "feedback-2");
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [
+            makeFinding({ fingerprint: "fp-waived-1", severity: "critical" }),
+            makeFinding({ fingerprint: "fp-waived-2", severity: "high" }),
+            makeFinding({ fingerprint: "fp-not-waived", severity: "low" }),
+          ],
+          activeWaivers: [waiver1, waiver2],
+          policy: makeConfig({ failOn: "critical" }),
+        }),
+      );
+
+      expect(result.decision.waivedFindings).toHaveLength(2);
+      const waivedFingerprints = result.decision.waivedFindings.map(
+        (f) => f.fingerprint,
+      );
+      expect(waivedFingerprints).toContain("fp-waived-1");
+      expect(waivedFingerprints).toContain("fp-waived-2");
+    });
+
+    it("[PEVAL-D7] should set evaluatedAt to a valid ISO 8601 timestamp", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [makeFinding({ fingerprint: "fp-1", severity: "low" })],
+        }),
+      );
+
+      const date = new Date(result.decision.evaluatedAt);
+      expect(date.toISOString()).toBe(result.decision.evaluatedAt);
+      expect(isNaN(date.getTime())).toBe(false);
+    });
+
+    it("[PEVAL-D8] should evaluate custom rules after built-in rules", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      const evaluationOrder: string[] = [];
+
+      const customRule: PolicyRule = {
+        name: "CustomRule",
+        evaluate(_findings, _config): PolicyRuleResult {
+          evaluationOrder.push("CustomRule");
+          return {
+            ruleName: "CustomRule",
+            passed: false,
+            reason: "Custom rule failed",
+          };
+        },
+      };
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [makeFinding({ fingerprint: "fp-1", severity: "low" })],
+          policy: makeConfig({ failOn: "critical", rules: [customRule] }),
+        }),
+      );
+
+      // Custom rule should appear after built-in rules
+      const ruleNames = result.decision.rulesEvaluated.map((r) => r.ruleName);
+      expect(ruleNames).toEqual([
+        "SeverityThreshold",
+        "CategoryBlock",
+        "CustomRule",
+      ]);
+
+      // Custom rule failure should block
+      expect(result.decision.decision).toBe("block");
+    });
+
+    it("[PEVAL-D9] should return decision pass with empty blockingFindings when findings is empty", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [],
+          policy: makeConfig({ failOn: "low" }),
+        }),
+      );
+
+      expect(result.decision.decision).toBe("pass");
+      expect(result.decision.reason).toBe("No findings to evaluate");
+      expect(result.decision.blockingFindings).toHaveLength(0);
+      expect(result.decision.rulesEvaluated).toHaveLength(0);
+    });
+  });
+
+  describe("4.5. ExecutionRecord (PEVAL-E1 to E5)", () => {
+    it("[PEVAL-E1] should create ExecutionRecord with type decision", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [makeFinding({ fingerprint: "fp-1", severity: "low" })],
+        }),
+      );
+
+      expect(result.executionRecord.type).toBe("decision");
+    });
+
+    it("[PEVAL-E2] should set result to human-readable string describing decision", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      // Pass case
+      const passResult = await evaluator.evaluate(
+        makeInput({
+          findings: [makeFinding({ fingerprint: "fp-1", severity: "low" })],
+          policy: makeConfig({ failOn: "critical" }),
+        }),
+      );
+      expect(passResult.executionRecord.result).toContain("PASS");
+
+      // Block case
+      const blockResult = await evaluator.evaluate(
+        makeInput({
+          findings: [
+            makeFinding({ fingerprint: "fp-1", severity: "critical" }),
+          ],
+          policy: makeConfig({ failOn: "critical" }),
+        }),
+      );
+      expect(blockResult.executionRecord.result).toContain("BLOCK");
+      expect(blockResult.executionRecord.result).toContain("blocking");
+    });
+
+    it("[PEVAL-E3] should populate references with scanExecutionIds and waiver feedbackRecordIds", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      const waiver = makeWaiver("fp-waived", "feedback-waiver-003");
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [
+            makeFinding({ fingerprint: "fp-waived", severity: "critical" }),
+          ],
+          activeWaivers: [waiver],
+          scanExecutionIds: ["exec-scan-001", "exec-scan-002"],
+          policy: makeConfig({ failOn: "critical" }),
+        }),
+      );
+
+      expect(result.executionRecord.references).toContain("exec-scan-001");
+      expect(result.executionRecord.references).toContain("exec-scan-002");
+      expect(result.executionRecord.references).toContain(
+        "feedback-waiver-003",
+      );
+    });
+
+    it("[PEVAL-E4] should set metadata kind to policy-decision with version and full PolicyDecision", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [makeFinding({ fingerprint: "fp-1", severity: "low" })],
+        }),
+      );
+
+      expect(result.executionRecord.metadata.kind).toBe("policy-decision");
+      expect(result.executionRecord.metadata.version).toBe("1.0.0");
+      expect(result.executionRecord.metadata.data).toBe(result.decision);
+    });
+
+    it("[PEVAL-E4b] should include id field in ExecutionRecord", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [makeFinding({ fingerprint: "fp-1", severity: "low" })],
+          taskId: "task-id-test",
+        }),
+      );
+
+      expect(result.executionRecord.id).toBeDefined();
+      expect(result.executionRecord.id).toContain("exec-policy-task-id-test-");
+    });
+
+    it("[PEVAL-E5] should return ExecutionRecord to caller without persisting", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [makeFinding({ fingerprint: "fp-1", severity: "low" })],
+          taskId: "task-test-e5",
+        }),
+      );
+
+      // executionRecord is returned directly, not persisted
+      expect(result.executionRecord).toBeDefined();
+      expect(result.executionRecord.type).toBe("decision");
+      expect(result.executionRecord.title).toContain("task-test-e5");
+    });
+  });
+
+  describe("4.9. OPA Integration (PEVAL-O5)", () => {
+    it("[PEVAL-O5] should skip OPA evaluation when opa config is undefined", async () => {
+      const deps = makeDeps();
+      const evaluator = createPolicyEvaluator(deps);
+
+      const result = await evaluator.evaluate(
+        makeInput({
+          findings: [makeFinding({ fingerprint: "fp-1", severity: "low" })],
+          policy: makeConfig({ failOn: "critical" }),
+        }),
+      );
+
+      // No OPA rules should appear in rulesEvaluated
+      const opaRules = result.decision.rulesEvaluated.filter((r) =>
+        r.ruleName.startsWith("opa:"),
+      );
+      expect(opaRules).toHaveLength(0);
+
+      // Only built-in rules should be evaluated
+      const ruleNames = result.decision.rulesEvaluated.map((r) => r.ruleName);
+      expect(ruleNames).toEqual(["SeverityThreshold", "CategoryBlock"]);
     });
   });
 });

--- a/packages/core/src/policy_evaluator/policy_evaluator.ts
+++ b/packages/core/src/policy_evaluator/policy_evaluator.ts
@@ -1,49 +1,240 @@
+/**
+ * PolicyEvaluator -- Epic 5: policy_evaluation.
+ *
+ * Factory: createPolicyEvaluator(deps) creates a PolicyEvaluator instance.
+ * Pipeline: apply waivers -> evaluate rules -> build decision -> build execution record.
+ *
+ * EARS: PEVAL-D1 through D9, PEVAL-E1 through E5
+ */
+
 import type {
   PolicyEvaluator,
+  PolicyEvaluatorDeps,
+  PolicyEvaluationInput,
+  PolicyEvaluationResult,
+  PolicyDecision,
+  PolicyExecutionRecordData,
+  PolicyConfig,
+  PolicyRuleResult,
   ConsolidatedFinding,
   FindingSeverity,
-  PolicyDecisionStub,
+  ActiveWaiver,
 } from "./policy_evaluator.types";
+import { SEVERITY_ORDER } from "./policy_evaluator.types";
+import { severityThreshold } from "./severity_threshold";
+import { categoryBlock } from "./category_block";
+import { createOpaRule } from "./opa_rule";
+
+// ============================================================================
+// Helper functions
+// ============================================================================
 
 /**
- * Severity order for threshold comparison.
- * Higher number = more severe.
+ * PEVAL-D1/D2: Match waivers to findings by fingerprint.
+ * Creates copies with isWaived/waiver set -- does not mutate originals.
  */
-const severityOrder: Record<FindingSeverity, number> = {
-  critical: 4,
-  high: 3,
-  medium: 2,
-  low: 1,
-};
+function applyWaivers(
+  findings: ConsolidatedFinding[],
+  activeWaivers: ActiveWaiver[],
+): ConsolidatedFinding[] {
+  const waiverMap = new Map(
+    activeWaivers
+      .filter((w) => w.fingerprint)
+      .map((w) => [w.fingerprint, w]),
+  );
+
+  // TODO: waiverRequirements enforcement (PEVAL-P2 Cycle 2)
+  // When waiverRequirements are configured for a category, waiver application should
+  // verify the waiver has sufficient approvals (ActorRecord/WorkflowRecord signatures).
+  // Cycle 1 validates waiverRequirements schema at load time; enforcement requires
+  // ActorRecord/FeedbackRecord integration beyond Cycle 1 scope.
+  return findings.map((f) => {
+    const waiver = waiverMap.get(f.fingerprint);
+    return waiver
+      ? { ...f, isWaived: true, waiver }
+      : { ...f, isWaived: false };
+  });
+}
 
 /**
- * Creates a stub PolicyEvaluator.
- *
- * This is a minimal implementation for Cycle 2 of audit_orchestration.
- * It checks active (non-waived) findings against a severity threshold
- * and returns pass/block. No ExecutionRecord is created (deferred to Epic 5).
+ * Finds non-waived findings that match severity threshold OR blocked categories.
+ * Used to populate blockingFindings in PolicyDecision.
  */
-export function createPolicyEvaluator(): PolicyEvaluator {
+function computeBlockingFindings(
+  findings: ConsolidatedFinding[],
+  policy: PolicyConfig,
+): ConsolidatedFinding[] {
+  const threshold = SEVERITY_ORDER[policy.failOn];
+  const blockedSet = new Set(policy.blockCategories ?? []);
+
+  return findings.filter(
+    (f) =>
+      !f.isWaived &&
+      (SEVERITY_ORDER[f.severity] >= threshold || blockedSet.has(f.category)),
+  );
+}
+
+/**
+ * Counts findings by severity.
+ */
+function buildSummary(
+  findings: ConsolidatedFinding[],
+): Record<FindingSeverity, number> {
+  const s: Record<FindingSeverity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+  };
+  for (const f of findings) {
+    s[f.severity] = s[f.severity] + 1;
+  }
+  return s;
+}
+
+/**
+ * Builds a human-readable result string for the ExecutionRecord.
+ */
+function buildResultString(decision: PolicyDecision): string {
+  if (decision.decision === "pass") {
+    const waived = decision.waivedFindings.length;
+    return waived > 0
+      ? `PASS: All findings waived or below threshold. ${String(waived)} waived.`
+      : "PASS: No findings exceed configured thresholds.";
+  }
+
+  const blocking = decision.blockingFindings.length;
+  const waived = decision.waivedFindings.length;
+  const parts = [`BLOCK: ${String(blocking)} blocking finding(s).`];
+  if (waived > 0) {
+    parts.push(`${String(waived)} waived.`);
+  }
+  return parts.join(" ");
+}
+
+/**
+ * Builds references array for the ExecutionRecord.
+ * Includes scanExecutionIds and waiver feedbackRecord IDs.
+ */
+function buildReferences(
+  scanExecutionIds: string[],
+  waivedFindings: ConsolidatedFinding[],
+): string[] {
+  const refs = [...scanExecutionIds];
+
+  for (const f of waivedFindings) {
+    if (f.waiver?.feedback?.id) {
+      refs.push(f.waiver.feedback.id);
+    }
+  }
+
+  return refs;
+}
+
+/**
+ * Builds the ExecutionRecord data for the policy evaluation.
+ */
+function buildExecutionRecord(
+  input: PolicyEvaluationInput,
+  decision: PolicyDecision,
+): PolicyExecutionRecordData {
+  return {
+    id: `exec-policy-${input.taskId}-${Date.now()}`,
+    type: "decision",
+    title: `Policy evaluation for task ${input.taskId}`,
+    result: buildResultString(decision),
+    references: buildReferences(input.scanExecutionIds, decision.waivedFindings),
+    metadata: {
+      kind: "policy-decision",
+      version: "1.0.0",
+      data: decision,
+    },
+  };
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Factory: creates PolicyEvaluator with injected dependencies.
+ */
+export function createPolicyEvaluator(
+  _deps: PolicyEvaluatorDeps,
+): PolicyEvaluator {
   return {
     async evaluate(
-      findings: ConsolidatedFinding[],
-      options: { failOn?: FindingSeverity; taskId: string },
-    ): Promise<PolicyDecisionStub> {
-      const failOn = options.failOn ?? "critical";
-      const threshold = severityOrder[failOn];
+      input: PolicyEvaluationInput,
+    ): Promise<PolicyEvaluationResult> {
+      const { findings, activeWaivers, policy } = input;
 
-      const activeFindings = findings.filter((f) => !f.isWaived);
-      const hasBlocking = activeFindings.some(
-        (f) => severityOrder[f.severity] >= threshold,
+      // PEVAL-D9: Empty findings -> pass immediately
+      if (findings.length === 0) {
+        const decision: PolicyDecision = {
+          decision: "pass",
+          reason: "No findings to evaluate",
+          blockingFindings: [],
+          waivedFindings: [],
+          summary: { critical: 0, high: 0, medium: 0, low: 0 },
+          rulesEvaluated: [],
+          evaluatedAt: new Date().toISOString(),
+        };
+        return {
+          decision,
+          executionRecord: buildExecutionRecord(input, decision),
+        };
+      }
+
+      // PEVAL-D1/D2: Apply waivers by fingerprint matching
+      const withWaivers = applyWaivers(findings, activeWaivers);
+
+      // PEVAL-D3/D4/D8: Evaluate built-in + custom + OPA rules
+      const builtInRules = [severityThreshold, categoryBlock];
+
+      // Load OPA rules if configured (PEVAL-O5: skip when opa is undefined)
+      const repoRoot = process.cwd();
+      const opaRules =
+        policy.opa?.policies && policy.opa.policies.length > 0
+          ? await Promise.all(
+              policy.opa.policies.map((p) => createOpaRule(p, repoRoot)),
+            )
+          : [];
+
+      const allRules = [
+        ...builtInRules,
+        ...(policy.rules ?? []),
+        ...opaRules,
+      ];
+
+      // All rules are evaluated (no short-circuit)
+      const rulesEvaluated: PolicyRuleResult[] = allRules.map((rule) =>
+        rule.evaluate(withWaivers, policy),
       );
 
-      return {
-        decision: hasBlocking ? "block" : "pass",
-        reason: hasBlocking
-          ? `Found findings at or above ${failOn} severity`
-          : `No findings at or above ${failOn} severity`,
-        executionRecordId: "", // Stub -- Epic 5 creates real ExecutionRecord
+      const anyFailed = rulesEvaluated.some((r) => !r.passed);
+
+      // PEVAL-D5/D6/D7: Build PolicyDecision
+      const decision: PolicyDecision = {
+        decision: anyFailed ? "block" : "pass",
+        reason: anyFailed
+          ? rulesEvaluated
+              .filter((r) => !r.passed)
+              .map((r) => r.reason)
+              .join("; ")
+          : "All findings waived or below configured thresholds.",
+        blockingFindings: anyFailed
+          ? computeBlockingFindings(withWaivers, policy)
+          : [],
+        waivedFindings: withWaivers.filter((f) => f.isWaived),
+        summary: buildSummary(withWaivers),
+        rulesEvaluated,
+        evaluatedAt: new Date().toISOString(),
       };
+
+      // PEVAL-E1 through E5: Build ExecutionRecord data
+      const executionRecord = buildExecutionRecord(input, decision);
+
+      return { decision, executionRecord };
     },
   };
 }

--- a/packages/core/src/policy_evaluator/policy_evaluator.types.ts
+++ b/packages/core/src/policy_evaluator/policy_evaluator.types.ts
@@ -1,16 +1,186 @@
 /**
- * PolicyEvaluator types.
+ * PolicyEvaluator types — Epic 5: policy_evaluation.
  *
- * Re-exports the interface and related types from audit_orchestrator.types
- * for convenience. The canonical definition lives in audit_orchestrator.types.ts
- * since PolicyEvaluator is a dependency of AuditOrchestrator.
- *
- * This file exists to follow the module folder convention and provide
- * a place for future policy-specific types (Epic 5: policy_evaluation).
+ * Canonical types for policy evaluation. ConsolidatedFinding and FindingSeverity
+ * are re-exported from audit_orchestrator (not redefined).
+ * ActiveWaiver and IWaiverReader are imported from source_auditor.
  */
-export type {
-  PolicyEvaluator,
-  PolicyDecisionStub,
+
+import type {
   ConsolidatedFinding,
   FindingSeverity,
 } from "../audit_orchestrator/audit_orchestrator.types";
+import type { ActiveWaiver, IWaiverReader } from "../source_auditor/types";
+
+// Re-export for convenience
+export type { ConsolidatedFinding, FindingSeverity } from "../audit_orchestrator/audit_orchestrator.types";
+export type { ActiveWaiver, IWaiverReader } from "../source_auditor/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Core Domain Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Input to PolicyEvaluator.evaluate().
+ * Constructed by the caller (AuditOrchestrator or CLI).
+ */
+export type PolicyEvaluationInput = {
+  findings: ConsolidatedFinding[];
+  activeWaivers: ActiveWaiver[];
+  policy: PolicyConfig;
+  scanExecutionIds: string[];
+  taskId: string;
+};
+
+/**
+ * Runtime policy configuration.
+ * Loaded from .gitgov/policy.yml via loadPolicyConfig(), or constructed programmatically.
+ */
+export type PolicyConfig = {
+  failOn: FindingSeverity;
+  blockCategories?: string[];
+  waiverRequirements?: Record<string, WaiverRequirement>;
+  rules?: PolicyRule[];
+  opa?: OpaConfig;
+};
+
+/**
+ * OPA engine configuration.
+ * When present, .rego policies are loaded and evaluated via WASM.
+ */
+export type OpaConfig = {
+  /** Paths to .rego files relative to repo root */
+  policies: string[];
+};
+
+/**
+ * Schema for .gitgov/policy.yml file on disk.
+ * Parsed by loadPolicyConfig().
+ */
+export type PolicyConfigFile = {
+  version: string;
+  failOn: FindingSeverity;
+  blockCategories?: string[];
+  waiverRequirements?: Record<string, WaiverRequirement>;
+  opa?: {
+    policies: string[];
+  };
+};
+
+/**
+ * Requirements for waiver approval per category.
+ * Example: { role: "ciso", minApprovals: 1 }
+ */
+export type WaiverRequirement = {
+  role: string;
+  minApprovals: number;
+};
+
+/**
+ * Result of policy evaluation.
+ * Returned by PolicyEvaluator.evaluate().
+ */
+export type PolicyDecision = {
+  decision: "pass" | "block";
+  reason: string;
+  blockingFindings: ConsolidatedFinding[];
+  waivedFindings: ConsolidatedFinding[];
+  summary: Record<FindingSeverity, number>;
+  rulesEvaluated: PolicyRuleResult[];
+  evaluatedAt: string; // ISO 8601
+};
+
+/**
+ * Result of a single rule evaluation.
+ */
+export type PolicyRuleResult = {
+  ruleName: string;
+  passed: boolean;
+  reason: string;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interfaces (contracts with methods)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A policy rule that evaluates findings against a specific criterion.
+ * Strategy pattern: built-in and custom rules share this interface.
+ */
+export interface PolicyRule {
+  readonly name: string;
+  evaluate(
+    findings: ConsolidatedFinding[],
+    config: PolicyConfig,
+  ): PolicyRuleResult;
+}
+
+/**
+ * PolicyEvaluator interface.
+ * ASYNC -- evaluate() returns Promise<PolicyEvaluationResult>.
+ */
+export interface PolicyEvaluator {
+  evaluate(input: PolicyEvaluationInput): Promise<PolicyEvaluationResult>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dependency injection and result types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Dependencies injected into createPolicyEvaluator().
+ */
+export type PolicyEvaluatorDeps = {
+  waiverReader: IWaiverReader;
+};
+
+/**
+ * Full result from PolicyEvaluator.evaluate().
+ * Wraps PolicyDecision + ExecutionRecord data.
+ */
+export type PolicyEvaluationResult = {
+  decision: PolicyDecision;
+  executionRecord: PolicyExecutionRecordData;
+};
+
+/**
+ * Data for the ExecutionRecord created by PolicyEvaluator.
+ * The caller (orchestrator) handles persistence via RecordStore.
+ */
+export type PolicyExecutionRecordData = {
+  id: string;
+  type: "decision";
+  title: string;
+  result: string;
+  references: string[];
+  metadata: {
+    kind: "policy-decision";
+    version: "1.0.0";
+    data: PolicyDecision;
+  };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants and helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Severity ordering for threshold comparison.
+ * critical(4) > high(3) > medium(2) > low(1).
+ */
+export const SEVERITY_ORDER: Record<FindingSeverity, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+/**
+ * Returns the higher of two severities.
+ */
+export function higherSeverity(
+  a: FindingSeverity,
+  b: FindingSeverity,
+): FindingSeverity {
+  return SEVERITY_ORDER[a] >= SEVERITY_ORDER[b] ? a : b;
+}

--- a/packages/core/src/policy_evaluator/severity_threshold.test.ts
+++ b/packages/core/src/policy_evaluator/severity_threshold.test.ts
@@ -1,0 +1,90 @@
+/**
+ * SeverityThreshold rule tests.
+ *
+ * EARS: PEVAL-C1, PEVAL-C2, PEVAL-C3
+ */
+
+import { severityThreshold } from "./severity_threshold";
+import type {
+  ConsolidatedFinding,
+  PolicyConfig,
+} from "./policy_evaluator.types";
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function makeFinding(
+  overrides: Partial<ConsolidatedFinding> = {},
+): ConsolidatedFinding {
+  return {
+    fingerprint: "fp-test-001",
+    message: "test finding",
+    severity: "high",
+    category: "test",
+    file: "src/foo.ts",
+    line: 10,
+    reportedBy: ["agent-1"],
+    isWaived: false,
+    ...overrides,
+  };
+}
+
+function makeConfig(
+  overrides: Partial<PolicyConfig> = {},
+): PolicyConfig {
+  return {
+    failOn: "critical",
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("SeverityThreshold", () => {
+  describe("4.3. Built-in rules (PEVAL-C1 to C3)", () => {
+    it("[PEVAL-C1] should return passed:false when non-waived findings exceed severity threshold", () => {
+      const findings = [
+        makeFinding({ fingerprint: "fp-1", severity: "critical", isWaived: false }),
+        makeFinding({ fingerprint: "fp-2", severity: "high", isWaived: false }),
+      ];
+      const config = makeConfig({ failOn: "high" });
+
+      const result = severityThreshold.evaluate(findings, config);
+
+      expect(result.passed).toBe(false);
+      expect(result.ruleName).toBe("SeverityThreshold");
+      expect(result.reason).toContain('2 finding(s) at severity >= "high" exceed threshold');
+    });
+
+    it("[PEVAL-C2] should return passed:true when all findings at threshold are waived", () => {
+      const findings = [
+        makeFinding({ fingerprint: "fp-1", severity: "critical", isWaived: true }),
+        makeFinding({ fingerprint: "fp-2", severity: "critical", isWaived: true }),
+        makeFinding({ fingerprint: "fp-3", severity: "low", isWaived: false }),
+      ];
+      const config = makeConfig({ failOn: "critical" });
+
+      const result = severityThreshold.evaluate(findings, config);
+
+      expect(result.passed).toBe(true);
+      expect(result.reason).toContain("All findings at or above threshold");
+      expect(result.reason).toContain("are waived");
+    });
+
+    it("[PEVAL-C3] should return passed:true when no findings at or above threshold", () => {
+      const findings = [
+        makeFinding({ fingerprint: "fp-1", severity: "medium", isWaived: false }),
+        makeFinding({ fingerprint: "fp-2", severity: "low", isWaived: false }),
+      ];
+      const config = makeConfig({ failOn: "critical" });
+
+      const result = severityThreshold.evaluate(findings, config);
+
+      expect(result.passed).toBe(true);
+      expect(result.reason).toContain("No findings at or above threshold");
+    });
+  });
+});

--- a/packages/core/src/policy_evaluator/severity_threshold.ts
+++ b/packages/core/src/policy_evaluator/severity_threshold.ts
@@ -1,0 +1,46 @@
+/**
+ * SeverityThreshold rule -- built-in PolicyRule.
+ *
+ * Blocks when non-waived findings have severity >= config.failOn.
+ * EARS: PEVAL-C1, PEVAL-C2, PEVAL-C3
+ */
+
+import type {
+  PolicyRule,
+  PolicyRuleResult,
+  ConsolidatedFinding,
+  PolicyConfig,
+} from "./policy_evaluator.types";
+import { SEVERITY_ORDER } from "./policy_evaluator.types";
+
+export const severityThreshold: PolicyRule = {
+  name: "SeverityThreshold",
+
+  evaluate(
+    findings: ConsolidatedFinding[],
+    config: PolicyConfig,
+  ): PolicyRuleResult {
+    const threshold = SEVERITY_ORDER[config.failOn];
+    const blocking = findings.filter(
+      (f) => !f.isWaived && SEVERITY_ORDER[f.severity] >= threshold,
+    );
+
+    if (blocking.length === 0) {
+      // Distinguish: all-at-threshold waived vs none-at-threshold
+      const atThreshold = findings.filter(
+        (f) => SEVERITY_ORDER[f.severity] >= threshold,
+      );
+      const reason =
+        atThreshold.length > 0 && atThreshold.every((f) => f.isWaived)
+          ? `All findings at or above threshold "${config.failOn}" are waived`
+          : `No findings at or above threshold "${config.failOn}"`;
+      return { ruleName: "SeverityThreshold", passed: true, reason };
+    }
+
+    return {
+      ruleName: "SeverityThreshold",
+      passed: false,
+      reason: `${String(blocking.length)} finding(s) at severity >= "${config.failOn}" exceed threshold`,
+    };
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
+      '@open-policy-agent/opa-wasm':
+        specifier: ^1.10.0
+        version: 1.10.0
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -1163,6 +1166,9 @@ packages:
   '@oozcitak/util@8.3.8':
     resolution: {integrity: sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==}
     engines: {node: '>=8.0'}
+
+  '@open-policy-agent/opa-wasm@1.10.0':
+    resolution: {integrity: sha512-ymR/nFS3nO9o24j9xowGGQaf+Gmb813QcxUpVZkfRlJkawKWqSIllnEH15agyWjijmOIyhA+OBErenx6N3jphw==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4443,6 +4449,10 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -5292,6 +5302,11 @@ snapshots:
       '@oozcitak/util': 8.3.8
 
   '@oozcitak/util@8.3.8': {}
+
+  '@open-policy-agent/opa-wasm@1.10.0':
+    dependencies:
+      sprintf-js: 1.1.3
+      yaml: 1.10.2
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -8906,6 +8921,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml@1.10.2: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary

Cycle 1 of epic **policy_evaluation** ([#123](https://github.com/gitgovernance/monorepo/issues/123)).

PolicyEvaluator formal replaces stub. Separates scan (immutable findings) from policy (re-evaluable decisions). Loads config from `.gitgov/policy.yml`, applies waivers, evaluates built-in rules + OPA/Rego custom policies, emits ExecutionRecord type:"decision".

## Completed Tasks

- [x] Task 1.0: policy.yml Schema + Loader (PEVAL-P1..P4)
- [x] Task 1.1: Types and structure (PEVAL-A1..A5)
- [x] Task 1.3: Built-in rules — SeverityThreshold + CategoryBlock (PEVAL-C1..C6)
- [x] Task 1.4: PolicyEvaluator with waiver application + rule pipeline (PEVAL-D1..D9)
- [x] Task 1.5: ExecutionRecord type:"decision" (PEVAL-E1..E5)
- [x] Task 1.7: OPA WASM integration (PEVAL-O1..O6)
- [x] Task 1.8: OPA Spike validated (17.7ms load, 5.7ms eval 1000 findings)
- [x] Orchestrator migrated: PolicyDecisionStub deprecated, new interface

## Metrics

| Metric | Value |
|---|---|
| EARS defined | 38 |
| EARS implemented (Cycle 1) | 35 |
| Tests passing | 49 |
| tsc --noEmit | 0 errors |

## Test plan

- [x] 49/49 tests passing across 6 suites
- [x] tsc --noEmit clean
- [x] 4x audit executed (ears, coverage, coherence, semantic)
- [x] 16 audit findings corrected
- [x] OPA WASM spike validated performance targets

Part of #123