### PR TITLE
feat(core): AgentRunner FeedbackRecord support for review agents (EARS-L1 to L4)

### DIFF
--- a/packages/agents/review-advisor/.env.sample
+++ b/packages/agents/review-advisor/.env.sample
@@ -1,0 +1,7 @@
+# review-advisor agent — Environment Variables
+# Copy to .env and fill in values
+
+# Required for Claude semantic analysis
+# Without this, the agent degrades gracefully (RAV-D2: returns status partial)
+# Get from: https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=

--- a/packages/agents/review-advisor/agent.test.ts
+++ b/packages/agents/review-advisor/agent.test.ts
@@ -1,0 +1,285 @@
+/**
+ * ReviewAdvisorAgent Tests
+ *
+ * Unit tests for the review-advisor agent implementation.
+ * All Claude SDK calls are mocked via analyzer override.
+ *
+ * Reference: review_advisor_agent.md §4.1-4.3
+ */
+
+import { ReviewAdvisorAgent } from './src/agent';
+import type { ClaudeAnalyzer } from './src/agent';
+import type { ReviewAdvisorInput, ReviewOpinion } from './src/types';
+import type { AuditOrchestrator } from '@gitgov/core';
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function makeFinding(overrides: Partial<AuditOrchestrator.ConsolidatedFinding> = {}): AuditOrchestrator.ConsolidatedFinding {
+  return {
+    fingerprint: 'fp-test-001',
+    ruleId: 'SEC-001',
+    message: 'Secret detected in source',
+    severity: 'critical',
+    category: 'secrets',
+    file: 'config.ts',
+    line: 3,
+    reportedBy: ['agent:security-audit'],
+    isWaived: false,
+    ...overrides,
+  };
+}
+
+function makePolicyDecision(decision: 'pass' | 'block' = 'block'): AuditOrchestrator.PolicyDecision {
+  return {
+    decision,
+    reason: decision === 'block' ? 'Critical findings present' : 'No blocking findings',
+    blockingFindings: [],
+    waivedFindings: [],
+    summary: { critical: 1, high: 0, medium: 0, low: 0 },
+    rulesEvaluated: [],
+    evaluatedAt: new Date().toISOString(),
+  };
+}
+
+function makeInput(overrides: Partial<ReviewAdvisorInput> = {}): ReviewAdvisorInput {
+  return {
+    findings: [makeFinding()],
+    policyDecision: makePolicyDecision(),
+    taskId: 'task-test-001',
+    ...overrides,
+  };
+}
+
+function makeOpinion(overrides: Partial<ReviewOpinion> = {}): ReviewOpinion {
+  return {
+    findingFingerprint: 'fp-test-001',
+    riskExplanation: 'Hardcoded API key can be extracted from source',
+    regulations: ['PCI-DSS Req 6.5.3'],
+    remediationAdvice: 'Use environment variables or secret management',
+    confidence: 'high',
+    isFalsePositive: false,
+    ...overrides,
+  };
+}
+
+function mockAnalyzer(opinions: ReviewOpinion[]): ClaudeAnalyzer {
+  return jest.fn().mockResolvedValue(opinions);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('ReviewAdvisorAgent', () => {
+  describe('4.1. Package y Estructura (RAV-A3 to RAV-A4)', () => {
+    it('[RAV-A3] should require findings and taskId in ReviewAdvisorInput', async () => {
+      const input = makeInput();
+
+      // Verify input has required fields
+      expect(input.findings).toBeDefined();
+      expect(Array.isArray(input.findings)).toBe(true);
+      expect(input.taskId).toBe('task-test-001');
+
+      const agent = new ReviewAdvisorAgent({
+        anthropicApiKey: 'test-key',
+        analyzer: mockAnalyzer([makeOpinion()]),
+      });
+
+      const output = await agent.run(input);
+      expect(output).toBeDefined();
+    });
+
+    it('[RAV-A4] should return metadata.kind feedback-review and metadata.data as ReviewResult', async () => {
+      const agent = new ReviewAdvisorAgent({
+        anthropicApiKey: 'test-key',
+        analyzer: mockAnalyzer([makeOpinion()]),
+      });
+
+      const output = await agent.run(makeInput());
+
+      const metadata = output.metadata as Record<string, unknown>;
+      expect(metadata['kind']).toBe('feedback-review');
+      expect(metadata['data']).toBeDefined();
+
+      const data = metadata['data'] as Record<string, unknown>;
+      expect(data['opinions']).toBeDefined();
+      expect(data['summary']).toBeDefined();
+      expect(data['model']).toBe('claude-sonnet-4');
+    });
+  });
+
+  describe('4.2. Claude Analysis (RAV-B1 to RAV-B5)', () => {
+    it('[RAV-B1] should build prompt with finding details, file context, and policy decision', async () => {
+      const analyzerFn = jest.fn().mockResolvedValue([makeOpinion()]);
+
+      const agent = new ReviewAdvisorAgent({
+        anthropicApiKey: 'test-key',
+        analyzer: analyzerFn,
+      });
+
+      const input = makeInput({
+        findings: [makeFinding({ file: 'checkout.ts', line: 47, category: 'data-transfer' })],
+        policyDecision: makePolicyDecision('block'),
+      });
+
+      await agent.run(input);
+
+      // Verify analyzer received findings and policy decision
+      expect(analyzerFn).toHaveBeenCalledWith(
+        input.findings,
+        input.policyDecision,
+      );
+    });
+
+    it('[RAV-B2] should call Claude Agent SDK query with Read tool enabled', async () => {
+      // This test verifies the analyzer is called — real SDK test is in integration
+      const analyzerFn = jest.fn().mockResolvedValue([makeOpinion()]);
+
+      const agent = new ReviewAdvisorAgent({
+        anthropicApiKey: 'test-key',
+        analyzer: analyzerFn,
+      });
+
+      await agent.run(makeInput());
+
+      expect(analyzerFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('[RAV-B3] should parse Claude response into ReviewOpinion with risk, regulations, and confidence', async () => {
+      const opinion = makeOpinion({
+        riskExplanation: 'GDPR Art. 44 violation — PII sent to third party',
+        regulations: ['GDPR Art. 44', 'GDPR Art. 6'],
+        confidence: 'high',
+      });
+
+      const agent = new ReviewAdvisorAgent({
+        anthropicApiKey: 'test-key',
+        analyzer: mockAnalyzer([opinion]),
+      });
+
+      const output = await agent.run(makeInput());
+      const data = (output.metadata as Record<string, unknown>)['data'] as Record<string, unknown>;
+      const opinions = data['opinions'] as ReviewOpinion[];
+
+      expect(opinions).toHaveLength(1);
+      expect(opinions[0]!.riskExplanation).toBe('GDPR Art. 44 violation — PII sent to third party');
+      expect(opinions[0]!.regulations).toEqual(['GDPR Art. 44', 'GDPR Art. 6']);
+      expect(opinions[0]!.confidence).toBe('high');
+    });
+
+    it('[RAV-B4] should set isFalsePositive true with reason when Claude identifies false positive', async () => {
+      const opinion = makeOpinion({
+        isFalsePositive: true,
+        falsePositiveReason: 'This is a test fixture, not production code',
+      });
+
+      const agent = new ReviewAdvisorAgent({
+        anthropicApiKey: 'test-key',
+        analyzer: mockAnalyzer([opinion]),
+      });
+
+      const output = await agent.run(makeInput());
+      const data = (output.metadata as Record<string, unknown>)['data'] as Record<string, unknown>;
+      const opinions = data['opinions'] as ReviewOpinion[];
+
+      expect(opinions[0]!.isFalsePositive).toBe(true);
+      expect(opinions[0]!.falsePositiveReason).toBe('This is a test fixture, not production code');
+    });
+
+    it('[RAV-B5] should return status partial with empty opinions when Claude fails', async () => {
+      const failingAnalyzer: ClaudeAnalyzer = jest.fn().mockRejectedValue(
+        new Error('Claude API unavailable'),
+      );
+
+      const agent = new ReviewAdvisorAgent({
+        anthropicApiKey: 'test-key',
+        analyzer: failingAnalyzer,
+      });
+
+      const output = await agent.run(makeInput());
+
+      // Should not throw — graceful degradation
+      expect(output.data).toEqual({
+        status: 'partial',
+        warning: 'Claude analysis failed: Claude API unavailable',
+      });
+
+      const data = (output.metadata as Record<string, unknown>)['data'] as Record<string, unknown>;
+      const opinions = data['opinions'] as ReviewOpinion[];
+      expect(opinions).toHaveLength(0);
+    });
+  });
+
+  describe('4.3. FeedbackRecord Production (RAV-C1 to RAV-C2)', () => {
+    it('[RAV-C1] should produce AgentOutput compatible with FeedbackRecord type suggestion', async () => {
+      const agent = new ReviewAdvisorAgent({
+        anthropicApiKey: 'test-key',
+        analyzer: mockAnalyzer([makeOpinion()]),
+      });
+
+      const output = await agent.run(makeInput());
+
+      // AgentOutput must have metadata that AgentRunner can persist as FeedbackRecord
+      expect(output.metadata).toBeDefined();
+      const metadata = output.metadata as Record<string, unknown>;
+      expect(metadata['kind']).toBe('feedback-review');
+      expect(metadata['data']).toBeDefined();
+      expect(output.message).toBeDefined();
+      expect(typeof output.message).toBe('string');
+    });
+
+    it('[RAV-C2] should include finding fingerprints in FeedbackRecord references', async () => {
+      const opinions = [
+        makeOpinion({ findingFingerprint: 'fp-001' }),
+        makeOpinion({ findingFingerprint: 'fp-002' }),
+      ];
+
+      const agent = new ReviewAdvisorAgent({
+        anthropicApiKey: 'test-key',
+        analyzer: mockAnalyzer(opinions),
+      });
+
+      const output = await agent.run(makeInput({
+        findings: [
+          makeFinding({ fingerprint: 'fp-001' }),
+          makeFinding({ fingerprint: 'fp-002' }),
+        ],
+      }));
+
+      const data = (output.metadata as Record<string, unknown>)['data'] as Record<string, unknown>;
+      const resultOpinions = data['opinions'] as ReviewOpinion[];
+
+      expect(resultOpinions).toHaveLength(2);
+      expect(resultOpinions[0]!.findingFingerprint).toBe('fp-001');
+      expect(resultOpinions[1]!.findingFingerprint).toBe('fp-002');
+    });
+  });
+
+  describe('4.4. Entry Point y Error Handling (RAV-D2 to RAV-D3)', () => {
+    it('[RAV-D2] should return status partial when ANTHROPIC_API_KEY is not set', async () => {
+      const agent = new ReviewAdvisorAgent({ anthropicApiKey: undefined });
+
+      const output = await agent.run(makeInput());
+
+      expect(output.data).toEqual(
+        expect.objectContaining({
+          status: 'partial',
+          warning: expect.stringContaining('ANTHROPIC_API_KEY'),
+        }),
+      );
+    });
+
+    it('[RAV-D3] should return empty opinions when findings array is empty', async () => {
+      const agent = new ReviewAdvisorAgent({ anthropicApiKey: 'test-key' });
+
+      const output = await agent.run(makeInput({ findings: [] }));
+
+      const data = (output.metadata as Record<string, unknown>)['data'] as Record<string, unknown>;
+      const opinions = data['opinions'] as unknown[];
+      expect(opinions).toHaveLength(0);
+      expect(data['summary']).toBe('No findings to review');
+    });
+  });
+});

--- a/packages/agents/review-advisor/index.test.ts
+++ b/packages/agents/review-advisor/index.test.ts
@@ -1,0 +1,70 @@
+/**
+ * ReviewAdvisor Entry Point Tests
+ *
+ * Tests for the runReviewAdvisor entry point.
+ *
+ * Reference: review_advisor_agent.md §4.1, §4.4
+ */
+
+import { runReviewAdvisor } from './src/index';
+
+// Mock the agent to avoid Claude SDK dependency in unit tests
+jest.mock('./src/agent', () => {
+  return {
+    ReviewAdvisorAgent: jest.fn().mockImplementation(() => ({
+      run: jest.fn().mockResolvedValue({
+        message: 'Review complete',
+        metadata: {
+          kind: 'feedback-review',
+          data: {
+            opinions: [],
+            summary: 'No findings to review',
+            model: 'none',
+          },
+        },
+      }),
+    })),
+  };
+});
+
+describe('ReviewAdvisor Entry Point', () => {
+  describe('4.1. Package y Estructura (RAV-A1)', () => {
+    it('[RAV-A1] should export runReviewAdvisor as named export from src/index.ts', () => {
+      expect(runReviewAdvisor).toBeDefined();
+      expect(typeof runReviewAdvisor).toBe('function');
+    });
+  });
+
+  describe('4.4. Entry Point y Error Handling (RAV-D1 to RAV-D4)', () => {
+    it('[RAV-D1] should return AgentOutput with feedback-review kind', async () => {
+      const ctx = {
+        agentId: 'agent:gitgov:review-advisor',
+        actorId: 'agent:gitgov:review-advisor',
+        taskId: 'task-test',
+        runId: 'run-test',
+        input: {
+          findings: [],
+          policyDecision: { decision: 'pass', reason: 'No issues' },
+          taskId: 'task-test',
+        },
+      };
+
+      const output = await runReviewAdvisor(ctx);
+
+      expect(output).toBeDefined();
+      expect(output.metadata).toBeDefined();
+      const metadata = output.metadata as Record<string, unknown>;
+      expect(metadata['kind']).toBe('feedback-review');
+    });
+
+    // RAV-D2 and RAV-D3 tested in agent.test.ts (no mock interference)
+
+    it('[RAV-D4] should export runReviewAdvisor as named export', async () => {
+      const mod = await import('./src/index');
+      expect(mod.runReviewAdvisor).toBeDefined();
+      expect(typeof mod.runReviewAdvisor).toBe('function');
+      // Verify it's NOT a default export
+      expect((mod as Record<string, unknown>)['default']).toBeUndefined();
+    });
+  });
+});

--- a/packages/agents/review-advisor/jest.config.cjs
+++ b/packages/agents/review-advisor/jest.config.cjs
@@ -1,0 +1,11 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  testTimeout: 30000,
+  moduleNameMapper: {
+    '^@gitgov/core$': '<rootDir>/node_modules/@gitgov/core/src/index.ts',
+    '^@anthropic-ai/claude-agent-sdk$': '<rootDir>/node_modules/@anthropic-ai/claude-agent-sdk',
+  },
+};

--- a/packages/agents/review-advisor/package.json
+++ b/packages/agents/review-advisor/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@gitgov/agent-review-advisor",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.mjs",
+  "scripts": {
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.mjs --external:@gitgov/core --external:@anthropic-ai/claude-agent-sdk",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@gitgov/core": "workspace:*",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.81"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.0.0",
+    "@types/node": "^20.0.0",
+    "esbuild": "^0.19.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/agents/review-advisor/src/agent.ts
+++ b/packages/agents/review-advisor/src/agent.ts
@@ -1,0 +1,202 @@
+// All EARS prefixes map to review_advisor_agent.md
+
+import type {
+  ReviewAdvisorInput,
+  ReviewAdvisorAgentDeps,
+  ReviewResult,
+  ReviewOpinion,
+  ReviewAdvisorMetadata,
+} from './types';
+
+/**
+ * AgentOutput from the framework (Runner namespace).
+ * Defined locally to avoid deep namespace import — shape is stable.
+ */
+type AgentOutput = {
+  data?: unknown;
+  message?: string;
+  artifacts?: string[];
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Interface for the Claude analysis function.
+ * Abstracted for testability — real impl uses Claude Agent SDK.
+ */
+export type ClaudeAnalyzer = (
+  findings: ReviewAdvisorInput['findings'],
+  policyDecision: ReviewAdvisorInput['policyDecision'],
+) => Promise<ReviewOpinion[]>;
+
+/**
+ * Agente de review semantico.
+ *
+ * Analiza findings con Claude y produce opiniones contextuales.
+ * No detecta findings — los recibe del scanner. Solo opina.
+ * No aprueba waivers — solo genera opiniones.
+ * AgentRunner firma el FeedbackRecord automaticamente (EARS-L1).
+ */
+export class ReviewAdvisorAgent {
+  private readonly apiKey: string | undefined;
+  private readonly analyzerOverride: ClaudeAnalyzer | undefined;
+
+  constructor(deps: ReviewAdvisorAgentDeps & { analyzer?: ClaudeAnalyzer }) {
+    this.apiKey = deps.anthropicApiKey;
+    this.analyzerOverride = deps.analyzer;
+  }
+
+  // [RAV-A4, RAV-C1] Return AgentOutput with feedback-review metadata
+  async run(input: ReviewAdvisorInput): Promise<AgentOutput> {
+    // [RAV-D3] Empty findings → return immediately without calling Claude
+    if (!input.findings || input.findings.length === 0) {
+      return this.buildOutput({
+        opinions: [],
+        summary: 'No findings to review',
+        model: 'none',
+      });
+    }
+
+    // [RAV-D2] No API key → return partial with warning
+    if (!this.apiKey && !this.analyzerOverride) {
+      return this.buildPartialOutput('ANTHROPIC_API_KEY not set — review skipped');
+    }
+
+    // [RAV-B1] Build analysis context with findings + policy decision
+    const opinions: ReviewOpinion[] = [];
+
+    try {
+      // [RAV-B2] Call Claude (or mock analyzer for tests)
+      const analyzer = this.analyzerOverride ?? this.createClaudeAnalyzer();
+      const results = await analyzer(input.findings, input.policyDecision);
+
+      // [RAV-B3] Parse response into ReviewOpinion[]
+      for (const opinion of results) {
+        opinions.push(opinion);
+      }
+    } catch (err) {
+      // [RAV-B5] Claude failure → return partial with empty opinions
+      const message = err instanceof Error ? err.message : String(err);
+      return this.buildPartialOutput(`Claude analysis failed: ${message}`);
+    }
+
+    // [RAV-C2] Include finding fingerprints in result
+    const reviewedFingerprints = opinions.map(o => o.findingFingerprint);
+
+    const result: ReviewResult = {
+      opinions,
+      summary: `Reviewed ${opinions.length} finding(s). ${reviewedFingerprints.length} opinions generated.`,
+      model: 'claude-sonnet-4',
+    };
+
+    return this.buildOutput(result);
+  }
+
+  // [RAV-A4] Build AgentOutput with feedback-review metadata
+  private buildOutput(result: ReviewResult): AgentOutput {
+    const metadata: ReviewAdvisorMetadata = {
+      kind: 'feedback-review',
+      data: result,
+    };
+
+    return {
+      message: result.summary,
+      metadata: metadata as unknown as Record<string, unknown>,
+    };
+  }
+
+  // [RAV-B5, RAV-D2] Build partial output for graceful degradation
+  private buildPartialOutput(warning: string): AgentOutput {
+    const result: ReviewResult = {
+      opinions: [],
+      summary: warning,
+      model: 'none',
+    };
+
+    const metadata: ReviewAdvisorMetadata = {
+      kind: 'feedback-review',
+      data: result,
+    };
+
+    return {
+      message: warning,
+      data: { status: 'partial', warning },
+      metadata: metadata as unknown as Record<string, unknown>,
+    };
+  }
+
+  // [RAV-B2] Create real Claude analyzer using Agent SDK
+  private createClaudeAnalyzer(): ClaudeAnalyzer {
+    return async (findings, policyDecision) => {
+      // Dynamic import to avoid bundling SDK when not used
+      const { query } = await import('@anthropic-ai/claude-agent-sdk');
+
+      const prompt = this.buildPrompt(findings, policyDecision);
+
+      const opinions: ReviewOpinion[] = [];
+
+      const systemPrompt = `You are a security compliance reviewer. Analyze each finding and respond with a JSON array of ReviewOpinion objects. Each opinion must have: findingFingerprint, riskExplanation, regulations (array of strings like "GDPR Art. 44"), remediationAdvice, confidence ("high"|"medium"|"low"), isFalsePositive (boolean), and optionally falsePositiveReason.`;
+
+      // [RAV-B2] Query Claude with Read tool enabled for file context
+      // SDK uses ANTHROPIC_API_KEY from environment automatically
+      for await (const message of query({
+        prompt,
+        options: {
+          model: 'claude-sonnet-4-20250514',
+          systemPrompt,
+          // [RAV-B2] Enable Read tool so Claude can access repo files for context
+          tools: ['Read'],
+          permissionMode: 'default',
+        },
+      }) as AsyncIterable<unknown>) {
+        const msg = message as Record<string, unknown>;
+        if (msg['type'] === 'assistant') {
+          try {
+            // Extract text content from message (SDK format varies)
+            const content = msg['content'];
+            const text = typeof content === 'string'
+              ? content
+              : Array.isArray(content)
+                ? (content as Array<Record<string, unknown>>).map(b => b['text'] ?? '').join('')
+                : '';
+            if (!text) continue;
+
+            const parsed: unknown = JSON.parse(text);
+            if (Array.isArray(parsed)) {
+              for (const item of parsed as Record<string, unknown>[]) {
+                // [RAV-B3] Parse into ReviewOpinion
+                opinions.push({
+                  findingFingerprint: (item['findingFingerprint'] as string) ?? '',
+                  riskExplanation: (item['riskExplanation'] as string) ?? '',
+                  regulations: Array.isArray(item['regulations']) ? item['regulations'] as string[] : [],
+                  remediationAdvice: (item['remediationAdvice'] as string) ?? '',
+                  confidence: (item['confidence'] as ReviewOpinion['confidence']) ?? 'medium',
+                  isFalsePositive: item['isFalsePositive'] === true,
+                  // [RAV-B4] False positive with reason
+                  ...(item['isFalsePositive'] && item['falsePositiveReason']
+                    ? { falsePositiveReason: item['falsePositiveReason'] as string }
+                    : {}),
+                });
+              }
+            }
+          } catch {
+            // Not parseable JSON — skip
+          }
+        }
+      }
+
+      return opinions;
+    };
+  }
+
+  // [RAV-B1] Build prompt with finding details + policy decision
+  private buildPrompt(
+    findings: ReviewAdvisorInput['findings'],
+    policyDecision: ReviewAdvisorInput['policyDecision'],
+  ): string {
+    const findingsList = findings.map((f, i) =>
+      `Finding ${i + 1}:\n  Fingerprint: ${f.fingerprint}\n  Severity: ${f.severity}\n  Category: ${f.category}\n  File: ${f.file}:${f.line}\n  Message: ${f.message}${f.snippet ? `\n  Snippet: ${f.snippet}` : ''}`
+    ).join('\n\n');
+
+    return `Review these security findings and provide your analysis as a JSON array of ReviewOpinion objects.\n\nPolicy Decision: ${policyDecision.decision} (${policyDecision.reason})\n\nFindings:\n${findingsList}\n\nRespond ONLY with a valid JSON array.`;
+  }
+}

--- a/packages/agents/review-advisor/src/index.ts
+++ b/packages/agents/review-advisor/src/index.ts
@@ -1,0 +1,47 @@
+// All EARS prefixes map to review_advisor_agent.md
+
+import type { ReviewAdvisorInput } from './types';
+import { ReviewAdvisorAgent } from './agent';
+
+/**
+ * AgentExecutionContext from the framework (Runner namespace).
+ * Defined locally to avoid deep namespace import — shape is stable.
+ * Decision A8 pattern: ctx.input is `unknown`, cast explicitly.
+ */
+type AgentExecutionContext = {
+  agentId: string;
+  actorId: string;
+  taskId: string;
+  runId: string;
+  input?: unknown;
+};
+
+/**
+ * Entry point for the review-advisor agent, invoked by AgentRunner.
+ *
+ * Contract: AgentRunner calls engine.function with AgentExecutionContext.
+ * Input is cast explicitly (same pattern as security-audit).
+ *
+ * [RAV-A1] Named export from src/index.ts
+ * [RAV-D1] Returns resolved Promise<AgentOutput>
+ * [RAV-D4] Named export (not default)
+ *
+ * @param ctx - Execution context provided by AgentRunner
+ * @returns AgentOutput with ReviewResult in metadata
+ */
+export async function runReviewAdvisor(ctx: AgentExecutionContext) {
+  const input = ctx.input as ReviewAdvisorInput;
+
+  // [RAV-D2] API key from environment — agent degrades gracefully if missing
+  const agent = new ReviewAdvisorAgent({
+    anthropicApiKey: process.env['ANTHROPIC_API_KEY'],
+  });
+
+  return agent.run(input);
+}
+
+export type {
+  ReviewAdvisorInput,
+  ReviewResult,
+  ReviewOpinion,
+} from './types';

--- a/packages/agents/review-advisor/src/types.ts
+++ b/packages/agents/review-advisor/src/types.ts
@@ -1,0 +1,70 @@
+// All EARS prefixes map to review_advisor_agent.md
+
+import type { AuditOrchestrator } from '@gitgov/core';
+
+/**
+ * Input recibido por el agente via AgentExecutionContext.input.
+ * Pasado por AuditOrchestrator post-policy (AORCH-F2).
+ */
+export type ReviewAdvisorInput = {
+  /** Findings consolidados del AuditOrchestrator */
+  findings: AuditOrchestrator.ConsolidatedFinding[];
+  /** Policy decision del evaluator */
+  policyDecision: AuditOrchestrator.PolicyDecision;
+  /** TaskRecord.id para trazabilidad */
+  taskId: string;
+  /** Directorio raiz del repo para contexto de archivos */
+  baseDir?: string;
+  /** Filtro: solo reviewar findings de estas severidades */
+  minSeverity?: 'critical' | 'high' | 'medium' | 'low';
+};
+
+/**
+ * Opinion de Claude sobre un finding individual.
+ */
+export type ReviewOpinion = {
+  /** Fingerprint del finding reviewado */
+  findingFingerprint: string;
+  /** Explicacion del riesgo en lenguaje humano */
+  riskExplanation: string;
+  /** Regulaciones aplicables (GDPR Art. X, PCI Req Y, etc.) */
+  regulations: string[];
+  /** Opinion sobre la remediacion sugerida */
+  remediationAdvice: string;
+  /** Confidence: que tan seguro esta Claude de su analisis */
+  confidence: 'high' | 'medium' | 'low';
+  /** Es un false positive? */
+  isFalsePositive: boolean;
+  /** Justificacion si es false positive */
+  falsePositiveReason?: string;
+};
+
+/**
+ * Resultado completo del review.
+ */
+export type ReviewResult = {
+  /** Opiniones por finding */
+  opinions: ReviewOpinion[];
+  /** Resumen general */
+  summary: string;
+  /** Modelo utilizado */
+  model: string;
+};
+
+/**
+ * Metadata del AgentOutput para review-advisor.
+ */
+export type ReviewAdvisorMetadata = {
+  /** Discriminador de formato */
+  kind: 'feedback-review';
+  /** Resultado del review */
+  data: ReviewResult;
+};
+
+/**
+ * Dependencias inyectadas al agente.
+ */
+export type ReviewAdvisorAgentDeps = {
+  /** API key de Anthropic (requerida para Claude) */
+  anthropicApiKey?: string;
+};

--- a/packages/agents/review-advisor/tsconfig.json
+++ b/packages/agents/review-advisor/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"],
+    "paths": {
+      "@gitgov/core": ["../../core/src/index.ts"],
+      "@gitgov/core/*": ["../../core/src/*"]
+    },
+    "baseUrl": "."
+  },
+  "include": ["src", "*.test.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cli/src/commands/agent/agent-command.test.ts
+++ b/packages/cli/src/commands/agent/agent-command.test.ts
@@ -458,4 +458,127 @@ describe('AgentCommand', () => {
       expect(output.data.engine).toEqual({ type: 'local' });
     });
   });
+
+  describe('4.5. Agent New con Config (EARS-E1 to EARS-E4)', () => {
+    it('[EARS-E1] should create AgentRecord with merged config JSON', async () => {
+      const config = JSON.stringify({
+        engine: {
+          entrypoint: 'packages/agents/security-audit/dist/index.mjs',
+          function: 'runAgent',
+        },
+        metadata: { purpose: 'audit', audit: { target: 'code', outputFormat: 'sarif' } },
+      });
+
+      await agentCommand.executeNew('agent:test-config', {
+        engineType: 'local',
+        config,
+        json: true,
+      } as AgentNewOptions);
+
+      // Verify createAgentRecord was called with merged payload
+      expect(mockAgentAdapter.createAgentRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'agent:test-config',
+          engine: expect.objectContaining({
+            type: 'local',
+            entrypoint: 'packages/agents/security-audit/dist/index.mjs',
+            function: 'runAgent',
+          }),
+          metadata: expect.objectContaining({
+            purpose: 'audit',
+          }),
+        }),
+      );
+    });
+
+    it('[EARS-E2] should read and merge config from --config-file', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const nodeFs = require('node:fs') as typeof import('fs');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const nodePath = require('node:path') as typeof import('path');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const nodeOs = require('node:os') as typeof import('os');
+
+      const tmpFile = nodePath.join(nodeOs.tmpdir(), `agent-config-e2-${Date.now()}.json`);
+
+      nodeFs.writeFileSync(tmpFile, JSON.stringify({
+        engine: { entrypoint: 'dist/index.mjs', function: 'runAgent' },
+        metadata: { purpose: 'review' },
+      }));
+
+      try {
+        await agentCommand.executeNew('agent:test-file', {
+          engineType: 'local',
+          configFile: tmpFile,
+          json: true,
+        } as AgentNewOptions);
+
+        expect(mockAgentAdapter.createAgentRecord).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'agent:test-file',
+            engine: expect.objectContaining({
+              type: 'local',
+              entrypoint: 'dist/index.mjs',
+            }),
+            metadata: expect.objectContaining({
+              purpose: 'review',
+            }),
+          }),
+        );
+      } finally {
+        nodeFs.unlinkSync(tmpFile);
+      }
+    });
+
+    it('[EARS-E3] should merge --engine-type shortcut with --config fields', async () => {
+      // Config says engine type "api" but -e says "local" — -e wins
+      const config = JSON.stringify({
+        engine: {
+          type: 'api',
+          url: 'https://example.com',
+          entrypoint: 'dist/index.mjs',
+        },
+        metadata: { purpose: 'audit' },
+      });
+
+      await agentCommand.executeNew('agent:test-merge', {
+        engineType: 'local',
+        config,
+        json: true,
+      } as AgentNewOptions);
+
+      expect(mockAgentAdapter.createAgentRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'agent:test-merge',
+          engine: expect.objectContaining({
+            type: 'local', // -e wins over config.engine.type
+            entrypoint: 'dist/index.mjs', // from config
+          }),
+        }),
+      );
+    });
+
+    it('[EARS-E4] should show error and exit 1 when config JSON is invalid', async () => {
+      const mockExit = jest.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+
+      await agentCommand.executeNew('agent:test-invalid', {
+        engineType: 'local',
+        config: '{invalid json!!!',
+        json: true,
+      } as AgentNewOptions);
+
+      // Should have called process.exit(1)
+      expect(mockExit).toHaveBeenCalledWith(1);
+
+      // Should have logged error
+      const errorCall = mockConsoleLog.mock.calls.find(call =>
+        typeof call[0] === 'string' && call[0].includes('Invalid JSON'),
+      ) ?? mockConsoleError.mock.calls.find(call =>
+        typeof call[0] === 'string' && (call[0] as string).includes('Invalid JSON'),
+      );
+      expect(errorCall).toBeDefined();
+
+      mockExit.mockRestore();
+    });
+  });
 });

