### PR TITLE
fix(e2e): remove core-gitlab workspace:* that breaks CI

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -12,7 +12,6 @@
   },
   "devDependencies": {
     "@gitgov/core": "workspace:*",
-    "@gitgov/core-gitlab": "workspace:*",
     "@gitbeaker/rest": "^40.0.0",
     "@octokit/rest": "^22.0.1",
     "@prisma/adapter-pg": "^6.0.0",


### PR DESCRIPTION
## Summary

`@gitgov/core-gitlab` is a git submodule, not a pnpm workspace package. The `workspace:*` reference in `packages/e2e/package.json` causes `pnpm install` to fail in GitHub Actions CI (submodule not cloned).

This blocks the release-core workflow (PR #133 release failed).

Will re-add with NPM version (`@gitgov/core-gitlab: "^0.1.0"`) once the package is published.

## Test plan

- [x] Unblocks release-core workflow