### PR TITLE
feat(core): add direct exports for Git and FileLister types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,9 +84,13 @@ export type { RecordStore, IdEncoder } from "./record_store";
 // ConfigStore type export (interface only — implementations in @gitgov/core/github and @gitgov/core/fs)
 export type { ConfigStore } from "./config_store";
 
-// FileLister interface export (renamed to avoid tsup namespace/interface name collision)
-// Use IFileLister when importing the interface directly; FileLister namespace for errors/subtypes
-export type { FileLister as IFileLister } from "./file_lister";
+// FileLister direct exports (interface + types + errors)
+export type { FileLister as IFileLister, FileListOptions, FileStats } from "./file_lister";
+export { FileListerError } from "./file_lister";
+
+// Git direct exports (interface + types + errors)
+export type { IGitModule, ExecOptions, ExecResult, GetCommitHistoryOptions, CommitInfo, ChangedFile, CommitAuthor } from "./git";
+export { GitError, GitCommandError, FileNotFoundError, BranchNotFoundError, BranchAlreadyExistsError, MergeConflictError } from "./git";
 export type {
   GitGovTaskRecord,
   GitGovCycleRecord,


### PR DESCRIPTION
## Summary

- Export `IGitModule`, `GitError`, `FileNotFoundError`, `BranchNotFoundError`, `BranchAlreadyExistsError`, `MergeConflictError`, `GitCommandError` directly from `@gitgov/core`
- Export `FileListerError`, `FileListOptions`, `FileStats` directly from `@gitgov/core`
- Follows existing pattern (`TaskRecord`, `ConfigStore`, `IFileLister` already had direct exports)

Enables `@gitgov/core-gitlab` (and future provider packages) to import everything from `@gitgov/core` without deep path imports.

## Test plan

- [x] `pnpm build` passes in core
- [x] `pnpm typecheck` passes in core-gitlab with updated imports
- [x] 166 tests pass in core-gitlab

Part of gitlab_saas_integration epic (Cycle 0).