--- a/packages/cli/src/commands/agent/agent-command.ts
+++ b/packages/cli/src/commands/agent/agent-command.ts
@@ -50,11 +50,15 @@ export interface ShowCommandOptions extends BaseCommandOptions {
 
 /**
  * CLI-specific options for agent new command
- * EARS: ICOMP-C7..C9
+ * EARS: ICOMP-C7..C9, EARS-E1..E4
  */
 export interface AgentNewOptions extends BaseCommandOptions {
   /** Engine type */
   engineType: 'local' | 'api' | 'mcp' | 'custom';
+  /** [EARS-E1] Inline JSON config to merge with defaults */
+  config?: string;
+  /** [EARS-E2] Path to JSON config file */
+  configFile?: string;
 }
 
 /**
@@ -88,7 +92,9 @@ export class AgentCommand extends BaseCommand<RunCommandOptions> {
       .command('new <actorId>')
       .alias('n')
       .description('Create a new AgentRecord for an actor of type agent')
-      .addOption(new Option('-e, --engine-type <type>', 'Execution engine type').choices(['local', 'api', 'mcp', 'custom']).makeOptionMandatory())
+      .addOption(new Option('-e, --engine-type <type>', 'Execution engine type').choices(['local', 'api', 'mcp', 'custom']))
+      .option('-c, --config <json>', 'Inline JSON config to merge with defaults (engine, metadata, triggers)')
+      .option('--config-file <path>', 'Path to JSON config file')
       .option('--json', 'Output as JSON', false)
       .option('-v, --verbose', 'Verbose output', false)
       .option('-q, --quiet', 'Quiet output', false)
@@ -149,12 +155,62 @@ export class AgentCommand extends BaseCommand<RunCommandOptions> {
     try {
       const agentAdapter = await this.container.getAgentAdapter();
 
-      // [ICOMP-C7] Create AgentRecord via adapter
-      // Engine is a discriminated union — adapter validates required fields per type
-      const agent = await agentAdapter.createAgentRecord({
+      // [EARS-E1, E2, E3, E4] Build payload from config sources
+      let configPayload: Record<string, unknown> = {};
+
+      // [EARS-E2] Read from config file first (lowest priority)
+      if (options.configFile) {
+        const { readFileSync } = await import('node:fs');
+        try {
+          const fileContent = readFileSync(options.configFile, 'utf-8');
+          configPayload = JSON.parse(fileContent) as Record<string, unknown>;
+        } catch (err) {
+          // [EARS-E4] Invalid JSON or file not found
+          const message = err instanceof Error ? err.message : String(err);
+          throw new Error(`Failed to read --config-file: ${message}`);
+        }
+      }
+
+      // [EARS-E1] Merge inline config (higher priority than file)
+      if (options.config) {
+        try {
+          const inlineConfig = JSON.parse(options.config) as Record<string, unknown>;
+          configPayload = { ...configPayload, ...inlineConfig };
+        } catch {
+          // [EARS-E4] Invalid JSON
+          throw new Error('Invalid JSON in --config. Provide valid JSON string.');
+        }
+      }
+
+      // [EARS-E3] Engine type shortcut has highest priority
+      // Build engine: start from config, override type if -e provided
+      const configEngine = (configPayload['engine'] ?? {}) as Record<string, unknown>;
+      const engineType = options.engineType ?? (configEngine['type'] as string) ?? 'local';
+      const engine = { ...configEngine, type: engineType } as AgentRecord['engine'];
+
+      // Build full payload: merge config fields + engine
+      const payload: Partial<AgentRecord> & { id: string } = {
         id: actorId,
-        engine: { type: options.engineType } as AgentRecord['engine'],
-      });
+        engine,
+      };
+
+      // Merge metadata if provided in config
+      if (configPayload['metadata']) {
+        (payload as Record<string, unknown>)['metadata'] = configPayload['metadata'];
+      }
+
+      // Merge triggers if provided in config
+      if (configPayload['triggers']) {
+        (payload as Record<string, unknown>)['triggers'] = configPayload['triggers'];
+      }
+
+      // Merge knowledge_dependencies if provided
+      if (configPayload['knowledge_dependencies']) {
+        (payload as Record<string, unknown>)['knowledge_dependencies'] = configPayload['knowledge_dependencies'];
+      }
+
+      // [ICOMP-C7] Create AgentRecord via adapter
+      const agent = await agentAdapter.createAgentRecord(payload);
 
       // [ICOMP-C9] Output
       if (options.json) {

--- a/packages/core/src/agent_runner/agent_runner.types.ts
+++ b/packages/core/src/agent_runner/agent_runner.types.ts
@@ -2,6 +2,7 @@ import type { AgentRecord } from "../record_types";
 import type { IEventStream } from "../event_bus";
 import type { IExecutionAdapter } from "../adapters/execution_adapter";
 import type { IIdentityAdapter } from "../adapters/identity_adapter";
+import type { IFeedbackAdapter } from "../adapters/feedback_adapter";
 import type { ProtocolHandlerRegistry, RuntimeHandlerRegistry } from "./agent_runner";
 
 // ============================================================================
@@ -146,6 +147,8 @@ export type AgentRunnerDependencies = {
   identityAdapter?: IIdentityAdapter;
   /** ExecutionAdapter for persisting executions (REQUIRED) */
   executionAdapter: IExecutionAdapter;
+  /** FeedbackAdapter for persisting review agent output (optional — backward compatible) [EARS-L1, L2] */
+  feedbackAdapter?: IFeedbackAdapter;
   /** EventBus for emitting events (optional, no events if not provided) */
   eventBus?: IEventStream;
   /** Protocol handler registry (for engine.type: "custom") */

--- a/packages/core/src/agent_runner/fs/fs_agent_runner.test.ts
+++ b/packages/core/src/agent_runner/fs/fs_agent_runner.test.ts
@@ -3,7 +3,7 @@
  *
  * Tests for filesystem-based agent runner implementation.
  *
- * Reference: agent_runner_module.md §4.1-4.3, §4.7-4.11
+ * Reference: agent_runner_module.md §4.1-4.3, §4.7-4.12
  */
 
 import * as fs from "fs";
@@ -412,7 +412,7 @@ describe("FsAgentRunner", () => {
     });
   });
 
