### PR TITLE
feat(core): add versionControlProvenance to SARIF output

### DIFF
--- a/packages/core/src/sarif/sarif.types.ts
+++ b/packages/core/src/sarif/sarif.types.ts
@@ -31,6 +31,21 @@ export type SarifRun = {
   invocations?: SarifInvocation[];
   /** Custom GitGov properties for the run */
   properties?: SarifRunProperties;
+  /** Version control provenance — §3.14.16 */
+  versionControlProvenance?: SarifVersionControlDetails[];
+};
+
+/**
+ * Version control information for the scanned repository.
+ * §3.55 versionControlDetails object
+ */
+export type SarifVersionControlDetails = {
+  /** Repository URI (e.g., "https://github.com/org/repo") */
+  repositoryUri: string;
+  /** Commit hash at time of scan */
+  revisionId?: string;
+  /** Branch name (e.g., "main", "feature/xyz") */
+  branch?: string;
 };
 
 /**
@@ -375,6 +390,14 @@ export type SarifBuilderOptions = {
   // ── Output control ─────────────────────────────────────────
   /** Controls snippet redaction in SARIF output */
   redactionLevel?: RedactionLevel;
+
+  // ── Version control provenance §3.14.16 ───────────────────
+  /** Git commit hash for versionControlProvenance */
+  commitHash?: string;
+  /** Git branch name for versionControlProvenance */
+  branch?: string;
+  /** Repository URI for versionControlProvenance */
+  repositoryUri?: string;
 };
 
 /**

--- a/packages/core/src/sarif/sarif_builder.test.ts
+++ b/packages/core/src/sarif/sarif_builder.test.ts
@@ -349,4 +349,36 @@ describe('SarifBuilder', () => {
       expect(result.approvedBy).toBe('human:ciso');
     });
   });
+
+  describe('4.12. versionControlProvenance (SARIF-L1 to L3)', () => {
+    it('[SARIF-L1] build: should populate versionControlProvenance with revisionId and branch', async () => {
+      const sarif = await builder.build({
+        ...baseOptions,
+        commitHash: 'abc123def456',
+        branch: 'main',
+        repositoryUri: 'https://github.com/org/repo',
+      });
+      const provenance = sarif.runs[0]!.versionControlProvenance;
+      expect(provenance).toBeDefined();
+      expect(provenance!.length).toBe(1);
+      expect(provenance![0]!.revisionId).toBe('abc123def456');
+      expect(provenance![0]!.branch).toBe('main');
+      expect(provenance![0]!.repositoryUri).toBe('https://github.com/org/repo');
+    });
+
+    it('[SARIF-L2] build: should include repositoryUri in versionControlProvenance', async () => {
+      const sarif = await builder.build({
+        ...baseOptions,
+        repositoryUri: 'https://github.com/org/repo',
+      });
+      const provenance = sarif.runs[0]!.versionControlProvenance;
+      expect(provenance).toBeDefined();
+      expect(provenance![0]!.repositoryUri).toBe('https://github.com/org/repo');
+    });
+
+    it('[SARIF-L3] build: should not include versionControlProvenance when no git context fields given', async () => {
+      const sarif = await builder.build(baseOptions);
+      expect(sarif.runs[0]!.versionControlProvenance).toBeUndefined();
+    });
+  });
 });

--- a/packages/core/src/sarif/sarif_builder.ts
+++ b/packages/core/src/sarif/sarif_builder.ts
@@ -243,9 +243,10 @@ class SarifBuilderImpl implements SarifBuilder {
     }
 
     // SARIF-L1/L2/L3: versionControlProvenance §3.14.16
-    if (options.commitHash || options.branch || options.repositoryUri) {
+    // repositoryUri is required per SARIF spec — only create provenance when it's provided
+    if (options.repositoryUri) {
       run.versionControlProvenance = [{
-        repositoryUri: options.repositoryUri ?? '',
+        repositoryUri: options.repositoryUri,
         ...(options.commitHash ? { revisionId: options.commitHash } : {}),
         ...(options.branch ? { branch: options.branch } : {}),
       }];

--- a/packages/core/src/sarif/sarif_builder.ts
+++ b/packages/core/src/sarif/sarif_builder.ts
@@ -242,6 +242,15 @@ class SarifBuilderImpl implements SarifBuilder {
       run.properties = runProps;
     }
 
+    // SARIF-L1/L2/L3: versionControlProvenance §3.14.16
+    if (options.commitHash || options.branch || options.repositoryUri) {
+      run.versionControlProvenance = [{
+        repositoryUri: options.repositoryUri ?? '',
+        ...(options.commitHash ? { revisionId: options.commitHash } : {}),
+        ...(options.branch ? { branch: options.branch } : {}),
+      }];
+    }
+
     return {
       $schema: SARIF_SCHEMA_URL,
       version: '2.1.0',


### PR DESCRIPTION
## Summary

Cycle 2 of epic **sarif_compliance_spec** ([#129](https://github.com/gitgovernance/monorepo/issues/129)).

Adds `versionControlProvenance` (SARIF 2.1.0 §3.14.16) to SarifBuilder output. Enables tracking commit hash, branch, and repository URI per scan — required for the History tab in the UI.

## Completed Tasks

- [x] Task 2.2: versionControlProvenance (SARIF-L1..L3)
- [x] Audit fix: require repositoryUri for provenance (prevent empty URI)

## Metrics

| Metric | Value |
|---|---|
| EARS defined | 3 (L1-L3) |
| EARS implemented | 3 |
| Tests passing | 45/45 (sarif module) |
| tsc --noEmit | 0 errors |

## Test plan

- [x] SARIF-L1: commitHash + branch → versionControlProvenance populated
- [x] SARIF-L2: repositoryUri included in provenance
- [x] SARIF-L3: no git context → no versionControlProvenance
- [x] All 42 existing sarif tests still pass
- [x] 4-way audit: ears (37/37), coverage (43/43), coherence (45/45), semantic (1 finding fixed)

Closes #129