### PR TITLE
feat(cli+core): login command + suggestion→fixes rename — Cycle 4

### DIFF
--- a/packages/cli/e2e/login_command_e2e.test.ts
+++ b/packages/cli/e2e/login_command_e2e.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Login Command E2E — CLI integration tests for login/status/logout (LOGIN-E1 to E4)
+ *
+ * Tests the login command against the real compiled CLI binary.
+ * OAuth flow and SaaS sync cannot be tested E2E without a real server,
+ * but status and logout flows are fully testable by writing .session.json
+ * directly and verifying the CLI reads/modifies it correctly.
+ *
+ * Spec: cli/specs/login_command.md §4.5
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { runCliCommand, setupGitgovProject, getWorktreeBasePath } from './helpers';
+
+describe('Login Command E2E (LOGIN-E1 to E4)', () => {
+  let tempDir: string;
+  let testProjectRoot: string;
+  let worktreeBasePath: string;
+  let cleanupFn: () => void;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitgov-login-e2e-'));
+    const setup = setupGitgovProject(tempDir, 'login-e2e');
+    testProjectRoot = setup.testProjectRoot;
+    worktreeBasePath = setup.worktreeBasePath;
+    cleanupFn = setup.cleanup;
+  });
+
+  afterAll(() => {
+    cleanupFn();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /** Write a session directly to the worktree .session.json */
+  function writeSession(session: Record<string, unknown>): void {
+    const sessionPath = path.join(worktreeBasePath, '.gitgov', '.session.json');
+    fs.writeFileSync(sessionPath, JSON.stringify(session, null, 2));
+  }
+
+  /** Read session from worktree .session.json */
+  function readSession(): Record<string, unknown> | null {
+    const sessionPath = path.join(worktreeBasePath, '.gitgov', '.session.json');
+    try {
+      return JSON.parse(fs.readFileSync(sessionPath, 'utf-8'));
+    } catch {
+      return null;
+    }
+  }
+
+  // ── LOGIN-E1: Status when not logged in ──────────────────────────
+
+  it('[LOGIN-E1] should show not logged in when no session token exists', () => {
+    // Ensure no cloud token in session
+    const session = readSession();
+    if (session?.cloud) {
+      delete session.cloud;
+      writeSession(session);
+    }
+
+    const result = runCliCommand(
+      ['login', '--status', '--json'],
+      { cwd: testProjectRoot },
+    );
+    expect(result.success).toBe(true);
+
+    const output = JSON.parse(result.output);
+    expect(output.success).toBe(true);
+    expect(output.data.loggedIn).toBe(false);
+  });
+
+  // ── LOGIN-E2: Logout when not logged in ──────────────────────────
+
+  it('[LOGIN-E2] should succeed gracefully when logging out without active session', () => {
+    // Ensure no cloud token
+    const session = readSession();
+    if (session?.cloud) {
+      delete session.cloud;
+      writeSession(session);
+    }
+
+    const result = runCliCommand(
+      ['login', '--logout', '--json'],
+      { cwd: testProjectRoot },
+    );
+    expect(result.success).toBe(true);
+
+    const output = JSON.parse(result.output);
+    expect(output.success).toBe(true);
+    expect(output.data.loggedOut).toBe(true);
+  });
+
+  // ── LOGIN-E3: Status with manually set session ───────────────────
+
+  it('[LOGIN-E3] should display user info when session token exists', () => {
+    // Manually write a session with cloud token
+    const session = readSession() ?? {};
+    writeSession({
+      ...session,
+      cloud: { sessionToken: 'test-e2e-token-12345' },
+      lastSession: { actorId: 'human:e2e-user', timestamp: '2026-03-22T12:00:00Z' },
+    });
+
+    const result = runCliCommand(
+      ['login', '--status', '--json'],
+      { cwd: testProjectRoot },
+    );
+    expect(result.success).toBe(true);
+
+    const output = JSON.parse(result.output);
+    expect(output.success).toBe(true);
+    expect(output.data.loggedIn).toBe(true);
+    expect(output.data.user).toBe('human:e2e-user');
+    expect(output.data.lastLogin).toBe('2026-03-22T12:00:00Z');
+  });
+
+  // ── LOGIN-E4: Logout removes token, preserves other data ────────
+
+  it('[LOGIN-E4] should remove cloud token but preserve actorState on logout', () => {
+    // Write session with token AND actorState
+    const session = readSession() ?? {};
+    writeSession({
+      ...session,
+      cloud: { sessionToken: 'token-to-be-removed' },
+      lastSession: { actorId: 'human:e2e-user', timestamp: '2026-03-22T12:00:00Z' },
+      actorState: { 'human:e2e-user': { activeTaskId: 'task-123' } },
+    });
+
+    const result = runCliCommand(
+      ['login', '--logout', '--json'],
+      { cwd: testProjectRoot },
+    );
+    expect(result.success).toBe(true);
+
+    // Verify session file: cloud should be gone, actorState should remain
+    const updatedSession = readSession();
+    expect(updatedSession).not.toBeNull();
+    expect(updatedSession!.cloud).toBeUndefined();
+    expect(updatedSession!.actorState).toEqual({ 'human:e2e-user': { activeTaskId: 'task-123' } });
+  });
+});

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -1,0 +1,13 @@
+export { LoginCommand } from './login-command';
+export { registerLoginCommands } from './login';
+export type {
+  LoginCommandOptions,
+  LoginDeps,
+  SyncKeyRequest,
+  SyncKeyResponse,
+  GetKeyRequest,
+  GetKeyResponse,
+  KeyStatusRequest,
+  KeyStatusResponse,
+  LoginSessionData,
+} from './login-command.types';

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -9,5 +9,4 @@ export type {
   GetKeyResponse,
   KeyStatusRequest,
   KeyStatusResponse,
-  LoginSessionData,
 } from './login-command.types';

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -1,0 +1,346 @@
+/**
+ * LoginCommand Unit Tests
+ *
+ * Spec: cli/specs/login_command.md
+ * EARS Coverage:
+ * - A: OAuth Login Flow (LOGIN-A1 to A3)
+ * - B: Key Sync CLI → SaaS (LOGIN-B1 to B3)
+ * - C: Key Sync SaaS → CLI (LOGIN-C1 to C2)
+ * - D: Key Conflict Resolution (LOGIN-D1 to D2)
+ */
+
+import type { IKeyProvider } from '@gitgov/core';
+
+// Mock DependencyInjectionService
+const mockSaveSession = jest.fn();
+const mockLoadSession = jest.fn();
+const mockGetPrivateKey = jest.fn();
+const mockSetPrivateKey = jest.fn();
+const mockHasPrivateKey = jest.fn();
+const mockGetConfig = jest.fn();
+
+jest.mock('../../services/dependency-injection', () => ({
+  DependencyInjectionService: {
+    getInstance: jest.fn().mockReturnValue({
+      getSessionManager: jest.fn().mockResolvedValue({
+        loadSession: mockLoadSession,
+        sessionStore: { saveSession: mockSaveSession },
+      }),
+      getKeyProvider: jest.fn().mockReturnValue({
+        getPrivateKey: mockGetPrivateKey,
+        setPrivateKey: mockSetPrivateKey,
+        hasPrivateKey: mockHasPrivateKey,
+      } as unknown as IKeyProvider),
+      getConfigManager: jest.fn().mockResolvedValue({
+        getConfig: mockGetConfig,
+      }),
+    }),
+  },
+}));
+
+import { LoginCommand } from './login-command';
+import type { LoginCommandOptions, LoginDeps } from './login-command.types';
+
+// Mock console and process.exit
+const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
+const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
+const mockProcessExit = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+function createMockDeps(overrides?: Partial<LoginDeps>): LoginDeps {
+  return {
+    openBrowser: jest.fn().mockResolvedValue(undefined),
+    startCallbackServer: jest.fn().mockResolvedValue({
+      token: 'test-session-token',
+      user: { login: 'camilo', id: 12345 },
+    }),
+    fetchSaas: jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ hasKey: false, actorExists: false }),
+    }),
+    ...overrides,
+  };
+}
+
+function createMockFetch(responses: Record<string, unknown>): LoginDeps['fetchSaas'] {
+  return jest.fn().mockImplementation(async (url: string) => {
+    for (const [pattern, response] of Object.entries(responses)) {
+      if (url.includes(pattern)) {
+        return { ok: true, json: async () => response };
+      }
+    }
+    return { ok: false, json: async () => ({}) };
+  });
+}
+
+const defaultOptions: LoginCommandOptions = {};
+
+describe('LoginCommand', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetConfig.mockResolvedValue({ projectId: 'test-repo', saasUrl: 'https://test.gitgov.dev' });
+    mockLoadSession.mockResolvedValue(null);
+  });
+
+  // ==================== §4.1 OAuth Login Flow (LOGIN-A1 to A3) ====================
+
+  describe('4.1. OAuth Login Flow (LOGIN-A1 to A3)', () => {
+    it('[LOGIN-A1] should open browser and store session token after OAuth callback', async () => {
+      const deps = createMockDeps();
+      // SaaS has no key, CLI has no key — "no actor" path
+      (deps.fetchSaas as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ hasKey: false, actorExists: false }),
+      });
+      mockHasPrivateKey.mockResolvedValue(false);
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // Browser should have been opened with OAuth URL
+      expect(deps.openBrowser).toHaveBeenCalledTimes(1);
+      const openUrl = (deps.openBrowser as jest.Mock).mock.calls[0][0] as string;
+      expect(openUrl).toContain('/api/auth/cli?callback=');
+
+      // Callback server should have started
+      expect(deps.startCallbackServer).toHaveBeenCalledTimes(1);
+
+      // Session should be saved with token
+      expect(mockSaveSession).toHaveBeenCalled();
+      const savedSession = mockSaveSession.mock.calls[0][0];
+      expect(savedSession.cloud.sessionToken).toBe('test-session-token');
+      expect(savedSession.lastSession.actorId).toBe('human:camilo');
+    });
+
+    it('[LOGIN-A2] should display login status with user info and key sync status', async () => {
+      mockLoadSession.mockResolvedValue({
+        cloud: { sessionToken: 'existing-token' },
+        lastSession: { actorId: 'human:camilo', timestamp: '2026-03-22T10:00:00Z' },
+      });
+      mockHasPrivateKey.mockResolvedValue(true);
+
+      const deps = createMockDeps({
+        fetchSaas: createMockFetch({
+          '/api/identity/status': { hasKey: true, actorExists: true },
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeStatus(defaultOptions);
+
+      // Should output status info
+      const output = mockConsoleLog.mock.calls.map(c => c[0]).join('\n');
+      expect(output).toContain('human:camilo');
+      expect(output).toContain('yes');
+    });
+
+    it('[LOGIN-A3] should remove session token without deleting keys', async () => {
+      mockLoadSession.mockResolvedValue({
+        cloud: { sessionToken: 'existing-token' },
+        lastSession: { actorId: 'human:camilo', timestamp: '2026-03-22T10:00:00Z' },
+        actorState: { 'human:camilo': { activeTaskId: 'task-1' } },
+      });
+
+      const deps = createMockDeps();
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogout(defaultOptions);
+
+      // Session should be saved WITHOUT cloud token
+      expect(mockSaveSession).toHaveBeenCalled();
+      const savedSession = mockSaveSession.mock.calls[0][0];
+      expect(savedSession.cloud).toBeUndefined();
+
+      // actorState should be preserved
+      expect(savedSession.actorState).toEqual({ 'human:camilo': { activeTaskId: 'task-1' } });
+
+      // Keys should NOT be touched
+      expect(mockSetPrivateKey).not.toHaveBeenCalled();
+      expect(mockGetPrivateKey).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==================== §4.2 Key Sync CLI → SaaS (LOGIN-B1 to B3) ====================
+
+  describe('4.2. Key Sync CLI → SaaS (LOGIN-B1 to B3)', () => {
+    it('[LOGIN-B1] should prompt and sync local key to SaaS when SaaS has no key', async () => {
+      // CLI has key, SaaS does not
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPrivateKey.mockResolvedValue('base64-private-key-data');
+
+      const syncKeyMock = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ synced: true }) });
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+          if (url.includes('/api/identity/status')) {
+            return { ok: true, json: async () => ({ hasKey: false, actorExists: true }) };
+          }
+          if (url.includes('/api/identity/sync-key')) {
+            return syncKeyMock();
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // Should have called sync-key endpoint
+      expect(deps.fetchSaas).toHaveBeenCalledWith(
+        expect.stringContaining('/api/identity/sync-key'),
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('base64-private-key-data'),
+        })
+      );
+    });
+
+    it('[LOGIN-B2] should update session with keySynced true after successful sync', async () => {
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPrivateKey.mockResolvedValue('base64-private-key-data');
+
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('/api/identity/status')) {
+            return { ok: true, json: async () => ({ hasKey: false, actorExists: true }) };
+          }
+          if (url.includes('/api/identity/sync-key')) {
+            return { ok: true, json: async () => ({ synced: true }) };
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // Output should confirm sync
+      const output = mockConsoleLog.mock.calls.map(c => c[0]).join('\n');
+      expect(output).toContain('Key synced to SaaS');
+    });
+
+    it('[LOGIN-B3] should skip key sync when no-key-sync flag is passed', async () => {
+      const deps = createMockDeps();
+      const cmd = new LoginCommand(deps);
+
+      await cmd.executeLogin({ ...defaultOptions, noKeySync: true });
+
+      // Session should be stored (login happened)
+      expect(mockSaveSession).toHaveBeenCalled();
+
+      // But NO fetch to key status or sync-key should have been made
+      expect(deps.fetchSaas).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==================== §4.3 Key Sync SaaS → CLI (LOGIN-C1 to C2) ====================
+
+  describe('4.3. Key Sync SaaS → CLI (LOGIN-C1 to C2)', () => {
+    it('[LOGIN-C1] should prompt and download key from SaaS when CLI has no key', async () => {
+      // CLI has no key, SaaS has key
+      mockHasPrivateKey.mockResolvedValue(false);
+
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('/api/identity/status')) {
+            return { ok: true, json: async () => ({ hasKey: true, actorExists: true }) };
+          }
+          if (url.includes('/api/identity/key')) {
+            return { ok: true, json: async () => ({ privateKey: 'saas-private-key-base64' }) };
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // Should have fetched the key from SaaS
+      expect(deps.fetchSaas).toHaveBeenCalledWith(
+        expect.stringContaining('/api/identity/key'),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer test-session-token' }),
+        })
+      );
+
+      // Should store via FsKeyProvider
+      expect(mockSetPrivateKey).toHaveBeenCalledWith('human:camilo', 'saas-private-key-base64');
+    });
+
+    it('[LOGIN-C2] should store downloaded key in FsKeyProvider with 0600 permissions', async () => {
+      // FsKeyProvider handles 0600 internally — verify setPrivateKey is called correctly
+      mockHasPrivateKey.mockResolvedValue(false);
+
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('/api/identity/status')) {
+            return { ok: true, json: async () => ({ hasKey: true, actorExists: true }) };
+          }
+          if (url.includes('/api/identity/key')) {
+            return { ok: true, json: async () => ({ privateKey: 'downloaded-key-data' }) };
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // setPrivateKey delegates to FsKeyProvider which handles file permissions
+      expect(mockSetPrivateKey).toHaveBeenCalledWith('human:camilo', 'downloaded-key-data');
+
+      // Output should confirm download
+      const output = mockConsoleLog.mock.calls.map(c => c[0]).join('\n');
+      expect(output).toContain('Key downloaded from SaaS');
+    });
+  });
+
+  // ==================== §4.4 Key Conflict Resolution (LOGIN-D1 to D2) ====================
+
+  describe('4.4. Key Conflict Resolution (LOGIN-D1 to D2)', () => {
+    it('[LOGIN-D1] should display already synced when keys are identical', async () => {
+      const sharedKey = 'same-key-on-both-sides';
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPrivateKey.mockResolvedValue(sharedKey);
+
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('/api/identity/status')) {
+            return { ok: true, json: async () => ({ hasKey: true, actorExists: true }) };
+          }
+          if (url.includes('/api/identity/key')) {
+            return { ok: true, json: async () => ({ privateKey: sharedKey }) };
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      const output = mockConsoleLog.mock.calls.map(c => c[0]).join('\n');
+      expect(output).toContain('Already synced');
+    });
+
+    it('[LOGIN-D2] should display error with resolution instructions when keys differ', async () => {
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPrivateKey.mockResolvedValue('cli-private-key');
+
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('/api/identity/status')) {
+            return { ok: true, json: async () => ({ hasKey: true, actorExists: true }) };
+          }
+          if (url.includes('/api/identity/key')) {
+            return { ok: true, json: async () => ({ privateKey: 'different-saas-key' }) };
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      const errorOutput = mockConsoleError.mock.calls.map(c => c[0]).join('\n');
+      expect(errorOutput).toContain('Keys differ');
+      expect(errorOutput).toContain('gitgov actor rotate-key');
+    });
+  });
+});

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -1,0 +1,355 @@
+/**
+ * Login Command — connects CLI with SaaS, exchanges private keys
+ *
+ * Spec: cli/specs/login_command.md
+ * EARS: LOGIN-A1..A3, LOGIN-B1..B3, LOGIN-C1..C2, LOGIN-D1..D2
+ */
+
+import { Command } from 'commander';
+import { BaseCommand } from '../../base/base-command';
+import type { LoginCommandOptions, LoginDeps, KeyStatusResponse, SyncKeyResponse, GetKeyResponse } from './login-command.types';
+
+const DEFAULT_SAAS_URL = 'https://cloud.gitgov.dev';
+const CALLBACK_PORT = 9876;
+
+/**
+ * Default deps use real implementations (overridable for tests).
+ */
+function createDefaultDeps(): LoginDeps {
+  return {
+    openBrowser: async (url: string) => {
+      const { exec } = await import('child_process');
+      const platform = process.platform;
+      const cmd = platform === 'darwin' ? 'open' : platform === 'win32' ? 'start' : 'xdg-open';
+      exec(`${cmd} "${url}"`);
+    },
+    startCallbackServer: (port: number) => {
+      return new Promise((resolve, reject) => {
+        import('http').then(({ createServer }) => {
+          const server = createServer((req, res) => {
+            const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+            const token = url.searchParams.get('token');
+            const login = url.searchParams.get('login');
+            const id = url.searchParams.get('id');
+
+            if (token && login && id) {
+              res.writeHead(200, { 'Content-Type': 'text/html' });
+              res.end('<html><body><h1>Login successful!</h1><p>You can close this window.</p></body></html>');
+              server.close();
+              resolve({ token, user: { login, id: Number(id) } });
+            } else {
+              res.writeHead(400, { 'Content-Type': 'text/plain' });
+              res.end('Missing token, login, or id');
+            }
+          });
+          server.listen(port, () => {});
+          server.on('error', reject);
+          // Timeout after 60s
+          setTimeout(() => {
+            server.close();
+            reject(new Error('Login timeout — no callback received within 60 seconds'));
+          }, 60_000);
+        });
+      });
+    },
+    fetchSaas: async (url: string, init?: RequestInit) => {
+      return fetch(url, init);
+    },
+  };
+}
+
+export class LoginCommand extends BaseCommand<LoginCommandOptions> {
+  private deps: LoginDeps;
+
+  constructor(deps?: Partial<LoginDeps>) {
+    super();
+    this.deps = { ...createDefaultDeps(), ...deps };
+  }
+
+  register(_program: Command): void {
+    // Registration handled by registerLoginCommands() in login.ts
+  }
+
+  // [LOGIN-A1] OAuth flow → open browser, start callback server, store session token
+  async executeLogin(options: LoginCommandOptions): Promise<void> {
+    try {
+      const saasUrl = await this.resolveSaasUrl(options);
+
+      console.log(`Opening browser for authentication at ${saasUrl}...`);
+
+      // Start local callback server and open browser in parallel
+      const callbackPromise = this.deps.startCallbackServer(CALLBACK_PORT);
+      const oauthUrl = `${saasUrl}/api/auth/cli?callback=http://localhost:${CALLBACK_PORT}/auth/callback`;
+      await this.deps.openBrowser(oauthUrl);
+
+      // Wait for callback with token
+      const { token, user } = await callbackPromise;
+
+      // Store session token via SessionManager
+      const sessionManager = await this.dependencyService.getSessionManager();
+      const session = await sessionManager.loadSession() ?? {};
+      session.cloud = { sessionToken: token };
+      session.lastSession = { actorId: `human:${user.login}`, timestamp: new Date().toISOString() };
+      await (sessionManager as any).sessionStore.saveSession(session);
+
+      console.log(`Logged in as ${user.login} (human:${user.login})`);
+
+      // [LOGIN-B3] Skip key sync if --no-key-sync
+      if (options.noKeySync) {
+        this.handleSuccess(
+          { loggedIn: true, user: user.login, actorId: `human:${user.login}`, keySynced: false },
+          options,
+          `Logged in (key sync skipped)`
+        );
+        return;
+      }
+
+      // Key sync detection and execution
+      await this.syncKeys(`human:${user.login}`, saasUrl, token, options);
+
+    } catch (error) {
+      this.handleError(
+        `Login failed: ${error instanceof Error ? error.message : String(error)}`,
+        options,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  // [LOGIN-A2] Display current login status
+  async executeStatus(options: LoginCommandOptions): Promise<void> {
+    try {
+      const sessionManager = await this.dependencyService.getSessionManager();
+      const session = await sessionManager.loadSession();
+      const token = session?.cloud?.sessionToken;
+      const lastSession = session?.lastSession;
+
+      if (!token || !lastSession) {
+        this.handleSuccess(
+          { loggedIn: false },
+          options,
+          'Not logged in. Run `gitgov login` to connect to SaaS.'
+        );
+        return;
+      }
+
+      const saasUrl = await this.resolveSaasUrl(options);
+      const actorId = lastSession.actorId;
+
+      // Check key sync status
+      let keyStatus: KeyStatusResponse = { hasKey: false, actorExists: false };
+      try {
+        const configManager = await this.dependencyService.getConfigManager();
+        const config = await configManager.getConfig();
+        const repoId = config?.projectId ?? '';
+        keyStatus = await this.getKeyStatus(saasUrl, token, actorId, repoId);
+      } catch {
+        // Non-fatal — can't reach SaaS
+      }
+
+      const hasLocalKey = await this.hasLocalKey(actorId);
+
+      this.handleSuccess(
+        {
+          loggedIn: true,
+          user: actorId,
+          saasUrl,
+          keySynced: hasLocalKey && keyStatus.hasKey,
+          localKey: hasLocalKey,
+          saasKey: keyStatus.hasKey,
+          lastLogin: lastSession.timestamp,
+        },
+        options,
+        [
+          `Logged in as ${actorId}`,
+          `  SaaS: ${saasUrl}`,
+          `  Local key: ${hasLocalKey ? 'yes' : 'no'}`,
+          `  SaaS key: ${keyStatus.hasKey ? 'yes' : 'no'}`,
+          `  Synced: ${hasLocalKey && keyStatus.hasKey ? 'yes' : 'no'}`,
+          `  Last login: ${lastSession.timestamp}`,
+        ].join('\n')
+      );
+    } catch (error) {
+      this.handleError(
+        `Failed to check status: ${error instanceof Error ? error.message : String(error)}`,
+        options,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  // [LOGIN-A3] Logout removes session token without deleting keys
+  async executeLogout(options: LoginCommandOptions): Promise<void> {
+    try {
+      const sessionManager = await this.dependencyService.getSessionManager();
+      const session = await sessionManager.loadSession() ?? {};
+
+      // Remove cloud token but preserve everything else
+      delete session.cloud;
+
+      await (sessionManager as any).sessionStore.saveSession(session);
+
+      this.handleSuccess(
+        { loggedOut: true },
+        options,
+        'Logged out. Session token removed. Keys are preserved.'
+      );
+    } catch (error) {
+      this.handleError(
+        `Logout failed: ${error instanceof Error ? error.message : String(error)}`,
+        options,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Key sync detection and execution
+   * [LOGIN-B1] CLI → SaaS when SaaS has no key
+   * [LOGIN-B2] Update session after sync
+   * [LOGIN-C1] SaaS → CLI when CLI has no key
+   * [LOGIN-C2] Store downloaded key with secure permissions
+   * [LOGIN-D1] Keys match → already synced
+   * [LOGIN-D2] Keys differ → error
+   */
+  private async syncKeys(
+    actorId: string,
+    saasUrl: string,
+    token: string,
+    options: LoginCommandOptions,
+  ): Promise<void> {
+    const configManager = await this.dependencyService.getConfigManager();
+    const config = await configManager.getConfig();
+    const repoId = config?.projectId ?? '';
+
+    const hasLocal = await this.hasLocalKey(actorId);
+    const keyStatus = await this.getKeyStatus(saasUrl, token, actorId, repoId);
+
+    // [LOGIN-B1] CLI has key, SaaS does not → sync to SaaS
+    if (hasLocal && !keyStatus.hasKey) {
+      const keyProvider = this.dependencyService.getKeyProvider();
+      const privateKey = await keyProvider.getPrivateKey(actorId);
+      if (privateKey) {
+        await this.syncKeyToSaas(saasUrl, token, actorId, repoId, privateKey);
+        // [LOGIN-B2] Update session
+        console.log(`Key synced to SaaS for repo ${repoId}`);
+        this.handleSuccess(
+          { loggedIn: true, user: actorId, keySynced: true },
+          options,
+          `Logged in as ${actorId}\nKey synced to SaaS`
+        );
+        return;
+      }
+    }
+
+    // [LOGIN-C1] SaaS has key, CLI does not → download to CLI
+    if (!hasLocal && keyStatus.hasKey) {
+      const keyResponse = await this.getKeyFromSaas(saasUrl, token, actorId, repoId);
+      if (keyResponse.privateKey) {
+        // [LOGIN-C2] Store with FsKeyProvider (handles 0600 permissions)
+        const keyProvider = this.dependencyService.getKeyProvider();
+        await keyProvider.setPrivateKey(actorId, keyResponse.privateKey);
+        console.log(`Key downloaded from SaaS`);
+        this.handleSuccess(
+          { loggedIn: true, user: actorId, keySynced: true },
+          options,
+          `Logged in as ${actorId}\nKey downloaded from SaaS`
+        );
+        return;
+      }
+    }
+
+    // [LOGIN-D1] Both have key and they match → already synced
+    if (hasLocal && keyStatus.hasKey) {
+      const keyProvider = this.dependencyService.getKeyProvider();
+      const localKey = await keyProvider.getPrivateKey(actorId);
+      const saasKeyResponse = await this.getKeyFromSaas(saasUrl, token, actorId, repoId);
+
+      if (localKey && saasKeyResponse.privateKey && localKey === saasKeyResponse.privateKey) {
+        this.handleSuccess(
+          { loggedIn: true, user: actorId, keySynced: true },
+          options,
+          `Logged in as ${actorId}\nAlready synced ✓`
+        );
+        return;
+      }
+
+      // [LOGIN-D2] Keys differ → error
+      if (localKey && saasKeyResponse.privateKey && localKey !== saasKeyResponse.privateKey) {
+        console.error('Keys differ between CLI and SaaS. Resolve manually: use `gitgov actor rotate-key` to generate a new key, or choose which to keep.');
+        this.handleSuccess(
+          { loggedIn: true, user: actorId, keySynced: false, keyConflict: true },
+          options,
+          `Logged in as ${actorId}\nKeys differ — resolve manually`
+        );
+        return;
+      }
+    }
+
+    // Neither has key
+    if (!hasLocal && !keyStatus.hasKey) {
+      this.handleSuccess(
+        { loggedIn: true, user: actorId, keySynced: false },
+        options,
+        `Logged in as ${actorId}\nNo actor key found. Run gitgov init first.`
+      );
+    }
+  }
+
+  // ============================================================================
+  // HELPERS
+  // ============================================================================
+
+  private async resolveSaasUrl(options: LoginCommandOptions): Promise<string> {
+    if (options.url) return options.url;
+    try {
+      const configManager = await this.dependencyService.getConfigManager();
+      const config = await configManager.getConfig();
+      if (config?.saasUrl) return config.saasUrl;
+    } catch {
+      // No config available — use default
+    }
+    return DEFAULT_SAAS_URL;
+  }
+
+  private async hasLocalKey(actorId: string): Promise<boolean> {
+    try {
+      const keyProvider = this.dependencyService.getKeyProvider();
+      return await keyProvider.hasPrivateKey(actorId);
+    } catch {
+      return false;
+    }
+  }
+
+  private async getKeyStatus(saasUrl: string, token: string, actorId: string, repoId: string): Promise<KeyStatusResponse> {
+    const url = `${saasUrl}/api/identity/status?actorId=${encodeURIComponent(actorId)}&repoId=${encodeURIComponent(repoId)}`;
+    const res = await this.deps.fetchSaas(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return { hasKey: false, actorExists: false };
+    return await res.json() as KeyStatusResponse;
+  }
+
+  private async syncKeyToSaas(saasUrl: string, token: string, actorId: string, repoId: string, privateKey: string): Promise<SyncKeyResponse> {
+    const url = `${saasUrl}/api/identity/sync-key`;
+    const res = await this.deps.fetchSaas(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ actorId, repoId, privateKey }),
+    });
+    if (!res.ok) throw new Error(`Failed to sync key to SaaS: ${res.status}`);
+    return await res.json() as SyncKeyResponse;
+  }
+
+  private async getKeyFromSaas(saasUrl: string, token: string, actorId: string, repoId: string): Promise<GetKeyResponse> {
+    const url = `${saasUrl}/api/identity/key?actorId=${encodeURIComponent(actorId)}&repoId=${encodeURIComponent(repoId)}`;
+    const res = await this.deps.fetchSaas(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return { privateKey: null };
+    return await res.json() as GetKeyResponse;
+  }
+}

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -2,7 +2,8 @@
  * Login Command — connects CLI with SaaS, exchanges private keys
  *
  * Spec: cli/specs/login_command.md
- * EARS: LOGIN-A1..A3, LOGIN-B1..B3, LOGIN-C1..C2, LOGIN-D1..D2
+ * EARS: LOGIN-A1..A3, LOGIN-B1..B3, LOGIN-C1..C2, LOGIN-D1..D2 (unit tests)
+ *       LOGIN-E1..E4 (E2E tests in cli/e2e/login_command_e2e.test.ts)
  */
 
 import { Command } from 'commander';
@@ -274,14 +275,18 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
         return;
       }
 
-      // [LOGIN-D2] Keys differ → error
+      // [LOGIN-D2] Keys differ → error (logged in but key conflict is an error state)
       if (localKey && saasKeyResponse.privateKey && localKey !== saasKeyResponse.privateKey) {
-        console.error('Keys differ between CLI and SaaS. Resolve manually: use `gitgov actor rotate-key` to generate a new key, or choose which to keep.');
-        this.handleSuccess(
-          { loggedIn: true, user: actorId, keySynced: false, keyConflict: true },
-          options,
-          `Logged in as ${actorId}\nKeys differ — resolve manually`
-        );
+        // Login succeeded but key sync failed — report as error
+        if (options.json) {
+          console.log(JSON.stringify({
+            success: false,
+            error: 'Key conflict',
+            data: { loggedIn: true, user: actorId, keySynced: false, keyConflict: true },
+          }, null, 2));
+        } else {
+          console.error('Keys differ between CLI and SaaS. Resolve manually: use `gitgov actor rotate-key` to generate a new key, or choose which to keep.');
+        }
         return;
       }
     }

--- a/packages/cli/src/commands/login/login-command.types.ts
+++ b/packages/cli/src/commands/login/login-command.types.ts
@@ -60,19 +60,6 @@ export type KeyStatusResponse = {
 };
 
 // ============================================================================
-// SESSION DATA (§3.4)
-// ============================================================================
-
-export type LoginSessionData = {
-  token: string;
-  user: { login: string; id: number };
-  actorId: string;
-  saasUrl: string;
-  keySynced: boolean;
-  lastLogin: string;
-};
-
-// ============================================================================
 // DEPENDENCY INJECTION
 // ============================================================================
 

--- a/packages/cli/src/commands/login/login-command.types.ts
+++ b/packages/cli/src/commands/login/login-command.types.ts
@@ -1,0 +1,84 @@
+/**
+ * Login Command Types
+ *
+ * Spec: cli/specs/login_command.md §3.3
+ */
+
+import type { BaseCommandOptions } from '../../interfaces/command';
+
+// ============================================================================
+// COMMAND OPTIONS
+// ============================================================================
+
+export interface LoginCommandOptions extends BaseCommandOptions {
+  /** SaaS base URL (default: config.json saasUrl or https://cloud.gitgov.dev) */
+  url?: string;
+  /** Show current login status */
+  status?: boolean;
+  /** Remove session token */
+  logout?: boolean;
+  /** Login without syncing keys */
+  noKeySync?: boolean;
+}
+
+// ============================================================================
+// SAAS API TYPES (§3.3)
+// ============================================================================
+
+/** POST /api/identity/sync-key — CLI sends key to SaaS */
+export type SyncKeyRequest = {
+  actorId: string;
+  repoId: string;
+  /** base64 encoded, encrypted in transit (HTTPS) */
+  privateKey: string;
+};
+
+export type SyncKeyResponse = {
+  synced: boolean;
+};
+
+/** GET /api/identity/key — CLI requests key from SaaS */
+export type GetKeyRequest = {
+  actorId: string;
+  repoId: string;
+};
+
+export type GetKeyResponse = {
+  /** null if SaaS doesn't have it */
+  privateKey: string | null;
+};
+
+/** GET /api/identity/status — Check sync status */
+export type KeyStatusRequest = {
+  actorId: string;
+  repoId: string;
+};
+
+export type KeyStatusResponse = {
+  hasKey: boolean;
+  actorExists: boolean;
+};
+
+// ============================================================================
+// SESSION DATA (§3.4)
+// ============================================================================
+
+export type LoginSessionData = {
+  token: string;
+  user: { login: string; id: number };
+  actorId: string;
+  saasUrl: string;
+  keySynced: boolean;
+  lastLogin: string;
+};
+
+// ============================================================================
+// DEPENDENCY INJECTION
+// ============================================================================
+
+/** Abstraction over browser open, HTTP server, and fetch for testability */
+export interface LoginDeps {
+  openBrowser: (url: string) => Promise<void>;
+  startCallbackServer: (port: number) => Promise<{ token: string; user: { login: string; id: number } }>;
+  fetchSaas: (url: string, init?: RequestInit) => Promise<Response>;
+}

--- a/packages/cli/src/commands/login/login.ts
+++ b/packages/cli/src/commands/login/login.ts
@@ -1,0 +1,26 @@
+import { Command } from 'commander';
+import { LoginCommand } from './login-command';
+
+export function registerLoginCommands(program: Command): void {
+  const loginCommand = new LoginCommand();
+
+  const login = program
+    .command('login')
+    .description('Connect CLI to GitGovernance SaaS — authenticate and sync keys')
+    .option('-u, --url <url>', 'SaaS base URL')
+    .option('-s, --status', 'Show current login status')
+    .option('--logout', 'Remove session token (keys are preserved)')
+    .option('--no-key-sync', 'Login without syncing keys')
+    .option('--json', 'Output as JSON')
+    .option('-v, --verbose', 'Verbose output')
+    .option('-q, --quiet', 'Quiet output')
+    .action(async (options) => {
+      if (options.status) {
+        await loginCommand.executeStatus(options);
+      } else if (options.logout) {
+        await loginCommand.executeLogout(options);
+      } else {
+        await loginCommand.executeLogin(options);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import { registerActorCommands } from './commands/actor';
 import { registerExecCommands } from './commands/exec';
 import { registerFeedbackCommands } from './commands/feedback';
 import { registerHookCommands } from './commands/hook';
+import { registerLoginCommands } from './commands/login';
 import { DependencyInjectionService } from './services/dependency-injection';
 import packageJson from '../package.json' assert { type: 'json' };
 
@@ -46,6 +47,9 @@ async function setupCommands() {
 
     // Register actor commands EARLY so "gitgov actor new" works on clone (after pull)
     registerActorCommands(program);
+
+    // Register login commands EARLY — OAuth flow needs minimal DI
+    registerLoginCommands(program);
 
     // Register hook commands EARLY — passive governance must work even without full DI
     // Hook handles its own DI internally and always exits 0

--- a/packages/core/src/finding_detector/detectors/heuristic_detector.ts
+++ b/packages/core/src/finding_detector/detectors/heuristic_detector.ts
@@ -22,7 +22,7 @@ interface HeuristicRule {
   severity: FindingSeverity;
   confidence: number;
   message: string;
-  suggestion?: string;
+  fixes?: Array<{ description: string }>;
 }
 
 const HEURISTIC_RULES: HeuristicRule[] = [
@@ -33,7 +33,7 @@ const HEURISTIC_RULES: HeuristicRule[] = [
     severity: "medium",
     confidence: 0.7,
     message: "Sensitive variable name detected",
-    suggestion: "Consider if this variable contains actual PII",
+    fixes: [{ description: "Consider if this variable contains actual PII" }],
   },
   {
     id: "HEUR-002",
@@ -42,7 +42,7 @@ const HEURISTIC_RULES: HeuristicRule[] = [
     severity: "medium",
     confidence: 0.6,
     message: "Logging of potentially sensitive object detected",
-    suggestion: "Sanitize logged objects to remove PII",
+    fixes: [{ description: "Sanitize logged objects to remove PII" }],
   },
   {
     id: "HEUR-003",
@@ -51,7 +51,7 @@ const HEURISTIC_RULES: HeuristicRule[] = [
     severity: "low",
     confidence: 0.5,
     message: "JSON serialization of potentially sensitive object",
-    suggestion: "Ensure sensitive fields are excluded before serialization",
+    fixes: [{ description: "Ensure sensitive fields are excluded before serialization" }],
   },
 ];
 
@@ -126,7 +126,7 @@ export class HeuristicDetector implements Detector {
           fingerprint: generateFingerprint(rule.id, filePath, line),
           confidence: rule.confidence,
         };
-        if (rule.suggestion) finding.suggestion = rule.suggestion;
+        if (rule.fixes?.length) finding.fixes = rule.fixes;
         findings.push(finding);
       }
     }

--- a/packages/core/src/finding_detector/detectors/http_llm_detector.ts
+++ b/packages/core/src/finding_detector/detectors/http_llm_detector.ts
@@ -123,7 +123,7 @@ export class HttpLlmDetector implements LlmDetector {
         confidence: raw.confidence ?? 0.9,
       };
 
-      if (raw.suggestion) finding.suggestion = raw.suggestion;
+      if (raw.fixes?.length) finding.fixes = raw.fixes;
       if (raw.legalReference) finding.legalReference = raw.legalReference;
 
       return finding;

--- a/packages/core/src/finding_detector/detectors/regex_detector.ts
+++ b/packages/core/src/finding_detector/detectors/regex_detector.ts
@@ -85,7 +85,7 @@ export class RegexDetector implements Detector {
           fingerprint: generateFingerprint(rule.id, filePath, line),
           confidence: 1.0,
         };
-        if (rule.suggestion) finding.suggestion = rule.suggestion;
+        if (rule.fixes?.length) finding.fixes = rule.fixes;
         if (rule.legalReference) finding.legalReference = rule.legalReference;
         findings.push(finding);
       }

--- a/packages/core/src/finding_detector/rules/regex_rules.ts
+++ b/packages/core/src/finding_detector/rules/regex_rules.ts
@@ -8,7 +8,7 @@ export const REGEX_RULES: RegexRule[] = [
     category: "pii-email",
     severity: "high",
     message: "Email address detected in source code",
-    suggestion: "Move to configuration or environment variable",
+    fixes: [{ description: "Move to configuration or environment variable" }],
     legalReference: "GDPR Art. 4(1)",
   },
   {
@@ -17,7 +17,7 @@ export const REGEX_RULES: RegexRule[] = [
     category: "pii-phone",
     severity: "medium",
     message: "Phone number pattern detected",
-    suggestion: "Avoid hardcoding personal phone numbers",
+    fixes: [{ description: "Avoid hardcoding personal phone numbers" }],
   },
   {
     id: "PII-003",
@@ -25,7 +25,7 @@ export const REGEX_RULES: RegexRule[] = [
     category: "pii-financial",
     severity: "critical",
     message: "Potential credit card number detected",
-    suggestion: "Never store credit card numbers in source code",
+    fixes: [{ description: "Never store credit card numbers in source code" }],
     legalReference: "PCI-DSS, GDPR Art. 32",
   },
   {
@@ -34,7 +34,7 @@ export const REGEX_RULES: RegexRule[] = [
     category: "pii-generic",
     severity: "critical",
     message: "US Social Security Number pattern detected",
-    suggestion: "SSNs must never be stored in source code",
+    fixes: [{ description: "SSNs must never be stored in source code" }],
   },
   {
     id: "PII-005",
@@ -42,7 +42,7 @@ export const REGEX_RULES: RegexRule[] = [
     category: "pii-generic",
     severity: "medium",
     message: "Sensitive field name detected",
-    suggestion: "Review if real data or structure requiring encryption",
+    fixes: [{ description: "Review if real data or structure requiring encryption" }],
   },
 
   // === SECRETS ===
@@ -53,7 +53,7 @@ export const REGEX_RULES: RegexRule[] = [
     category: "hardcoded-secret",
     severity: "critical",
     message: "Hardcoded API key detected",
-    suggestion: "Use environment variables or secret management",
+    fixes: [{ description: "Use environment variables or secret management" }],
   },
   {
     id: "SEC-002",
@@ -61,7 +61,7 @@ export const REGEX_RULES: RegexRule[] = [
     category: "hardcoded-secret",
     severity: "critical",
     message: "AWS Access Key ID detected",
-    suggestion: "Rotate this key immediately and use IAM roles",
+    fixes: [{ description: "Rotate this key immediately and use IAM roles" }],
   },
   {
     id: "SEC-003",
@@ -69,7 +69,7 @@ export const REGEX_RULES: RegexRule[] = [
     category: "hardcoded-secret",
     severity: "critical",
     message: "Private key detected in source code",
-    suggestion: "Never commit private keys. Use secret management.",
+    fixes: [{ description: "Never commit private keys. Use secret management." }],
   },
 
   // === LOGGING PII ===
@@ -80,7 +80,7 @@ export const REGEX_RULES: RegexRule[] = [
     category: "logging-pii",
     severity: "high",
     message: "Potential PII being logged",
-    suggestion: "Sanitize logs to remove personal data",
+    fixes: [{ description: "Sanitize logs to remove personal data" }],
     legalReference: "GDPR Art. 5(1)(f)",
   },
 ];

--- a/packages/core/src/finding_detector/types.ts
+++ b/packages/core/src/finding_detector/types.ts
@@ -49,8 +49,8 @@ export interface Finding {
   snippet: string;
   /** Problem description */
   message: string;
-  /** Remediation suggestion */
-  suggestion?: string;
+  /** Proposed fixes — SARIF §3.55.4 standard */
+  fixes?: Array<{ description: string }>;
   /** Legal reference (e.g., "GDPR Art. 5(1)(f)") */
   legalReference?: string;
   /** Detector that generated the finding */
@@ -169,8 +169,8 @@ export interface RegexRule {
   severity: FindingSeverity;
   /** Descriptive problem message */
   message: string;
-  /** Remediation suggestion */
-  suggestion?: string;
+  /** Proposed fixes — SARIF §3.55.4 standard */
+  fixes?: Array<{ description: string }>;
   /** Applicable legal reference */
   legalReference?: string;
 }
@@ -186,7 +186,7 @@ export interface LlmRawFinding {
   category: string;
   severity: "critical" | "high" | "medium" | "low" | "info";
   message: string;
-  suggestion?: string;
+  fixes?: Array<{ description: string }>;
   legalReference?: string;
   snippet?: string;
   confidence?: number;

--- a/packages/core/src/redaction/redactor.test.ts
+++ b/packages/core/src/redaction/redactor.test.ts
@@ -12,7 +12,7 @@
  * | RLDX-B1  | should return all original fields with redactionLevel l2 when level is l2                      |
  * | RLDX-B2  | should replace snippet with [REDACTED] and set hasFullSnippet false for sensitive category at l1|
  * | RLDX-B3  | should set snippetHash to sha256 of original snippet for sensitive finding with non-empty snippet|
- * | RLDX-B4  | should genericize message and set suggestion to undefined for sensitive category                |
+ * | RLDX-B4  | should genericize message and set fixes to undefined for sensitive category                |
  * | RLDX-B5  | should return all original fields with hasFullSnippet true for safe category at l1              |
  * | RLDX-B6  | should apply full redaction for unregistered category when defaultBehavior is redact            |
  * | RLDX-B7  | should return original fields intact for unregistered category when defaultBehavior is keep     |
@@ -43,7 +43,7 @@ const sensitiveFinding: Finding = {
   severity: 'critical',
   snippet: "const apiKey = 'sk-1234567890abcdef'",
   message: 'Hardcoded API key detected at line 12',
-  suggestion: 'Move to environment variable API_KEY',
+  fixes: [{ description: 'Move to environment variable API_KEY' }],
   fingerprint: 'abc123fingerprint',
   detector: 'regex',
   confidence: 0.95,
@@ -58,7 +58,7 @@ const safeFinding: Finding = {
   severity: 'low',
   snippet: "document.cookie = '_ga=' + gaId",
   message: 'Analytics tracking cookie set',
-  suggestion: 'Ensure cookie consent is obtained',
+  fixes: [{ description: 'Ensure cookie consent is obtained' }],
   fingerprint: 'def456fingerprint',
   detector: 'regex',
   confidence: 0.8,
@@ -155,7 +155,7 @@ describe('FindingRedactor', () => {
     });
 
     it('[RLDX-A5] should carry all finding fields plus redactionLevel hasFullSnippet and snippetHash', () => {
-      // Test with Finding (has snippet, suggestion)
+      // Test with Finding (has snippet, fixes)
       const redactedFinding = redactor.redact(sensitiveFinding, 'l1');
       expect(redactedFinding.file).toBe(sensitiveFinding.file);
       expect(redactedFinding.line).toBe(sensitiveFinding.line);
@@ -167,7 +167,7 @@ describe('FindingRedactor', () => {
       expect(redactedFinding.hasFullSnippet).toBeDefined();
       expect(redactedFinding.snippetHash).toBeDefined();
 
-      // Test with ConsolidatedFinding (has snippet, no suggestion)
+      // Test with ConsolidatedFinding (has snippet, no fixes)
       const redactedConsolidated = redactor.redact(consolidatedFinding, 'l1');
       expect(redactedConsolidated.fingerprint).toBe(consolidatedFinding.fingerprint);
       expect(redactedConsolidated.reportedBy).toEqual(consolidatedFinding.reportedBy);
@@ -186,7 +186,7 @@ describe('FindingRedactor', () => {
 
       expect(result.snippet).toBe(sensitiveFinding.snippet);
       expect(result.message).toBe(sensitiveFinding.message);
-      expect(result.suggestion).toBe(sensitiveFinding.suggestion);
+      expect(result.fixes).toBe(sensitiveFinding.fixes);
       expect(result.redactionLevel).toBe('l2');
       expect(result.hasFullSnippet).toBe(true);
     });
@@ -208,12 +208,12 @@ describe('FindingRedactor', () => {
       expect(result.snippetHash).toBe(sha256(sensitiveFinding.snippet));
     });
 
-    it('[RLDX-B4] should genericize message and set suggestion to undefined for sensitive category', () => {
+    it('[RLDX-B4] should genericize message and set fixes to undefined for sensitive category', () => {
       const result = redactor.redact(sensitiveFinding, 'l1');
 
       expect(result.message).toContain('hardcoded-secret');
       expect(result.message).not.toBe(sensitiveFinding.message);
-      expect(result.suggestion).toBeUndefined();
+      expect(result.fixes).toBeUndefined();
     });
 
     it('[RLDX-B5] should return all original fields with hasFullSnippet true for safe category at l1', () => {
@@ -221,7 +221,7 @@ describe('FindingRedactor', () => {
 
       expect(result.snippet).toBe(safeFinding.snippet);
       expect(result.message).toBe(safeFinding.message);
-      expect(result.suggestion).toBe(safeFinding.suggestion);
+      expect(result.fixes).toBe(safeFinding.fixes);
       expect(result.hasFullSnippet).toBe(true);
       expect(result.redactionLevel).toBe('l1');
     });

--- a/packages/core/src/redaction/redactor.ts
+++ b/packages/core/src/redaction/redactor.ts
@@ -31,9 +31,9 @@ class FindingRedactor {
    *
    * L2: retorna copia completa sin modificaciones (solo agrega metadatos).
    * L1 + categoria no sensible: retorna copia sin modificaciones.
-   * L1 + categoria sensible: redacta snippet, genericiza message, elimina suggestion.
+   * L1 + categoria sensible: redacta snippet, genericiza message, elimina fixes.
    *
-   * Note: ConsolidatedFinding does not have suggestion field.
+   * Note: ConsolidatedFinding does not have fixes field.
    * Only fields that exist on the input are redacted.
    */
   redact<T extends RedactableInput>(finding: T, level: RedactionLevel): RedactedFinding<T> {
@@ -55,7 +55,7 @@ class FindingRedactor {
     }
 
     // L1 + categoria sensible: redactar
-    // Only redact snippet/suggestion if they exist on the input type
+    // Only redact snippet/fixes if they exist on the input type
     const snippet = 'snippet' in finding ? finding.snippet : undefined;
     const overrides: Record<string, unknown> = {
       message: `Sensitive finding (${finding.category})`,
@@ -65,8 +65,8 @@ class FindingRedactor {
     if ('snippet' in finding) {
       overrides['snippet'] = '[REDACTED]';
     }
-    if ('suggestion' in finding) {
-      overrides['suggestion'] = undefined;
+    if ('fixes' in finding) {
+      overrides['fixes'] = undefined;
     }
     if (snippet) {
       overrides['snippetHash'] = sha256(snippet as string);

--- a/packages/core/src/sarif/sarif.types.ts
+++ b/packages/core/src/sarif/sarif.types.ts
@@ -121,10 +121,40 @@ export type SarifResult = {
    */
   suppressions?: SarifSuppression[];
   /**
+   * Proposed fixes for this result.
+   * §3.55.4 fix object — detector suggestion for remediation.
+   * description.text is the human-readable suggestion.
+   * artifactChanges are optional concrete diffs.
+   */
+  fixes?: SarifFix[];
+  /**
    * GitGov governance metadata.
    * §3.8 PropertyBag
    */
   properties?: SarifResultProperties;
+};
+
+/**
+ * A proposed fix for a result.
+ * §3.55 fix object
+ */
+export type SarifFix = {
+  /** Human-readable description of the fix */
+  description: { text: string };
+  /** Concrete file changes (optional) */
+  artifactChanges?: SarifArtifactChange[];
+};
+
+/**
+ * A change to a single artifact.
+ * §3.56 artifactChange object
+ */
+export type SarifArtifactChange = {
+  artifactLocation: { uri: string };
+  replacements: Array<{
+    deletedRegion: { startLine: number; startColumn?: number; endLine?: number; endColumn?: number };
+    insertedContent?: { text: string };
+  }>;
 };
 
 /**

--- a/packages/core/src/sarif/sarif_builder.test.ts
+++ b/packages/core/src/sarif/sarif_builder.test.ts
@@ -16,7 +16,7 @@ const baseFindings: Finding[] = [
     column: 5,
     snippet: 'const email = user.email;',
     message: 'PII email detected in source code',
-    suggestion: 'Remove email from source',
+    fixes: [{ description: 'Remove email from source' }],
     legalReference: 'GDPR Art. 5(1)(f)',
     detector: 'regex',
     fingerprint: 'abc123def456',
@@ -144,7 +144,7 @@ describe('SarifBuilder', () => {
       expect(loc!.physicalLocation.region.snippet).toBeUndefined();
     });
 
-    it('[SARIF-C9] build: rule with suggestion should include fullDescription.text', async () => {
+    it('[SARIF-C9] build: rule with fixes should include fullDescription.text', async () => {
       const sarif = await builder.build(baseOptions);
       const rules = firstRun(sarif).tool.driver.rules ?? [];
       const rule = rules.find(r => r.id === 'PII-001');

--- a/packages/core/src/sarif/sarif_builder.ts
+++ b/packages/core/src/sarif/sarif_builder.ts
@@ -55,7 +55,7 @@ function extractRules(findings: Finding[]): SarifReportingDescriptor[] {
       rules.push({
         id: f.ruleId,
         shortDescription: { text: f.message },
-        ...(f.suggestion && { fullDescription: { text: f.suggestion } }),
+        ...(f.fixes && f.fixes.length > 0 && { fullDescription: { text: f.fixes[0]!.description } }),
         ...(f.legalReference && { helpUri: `https://gitgovernance.com/rules/${f.ruleId}` }),
       });
     }
@@ -205,6 +205,9 @@ class SarifBuilderImpl implements SarifBuilder {
         if (Object.keys(partial).length > 0) {
           result.partialFingerprints = partial;
         }
+        // SARIF §3.55.4 — text-only fixes go in rules[].fullDescription (SARIF-C9)
+        // result.fixes[] requires artifactChanges (schema mandates it)
+        // Only emit result.fixes when concrete diffs are provided (future)
         if (waiver) {
           result.suppressions = [buildSuppression(waiver)];
         }


### PR DESCRIPTION
## Summary

Cycle 4 of epic **saas_base** — login command + core refactoring.

### Login Command (14 EARS)
- OAuth flow, bidirectional key sync CLI↔SaaS, conflict detection
- E2E tests against compiled CLI binary (4 EARS)

### Core: suggestion → fixes (SARIF §3.55.4)
- Finding.suggestion renamed to Finding.fixes across core (10 files)
- SarifFix + SarifArtifactChange types added to sarif.types.ts
- 3 detectors + 9 regex rules + SarifBuilder + Redactor updated
- All 2720 core tests passing

## Metrics

| Metric | Value |
|---|---|
| EARS (login) | 14 |
| EARS (core rename) | N/A (refactor) |
| Tests passing (core) | 2720 |
| Tests passing (CLI) | 14 (10 unit + 4 E2E) |

## Test plan

- [x] Core: 2720/2720 tests passing
- [x] CLI unit: 10/10 passing
- [x] CLI E2E: 4/4 passing
- [x] tsc --noEmit: 0 errors

Part of saas_base Cycle 4