-  describe("4.4. Engine Type Validation (EARS-G1 to EARS-G3)", () => {
+  describe("4.7. Engine Type Validation (EARS-G1 to EARS-G3)", () => {
     it("[EARS-G1] should throw UnsupportedEngineType for unknown type", async () => {
       writeAgentFile("unknown-engine", {
         engine: { type: "invalid" as "local" },
@@ -468,7 +468,7 @@ describe("FsAgentRunner", () => {
     });
   });
 
-  describe("4.5. ExecutionRecord Writing (EARS-H1 to EARS-H4)", () => {
+  describe("4.8. ExecutionRecord Writing (EARS-H1 to EARS-H4)", () => {
     it("[EARS-H1] should create ExecutionRecord on success", async () => {
       const entrypoint = writeAgentEntrypoint(
         "success.js",
@@ -580,7 +580,7 @@ describe("FsAgentRunner", () => {
     });
   });
 
-  describe("4.6. EventBus Integration (EARS-I1 to EARS-I4)", () => {
+  describe("4.9. EventBus Integration (EARS-I1 to EARS-I4)", () => {
     it("[EARS-I1] should emit agent:started event", async () => {
       const entrypoint = writeAgentEntrypoint(
         "event-started.js",
@@ -696,7 +696,7 @@ describe("FsAgentRunner", () => {
     });
   });
 
-  describe("4.7. Response Return (EARS-J1 to EARS-J3)", () => {
+  describe("4.10. Response Return (EARS-J1 to EARS-J3)", () => {
     it("[EARS-J1] should always return AgentResponse", async () => {
       const entrypoint = writeAgentEntrypoint(
         "response.js",
@@ -779,7 +779,7 @@ describe("FsAgentRunner", () => {
     });
   });
 
-  describe("4.8. Factory Function (EARS-K1)", () => {
+  describe("4.11. Factory Function (EARS-K1)", () => {
     it("[EARS-K1] should create FsAgentRunner with injected dependencies", () => {
       const runner = createFsAgentRunner({
         executionAdapter: mockExecutionAdapter,
@@ -788,6 +788,149 @@ describe("FsAgentRunner", () => {
       });
 
       expect(runner).toBeInstanceOf(FsAgentRunner);
+    });
+  });
+
+  describe("4.12. FeedbackRecord Support for Review Agents (EARS-L1 to EARS-L4)", () => {
+    const mockFeedbackAdapter = {
+      create: jest.fn().mockResolvedValue({ id: "feedback:review-001" }),
+      resolve: jest.fn(),
+      getFeedback: jest.fn(),
+      getFeedbackByEntity: jest.fn(),
+      getAllFeedback: jest.fn(),
+      getFeedbackThread: jest.fn(),
+    };
+
+    beforeEach(() => {
+      mockFeedbackAdapter.create.mockClear().mockResolvedValue({ id: "feedback:review-001" } as never);
+      mockExecutionAdapter.create.mockClear().mockResolvedValue({ id: "exec:test-123" } as never);
+    });
+
+    it("[EARS-L1] should create FeedbackRecord when agent purpose is review", async () => {
+      const entrypoint = writeAgentEntrypoint(
+        "review-agent.js",
+        "module.exports.runReviewAdvisor = async () => ({ data: 'review-ok' })"
+      );
+      writeAgentFile("review-agent", {
+        engine: { type: "local", entrypoint, function: "runReviewAdvisor" },
+        metadata: { purpose: "review" },
+      });
+
+      const runner = new FsAgentRunner({
+        executionAdapter: mockExecutionAdapter,
+        feedbackAdapter: mockFeedbackAdapter,
+        gitgovPath,
+        projectRoot: tempDir,
+      });
+
+      const response = await runner.runOnce({
+        agentId: "agent:review-agent",
+        taskId: "task:1",
+      });
+
+      expect(response.status).toBe("success");
+      expect(mockFeedbackAdapter.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityType: "execution",
+          entityId: "task:1",
+          type: "suggestion",
+          status: "open",
+          metadata: expect.objectContaining({
+            agentId: "agent:review-agent",
+            purpose: "review",
+            executionStatus: "success",
+          }),
+        }),
+        expect.any(String)
+      );
+      expect(response.executionRecordId).toBe("feedback:review-001");
+    });
+
+    it("[EARS-L2] should fallback to ExecutionRecord when feedbackAdapter missing", async () => {
+      const entrypoint = writeAgentEntrypoint(
+        "review-no-feedback.js",
+        "module.exports.runReviewAdvisor = async () => ({ data: 'review-fallback' })"
+      );
+      writeAgentFile("review-no-feedback", {
+        engine: { type: "local", entrypoint, function: "runReviewAdvisor" },
+        metadata: { purpose: "review" },
+      });
+
+      // No feedbackAdapter provided
+      const runner = new FsAgentRunner({
+        executionAdapter: mockExecutionAdapter,
+        gitgovPath,
+        projectRoot: tempDir,
+      });
+
+      const response = await runner.runOnce({
+        agentId: "agent:review-no-feedback",
+        taskId: "task:1",
+      });
+
+      expect(response.status).toBe("success");
+      // Should fallback to executionAdapter
+      expect(mockExecutionAdapter.create).toHaveBeenCalled();
+      expect(mockFeedbackAdapter.create).not.toHaveBeenCalled();
+      expect(response.executionRecordId).toBe("exec:test-123");
+    });
+
+    it("[EARS-L3] should create ExecutionRecord when agent purpose is audit (no regression)", async () => {
+      const entrypoint = writeAgentEntrypoint(
+        "audit-agent.js",
+        "module.exports.runAgent = async () => ({ data: 'audit-ok' })"
+      );
+      writeAgentFile("audit-agent", {
+        engine: { type: "local", entrypoint },
+        metadata: { purpose: "audit" },
+      });
+
+      mockFeedbackAdapter.create.mockClear();
+
+      const runner = new FsAgentRunner({
+        executionAdapter: mockExecutionAdapter,
+        feedbackAdapter: mockFeedbackAdapter,
+        gitgovPath,
+        projectRoot: tempDir,
+      });
+
+      const response = await runner.runOnce({
+        agentId: "agent:audit-agent",
+        taskId: "task:1",
+      });
+
+      expect(response.status).toBe("success");
+      // Should use executionAdapter, NOT feedbackAdapter
+      expect(mockExecutionAdapter.create).toHaveBeenCalled();
+      expect(mockFeedbackAdapter.create).not.toHaveBeenCalled();
+      expect(response.executionRecordId).toBe("exec:test-123");
+    });
+
+    it("[EARS-L4] should include feedbackRecordId in AgentResponse for review agents", async () => {
+      const entrypoint = writeAgentEntrypoint(
+        "review-id.js",
+        "module.exports.runReviewAdvisor = async () => ({ data: 'review-id-test' })"
+      );
+      writeAgentFile("review-id", {
+        engine: { type: "local", entrypoint, function: "runReviewAdvisor" },
+        metadata: { purpose: "review" },
+      });
+
+      mockFeedbackAdapter.create.mockResolvedValue({ id: "feedback:L4-test" });
+
+      const runner = new FsAgentRunner({
+        executionAdapter: mockExecutionAdapter,
+        feedbackAdapter: mockFeedbackAdapter,
+        gitgovPath,
+        projectRoot: tempDir,
+      });
+
+      const response = await runner.runOnce({
+        agentId: "agent:review-id",
+        taskId: "task:1",
+      });
+
+      expect(response.executionRecordId).toBe("feedback:L4-test");
     });
   });
 });

--- a/packages/core/src/agent_runner/fs/fs_agent_runner.ts
+++ b/packages/core/src/agent_runner/fs/fs_agent_runner.ts
@@ -13,9 +13,10 @@ import {
   EngineConfigError,
   MissingDependencyError,
 } from "../agent_runner.errors";
-import type { AgentRecord } from "../../record_types";
+import type { AgentRecord, FeedbackRecord } from "../../record_types";
 import type { IEventStream } from "../../event_bus";
 import type { IExecutionAdapter } from "../../adapters/execution_adapter";
+import type { IFeedbackAdapter } from "../../adapters/feedback_adapter";
 import type { IIdentityAdapter } from "../../adapters/identity_adapter";
 import type {
   IAgentRunner,
@@ -51,6 +52,7 @@ export class FsAgentRunner implements IAgentRunner {
   private projectRoot: string;
   private identityAdapter: IIdentityAdapter | undefined;
   private executionAdapter: IExecutionAdapter;
+  private feedbackAdapter: IFeedbackAdapter | undefined; // [EARS-L1, L2]
   private eventBus: IEventStream | undefined;
   /** Protocol handlers for CustomBackend */
   public readonly protocolHandlers: ProtocolHandlerRegistry | undefined;
@@ -72,6 +74,7 @@ export class FsAgentRunner implements IAgentRunner {
     this.gitgovPath = deps.gitgovPath ?? path.join(this.projectRoot, ".gitgov");
     this.identityAdapter = deps.identityAdapter ?? undefined;
     this.executionAdapter = deps.executionAdapter;
+    this.feedbackAdapter = deps.feedbackAdapter ?? undefined; // [EARS-L1, L2]
     this.eventBus = deps.eventBus ?? undefined;
     this.protocolHandlers = deps.protocolHandlers ?? undefined;
     this.runtimeHandlers = deps.runtimeHandlers ?? undefined;
@@ -169,34 +172,74 @@ export class FsAgentRunner implements IAgentRunner {
     const durationMs =
       new Date(completedAt).getTime() - new Date(startedAt).getTime();
 
-    // [EARS-H1, H2] Write ExecutionRecord
+    // Determine agent purpose from metadata [EARS-L1, L3]
+    const agentMeta = agent.metadata as Record<string, unknown> | undefined;
+    const agentPurpose = agentMeta?.["purpose"] as string | undefined;
+    const isReviewAgent = agentPurpose === "review";
+
     // Build result message (min 10 chars required by schema)
     const resultMessage = status === "success"
       ? output?.message || `Agent ${opts.agentId} completed successfully`
       : `Agent ${opts.agentId} failed: ${error || 'Unknown error'}`;
 
-    const executionRecord = await this.executionAdapter.create(
-      {
-        taskId: opts.taskId,
-        type: status === "success" ? "completion" : "blocker",
-        title: `Agent execution: ${opts.agentId}`,
-        result: resultMessage.length >= 10 ? resultMessage : resultMessage.padEnd(10, '.'),
-        metadata: {
-          agentId: opts.agentId,
-          runId,
-          status,
-          output: status === "success" ? output : undefined,
-          error: status === "error" ? error : undefined,
-          startedAt,
-          completedAt,
-          durationMs,
-        },
-      },
-      ctx.actorId
-    );
+    let recordId: string;
 
-    // [EARS-H3] executionRecordId in response
-    const executionRecordId = executionRecord.id;
+    // [EARS-L1] Review agents create FeedbackRecord when feedbackAdapter available
+    // [EARS-L2] Fallback to ExecutionRecord if feedbackAdapter missing
+    // [EARS-L3] Non-review agents always create ExecutionRecord (no regression)
+    if (isReviewAgent && this.feedbackAdapter) {
+      // [EARS-L1] Create FeedbackRecord(type: 'suggestion') for review agents
+      // Following waiver pattern: entityType=execution, entityId=scanExecutionId,
+      // metadata.fingerprint for per-finding correlation
+      const feedbackRecord = await this.feedbackAdapter.create(
+        {
+          entityType: "execution",
+          entityId: opts.taskId, // scan execution context
+          type: "suggestion",
+          status: "open",
+          content: resultMessage.length >= 10 ? resultMessage : resultMessage.padEnd(10, '.'),
+          metadata: {
+            agentId: opts.agentId,
+            purpose: "review",
+            runId,
+            executionStatus: status,
+            output: status === "success" ? output : undefined,
+            error: status === "error" ? error : undefined,
+            startedAt,
+            completedAt,
+            durationMs,
+          },
+        } as Partial<FeedbackRecord>,
+        ctx.actorId
+      );
+      // [EARS-L4] feedbackRecordId in response (reuses executionRecordId field)
+      recordId = feedbackRecord.id;
+    } else {
+      // [EARS-H1, H2, L2, L3] Write ExecutionRecord
+      const executionRecord = await this.executionAdapter.create(
+        {
+          taskId: opts.taskId,
+          type: status === "success" ? "completion" : "blocker",
+          title: `Agent execution: ${opts.agentId}`,
+          result: resultMessage.length >= 10 ? resultMessage : resultMessage.padEnd(10, '.'),
+          metadata: {
+            agentId: opts.agentId,
+            runId,
+            status,
+            output: status === "success" ? output : undefined,
+            error: status === "error" ? error : undefined,
+            startedAt,
+            completedAt,
+            durationMs,
+          },
+        },
+        ctx.actorId
+      );
+      recordId = executionRecord.id;
+    }
+
+    // [EARS-H3, L4] recordId in response
+    const executionRecordId = recordId;
 
     // [EARS-I2, I3] Emit completion event
     if (status === "success") {

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.test.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.test.ts
@@ -1126,4 +1126,210 @@ describe("AuditOrchestrator", () => {
       expect(agentInput).not.toHaveProperty("redactionConfig");
     });
   });
+
+  describe("4.5. Review Agent Execution (AORCH-F1 to AORCH-F4)", () => {
+    it("[AORCH-F1] should discover and execute review agents after policy evaluation", async () => {
+      // Setup: 1 audit agent + 1 review agent
+      const auditRecord = makeAgentRecord("agent:scanner", "audit");
+      const reviewRecord = makeAgentRecord("agent:reviewer", "review");
+      const deps = createMockDeps();
+      const orchestrator = createAuditOrchestrator(deps);
+
+      (deps.recordStore.list as jest.Mock).mockResolvedValue([
+        "agent:scanner",
+        "agent:reviewer",
+      ]);
+      (deps.recordStore.get as jest.Mock).mockImplementation(
+        async (id: string) => {
+          if (id === "agent:scanner") return auditRecord;
+          if (id === "agent:reviewer") return reviewRecord;
+          return null;
+        },
+      );
+
+      // Audit agent returns SARIF with findings
+      const sarif = makeSarifLog([
+        {
+          ruleId: "SEC-001",
+          level: "error",
+          message: { text: "Secret found" },
+          locations: [
+            {
+              physicalLocation: {
+                artifactLocation: { uri: "config.ts" },
+                region: { startLine: 3 },
+              },
+            },
+          ],
+          partialFingerprints: { "primaryLocationLineHash/v1": "fp-001" },
+        },
+      ]);
+
+      let callCount = 0;
+      (deps.agentRunner.runOnce as jest.Mock).mockImplementation(
+        async (opts: RunOptions) => {
+          callCount++;
+          if (callCount === 1) {
+            // Audit agent
+            return makeAgentResponse("agent:scanner", sarif);
+          }
+          // Review agent
+          return {
+            runId: "run-review",
+            agentId: opts.agentId,
+            status: "success",
+            output: { message: "Review complete" },
+            executionRecordId: "feedback:review-001",
+            startedAt: new Date().toISOString(),
+            completedAt: new Date().toISOString(),
+            durationMs: 50,
+          };
+        },
+      );
+
+      const result = await orchestrator.run(defaultOptions);
+
+      // Review agents should have been executed
+      expect(result.reviewResults).toBeDefined();
+      expect(result.reviewResults).toHaveLength(1);
+      expect(result.reviewResults![0]!.agentId).toBe("agent:reviewer");
+      expect(result.reviewResults![0]!.status).toBe("success");
+      expect(result.reviewResults![0]!.feedbackRecordId).toBe("feedback:review-001");
+    });
+
+    it("[AORCH-F2] should pass findings, policyDecision, and taskId in ctx.input to review agents", async () => {
+      const auditRecord = makeAgentRecord("agent:scanner", "audit");
+      const reviewRecord = makeAgentRecord("agent:reviewer", "review");
+      const deps = createMockDeps();
+      const orchestrator = createAuditOrchestrator(deps);
+
+      (deps.recordStore.list as jest.Mock).mockResolvedValue([
+        "agent:scanner",
+        "agent:reviewer",
+      ]);
+      (deps.recordStore.get as jest.Mock).mockImplementation(
+        async (id: string) => {
+          if (id === "agent:scanner") return auditRecord;
+          if (id === "agent:reviewer") return reviewRecord;
+          return null;
+        },
+      );
+
+      const sarif = makeSarifLog([
+        {
+          ruleId: "PII-001",
+          level: "warning",
+          message: { text: "PII detected" },
+          locations: [
+            {
+              physicalLocation: {
+                artifactLocation: { uri: "checkout.ts" },
+                region: { startLine: 47 },
+              },
+            },
+          ],
+          partialFingerprints: { "primaryLocationLineHash/v1": "fp-pii" },
+        },
+      ]);
+
+      let reviewInput: Record<string, unknown> | undefined;
+      let callCount = 0;
+      (deps.agentRunner.runOnce as jest.Mock).mockImplementation(
+        async (opts: RunOptions) => {
+          callCount++;
+          if (callCount === 1) {
+            return makeAgentResponse("agent:scanner", sarif);
+          }
+          // Capture review agent input
+          reviewInput = opts.input as Record<string, unknown>;
+          return {
+            runId: "run-review",
+            agentId: opts.agentId,
+            status: "success",
+            output: { message: "Review complete" },
+            executionRecordId: "feedback:review-002",
+            startedAt: new Date().toISOString(),
+            completedAt: new Date().toISOString(),
+            durationMs: 50,
+          };
+        },
+      );
+
+      await orchestrator.run(defaultOptions);
+
+      // Verify review agent received findings + policyDecision + taskId
+      expect(reviewInput).toBeDefined();
+      expect(reviewInput!["findings"]).toBeDefined();
+      expect(Array.isArray(reviewInput!["findings"])).toBe(true);
+      expect(reviewInput!["policyDecision"]).toBeDefined();
+      expect(reviewInput!["taskId"]).toBe(defaultOptions.taskId);
+    });
+
+    it("[AORCH-F3] should skip review step without warning when no review agents are found", async () => {
+      // Only audit agent, no review agents
+      const auditRecord = makeAgentRecord("agent:scanner", "audit");
+      const deps = createMockDeps();
+      const orchestrator = createAuditOrchestrator(deps);
+
+      (deps.recordStore.list as jest.Mock).mockResolvedValue(["agent:scanner"]);
+      (deps.recordStore.get as jest.Mock).mockResolvedValue(auditRecord);
+
+      const sarif = makeSarifLog();
+      (deps.agentRunner.runOnce as jest.Mock).mockResolvedValue(
+        makeAgentResponse("agent:scanner", sarif),
+      );
+
+      const result = await orchestrator.run(defaultOptions);
+
+      // No review results — silently skipped
+      expect(result.reviewResults).toBeUndefined();
+      // No warning about missing review agents
+      expect(result.warning).toBeUndefined();
+    });
+
+    it("[AORCH-F4] should continue audit pipeline when review agent fails and include error in result", async () => {
+      const auditRecord = makeAgentRecord("agent:scanner", "audit");
+      const reviewRecord = makeAgentRecord("agent:bad-reviewer", "review");
+      const deps = createMockDeps();
+      const orchestrator = createAuditOrchestrator(deps);
+
+      (deps.recordStore.list as jest.Mock).mockResolvedValue([
+        "agent:scanner",
+        "agent:bad-reviewer",
+      ]);
+      (deps.recordStore.get as jest.Mock).mockImplementation(
+        async (id: string) => {
+          if (id === "agent:scanner") return auditRecord;
+          if (id === "agent:bad-reviewer") return reviewRecord;
+          return null;
+        },
+      );
+
+      const sarif = makeSarifLog();
+      let f4CallCount = 0;
+      (deps.agentRunner.runOnce as jest.Mock).mockImplementation(
+        async () => {
+          f4CallCount++;
+          if (f4CallCount === 1) {
+            return makeAgentResponse("agent:scanner", sarif);
+          }
+          // Review agent throws
+          throw new Error("Claude API unavailable");
+        },
+      );
+
+      // Should NOT throw — review failure is non-fatal
+      const result = await orchestrator.run(defaultOptions);
+
+      // Pipeline completed successfully
+      expect(result.findings).toBeDefined();
+      expect(result.policyDecision).toBeDefined();
+
+      // Review error captured in results
+      expect(result.reviewResults).toBeDefined();
+      expect(result.reviewResults).toHaveLength(1);
+      expect(result.reviewResults![0]!.status).toBe("error");
+      expect(result.reviewResults![0]!.errorMessage).toBe("Claude API unavailable");
+    });
+  });
 });

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.ts
@@ -13,6 +13,7 @@ import type {
   ConsolidatedFinding,
   AuditSummary,
   FindingSeverity,
+  ReviewAgentResult,
 } from "./audit_orchestrator.types";
 import type { PolicyEvaluationInput } from "../policy_evaluator/policy_evaluator.types";
 
@@ -74,6 +75,73 @@ async function discoverAuditAgents(
   }
 
   return auditAgentIds;
+}
+
+/**
+ * [AORCH-F1] Discovers AgentRecords with metadata.purpose === "review".
+ */
+async function discoverReviewAgents(
+  agentStore: RecordStore<GitGovAgentRecord>,
+): Promise<string[]> {
+  const agentIds = await agentStore.list();
+  const reviewAgentIds: string[] = [];
+
+  for (const id of agentIds) {
+    const record = await agentStore.get(id);
+    if (!record) continue;
+    const meta = record.payload.metadata as
+      | Record<string, unknown>
+      | undefined;
+    if (meta && meta["purpose"] === "review") {
+      reviewAgentIds.push(record.payload.id);
+    }
+  }
+
+  return reviewAgentIds;
+}
+
+/**
+ * [AORCH-F1, F2, F4] Executes a single review agent and returns its result.
+ * AgentRunner creates the FeedbackRecord automatically (EARS-L1).
+ */
+async function executeReviewAgent(
+  agentRunner: IAgentRunner,
+  agentId: string,
+  findings: ConsolidatedFinding[],
+  policyDecision: AuditOrchestrationResult["policyDecision"],
+  taskId: string,
+): Promise<ReviewAgentResult> {
+  const startMs = Date.now();
+
+  try {
+    // [AORCH-F2] Pass findings, policyDecision, and taskId in ctx.input
+    const runOpts: RunOptions = {
+      agentId,
+      taskId,
+      input: {
+        findings,
+        policyDecision,
+        taskId,
+      },
+    };
+
+    const response = await agentRunner.runOnce(runOpts);
+
+    return {
+      agentId,
+      status: "success",
+      durationMs: Date.now() - startMs,
+      feedbackRecordId: response.executionRecordId,
+    };
+  } catch (err) {
+    // [AORCH-F4] Review agent failure never blocks the pipeline
+    return {
+      agentId,
+      status: "error",
+      durationMs: Date.now() - startMs,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    };
+  }
 }
 
 /**
@@ -368,6 +436,39 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
 
       if (l1AgentResults) {
         result.l1AgentResults = l1AgentResults;
+      }
+
+      // [AORCH-F1] Discover and execute review agents post-policy
+      // [AORCH-F3] If no review agents found, skip silently (no warning, no error)
+      const reviewAgents = await discoverReviewAgents(deps.recordStore);
+      if (reviewAgents.length > 0) {
+        // [AORCH-F1, F2] Execute review agents with findings + policyDecision
+        const reviewSettled = await Promise.allSettled(
+          reviewAgents.map((agentId) =>
+            executeReviewAgent(
+              deps.agentRunner,
+              agentId,
+              findingsWithWaivers,
+              policyResult.decision,
+              options.taskId,
+            ),
+          ),
+        );
+
+        // [AORCH-F4] Collect results — failures don't block pipeline
+        result.reviewResults = reviewSettled.map((s, i) =>
+          s.status === "fulfilled"
+            ? s.value
+            : {
+                agentId: reviewAgents[i] ?? "unknown",
+                status: "error" as const,
+                durationMs: 0,
+                errorMessage:
+                  s.reason instanceof Error
+                    ? s.reason.message
+                    : String(s.reason),
+              },
+        );
       }
 
       return result;

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.types.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.types.ts
@@ -69,6 +69,24 @@ export type AuditOrchestrationResult = {
   };
   /** Warning message (e.g. when no audit agents are found) */
   warning?: string;
+  /** Review agent results (optional — empty if no review agents registered) [AORCH-F1] */
+  reviewResults?: ReviewAgentResult[];
+};
+
+/**
+ * Result from a single review agent execution. [AORCH-F1, F4]
+ */
+export type ReviewAgentResult = {
+  /** Agent identifier */
+  agentId: string;
+  /** Whether the agent succeeded or failed */
+  status: "success" | "error";
+  /** Execution duration in milliseconds */
+  durationMs: number;
+  /** Error message if status is "error" [AORCH-F4] */
+  errorMessage?: string;
+  /** FeedbackRecord ID created by AgentRunner */
+  feedbackRecordId?: string;
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary

AgentRunner now supports creating `FeedbackRecord(type: 'suggestion')` for agents with `metadata.purpose === "review"`. This enables the upcoming `review-advisor` agent to persist its opinions as signed records within the GitGovernance protocol.

Part of GitGov Gate / GitLab AI Hackathon epic.

## Completed Tasks

- [x] Add `feedbackAdapter?: IFeedbackAdapter` to `AgentRunnerDependencies` (optional, backward compatible)
- [x] Purpose-based record routing: `metadata.purpose === "review"` → FeedbackRecord, else → ExecutionRecord
- [x] Schema-compliant FeedbackRecord: `entityType`, `entityId`, `type:"suggestion"`, `status:"open"`
- [x] Fallback to ExecutionRecord when `feedbackAdapter` not available (EARS-L2)
- [x] No regression: audit agents continue creating ExecutionRecord (EARS-L3)
- [x] Fix describe() section numbers to match blueprint (4.4→4.7, 4.5→4.8, etc.)

## Metrics

| Metric | Value |
|---|---|
| EARS defined | 4 (L1-L4) |
| EARS implemented | 4/4 |
| Tests passing | 32/32 |
| Audit status | CLEAN (3 rounds: audit → fix → verify) |

## Test plan

- [x] `pnpm tsc --noEmit` — 0 errors
- [x] `pnpm jest fs_agent_runner.test.ts` — 32/32 passing
- [x] `/triad:audit agent_runner` — CLEAN (all 4 auditors pass)