### PR TITLE
fix(core/cli): tsc zero errors + audit command fixes + FeedbackRecord entityId

### DIFF
--- a/packages/cli/e2e/login_command_e2e.test.ts
+++ b/packages/cli/e2e/login_command_e2e.test.ts
@@ -53,8 +53,8 @@ describe('Login Command E2E (LOGIN-E1 to E4)', () => {
   it('[LOGIN-E1] should show not logged in when no session token exists', () => {
     // Ensure no cloud token in session
     const session = readSession();
-    if (session?.cloud) {
-      delete session.cloud;
+    if (session?.['cloud']) {
+      delete session['cloud'];
       writeSession(session);
     }
 
@@ -74,8 +74,8 @@ describe('Login Command E2E (LOGIN-E1 to E4)', () => {
   it('[LOGIN-E2] should succeed gracefully when logging out without active session', () => {
     // Ensure no cloud token
     const session = readSession();
-    if (session?.cloud) {
-      delete session.cloud;
+    if (session?.['cloud']) {
+      delete session['cloud'];
       writeSession(session);
     }
 
@@ -135,7 +135,7 @@ describe('Login Command E2E (LOGIN-E1 to E4)', () => {
     // Verify session file: cloud should be gone, actorState should remain
     const updatedSession = readSession();
     expect(updatedSession).not.toBeNull();
-    expect(updatedSession!.cloud).toBeUndefined();
-    expect(updatedSession!.actorState).toEqual({ 'human:e2e-user': { activeTaskId: 'task-123' } });
+    expect(updatedSession!['cloud']).toBeUndefined();
+    expect(updatedSession!['actorState']).toEqual({ 'human:e2e-user': { activeTaskId: 'task-123' } });
   });
 });

--- a/packages/cli/src/commands/audit/audit-command.test.ts
+++ b/packages/cli/src/commands/audit/audit-command.test.ts
@@ -3,7 +3,7 @@
  *
  * EARS Coverage:
  * - §4.1 CLI -> Orchestrator Integration (AORCH-C1 to C6)
- * - §4.2 Waiver Management (EARS-E1 to E5)
+ * - §4.5 Waiver Management (EARS-E1 to E5)
  */
 
 // Mock @gitgov/core
@@ -31,6 +31,7 @@ jest.doMock('@gitgov/core', () => {
       FindingDetectorModule: jest.fn(),
     },
     Sarif: actual.Sarif,
+    generateExecutionId: actual.generateExecutionId ?? ((title: string, ts: number) => `${ts}-exec-${title}`),
   };
 });
 
@@ -43,7 +44,15 @@ jest.mock('../../services/dependency-injection', () => ({
 
 import { AuditCommand, type AuditCommandOptions } from './audit-command';
 import { DependencyInjectionService } from '../../services/dependency-injection';
-import type { AuditOrchestrator, SourceAuditor, FeedbackRecord, ActorRecord } from '@gitgov/core';
+import type {
+  AuditOrchestrationOptions,
+  AuditOrchestrationResult,
+  PolicyDecision,
+  ConsolidatedFinding,
+  FeedbackRecord,
+  ActorRecord,
+  ActiveWaiver,
+} from '@gitgov/core';
 
 // Mock console methods
 const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
@@ -55,11 +64,11 @@ const mockDI = jest.mocked(DependencyInjectionService);
 
 // Mock orchestrator
 let mockOrchestrator: {
-  run: jest.MockedFunction<(options: AuditOrchestrator.AuditOrchestrationOptions) => Promise<AuditOrchestrator.AuditOrchestrationResult>>;
+  run: jest.MockedFunction<(options: AuditOrchestrationOptions) => Promise<AuditOrchestrationResult>>;
 };
 
 let mockWaiverReader: {
-  loadActiveWaivers: jest.MockedFunction<() => Promise<SourceAuditor.ActiveWaiver[]>>;
+  loadActiveWaivers: jest.MockedFunction<() => Promise<ActiveWaiver[]>>;
 };
 
 let mockFeedbackAdapter: {
@@ -73,7 +82,7 @@ let mockIdentityAdapter: {
 describe('AuditCommand', () => {
   let auditCommand: AuditCommand;
 
-  const mockPolicyDecisionPass: AuditOrchestrator.PolicyDecision = {
+  const mockPolicyDecisionPass: PolicyDecision = {
     decision: 'pass',
     reason: 'No findings exceed configured thresholds.',
     blockingFindings: [],
@@ -83,7 +92,7 @@ describe('AuditCommand', () => {
     evaluatedAt: '2026-03-18T00:00:00.000Z',
   };
 
-  const mockPolicyDecisionBlock: AuditOrchestrator.PolicyDecision = {
+  const mockPolicyDecisionBlock: PolicyDecision = {
     decision: 'block',
     reason: '1 finding(s) at or above critical threshold.',
     blockingFindings: [
@@ -106,7 +115,7 @@ describe('AuditCommand', () => {
     evaluatedAt: '2026-03-18T00:00:00.000Z',
   };
 
-  const mockResultWithFindings: AuditOrchestrator.AuditOrchestrationResult = {
+  const mockResultWithFindings: AuditOrchestrationResult = {
     findings: [
       {
         fingerprint: 'sha256:abc123def456',
@@ -159,7 +168,7 @@ describe('AuditCommand', () => {
     },
   };
 
-  const mockEmptyResult: AuditOrchestrator.AuditOrchestrationResult = {
+  const mockEmptyResult: AuditOrchestrationResult = {
     findings: [],
     agentResults: [],
     policyDecision: mockPolicyDecisionPass,
@@ -375,7 +384,7 @@ describe('AuditCommand', () => {
       const diInstance = mockDI.getInstance();
       const backlogAdapter = await diInstance.getBacklogAdapter();
       expect(backlogAdapter.createTask).toHaveBeenCalledTimes(1);
-      const createTaskArgs = backlogAdapter.createTask.mock.calls[0];
+      const createTaskArgs = (backlogAdapter.createTask as jest.Mock).mock.calls[0];
       expect(createTaskArgs[0]).toMatchObject({
         title: expect.stringContaining('Audit:'),
         status: 'active',
@@ -418,7 +427,7 @@ describe('AuditCommand', () => {
     });
   });
 
-  describe('4.2. Waiver Management (EARS-E1 to E5)', () => {
+  describe('4.5. Waiver Management (EARS-E1 to E5)', () => {
     it('[EARS-E1] should create FeedbackRecord with waiver metadata', async () => {
       await auditCommand.executeWaive('sha256:abc123', {
         justification: 'Test data for unit tests',
@@ -463,7 +472,7 @@ describe('AuditCommand', () => {
               file: 'test.ts',
               line: 10,
             },
-          } as SourceAuditor.ActiveWaiver['feedback'],
+          } as ActiveWaiver['feedback'],
         },
       ]);
 

--- a/packages/cli/src/commands/audit/audit-command.ts
+++ b/packages/cli/src/commands/audit/audit-command.ts
@@ -2,8 +2,16 @@ import { Command, Option } from 'commander';
 import { BaseCommand } from '../../base/base-command';
 import type { BaseCommandOptions } from '../../interfaces/command';
 import { readFile } from 'node:fs/promises';
-import type { AuditOrchestrator, FindingDetector, Sarif } from '@gitgov/core';
-import { Sarif as SarifModule } from '@gitgov/core';
+import { Sarif as SarifModule, generateExecutionId } from '@gitgov/core';
+import type {
+  AuditOrchestrationOptions,
+  AuditOrchestrationResult,
+  ConsolidatedFinding,
+  Finding,
+  FindingCategory,
+  DetectorName,
+  GetLineContentFn,
+} from '@gitgov/core';
 
 /**
  * CLI-specific options for audit command
@@ -30,7 +38,7 @@ export interface AuditCommandOptions extends BaseCommandOptions {
  * Options for waive subcommand
  */
 export interface WaiveCommandOptions extends BaseCommandOptions {
-  /** Justification for the waiver */
+  /** Justification for the waiver (required by EARS-E2 at runtime) */
   justification?: string;
   /** List active waivers */
   list?: boolean;
@@ -114,7 +122,7 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
       }, actorId);
 
       // Invoke orchestrator - ALL logic lives here
-      const orchestrationOptions: AuditOrchestrator.AuditOrchestrationOptions = {
+      const orchestrationOptions: AuditOrchestrationOptions = {
         scope: options.scope,
         taskId: auditTask.id,
         failOn: options.failOn,
@@ -156,7 +164,7 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
    * Format and display output based on --output option
    * [AORCH-C4]
    */
-  private async formatOutput(result: AuditOrchestrator.AuditOrchestrationResult, options: AuditCommandOptions): Promise<void> {
+  private async formatOutput(result: AuditOrchestrationResult, options: AuditCommandOptions): Promise<void> {
     // Quiet mode - only show critical findings
     if (options.quiet) {
       const criticals = result.findings.filter(f => f.severity === 'critical' && !f.isWaived);
@@ -184,7 +192,7 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
   /**
    * Format text output: FINDINGS -> SUMMARY -> POLICY DECISION
    */
-  private formatTextOutput(result: AuditOrchestrator.AuditOrchestrationResult, options: AuditCommandOptions): void {
+  private formatTextOutput(result: AuditOrchestrationResult, options: AuditCommandOptions): void {
     const { findings, summary, policyDecision } = result;
     const activeFindings = findings.filter(f => !f.isWaived);
 
@@ -240,8 +248,8 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
   /**
    * Display findings grouped by file
    */
-  private displayByFile(findings: AuditOrchestrator.ConsolidatedFinding[]): void {
-    const byFile: Record<string, AuditOrchestrator.ConsolidatedFinding[]> = {};
+  private displayByFile(findings: ConsolidatedFinding[]): void {
+    const byFile: Record<string, ConsolidatedFinding[]> = {};
     for (const f of findings) {
       const existing = byFile[f.file];
       if (existing) {
@@ -268,7 +276,7 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
   /**
    * Format JSON output
    */
-  private formatJsonOutput(result: AuditOrchestrator.AuditOrchestrationResult): void {
+  private formatJsonOutput(result: AuditOrchestrationResult): void {
     console.log(JSON.stringify(result, null, 2));
   }
 
@@ -276,10 +284,10 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
    * Format SARIF output using SarifBuilder from @gitgov/core
    * [AORCH-C4]
    */
-  private async formatSarifOutput(result: AuditOrchestrator.AuditOrchestrationResult): Promise<void> {
+  private async formatSarifOutput(result: AuditOrchestrationResult): Promise<void> {
     const builder = SarifModule.createSarifBuilder();
 
-    const getLineContent: Sarif.GetLineContentFn = async (file, line) => {
+    const getLineContent: GetLineContentFn = async (file: string, line: number) => {
       try {
         const content = await readFile(file, 'utf-8');
         const lines = content.split('\n');
@@ -289,20 +297,20 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
       }
     };
 
-    // Convert ConsolidatedFindings to FindingDetector.Finding shape for SarifBuilder
-    const findings: FindingDetector.Finding[] = result.findings.map(f => {
-      const finding: FindingDetector.Finding = {
+    // Convert ConsolidatedFindings to Finding shape for SarifBuilder
+    const findings: Finding[] = result.findings.map(f => {
+      const finding: Finding = {
         id: f.fingerprint,
         fingerprint: f.fingerprint,
         file: f.file,
         line: f.line,
         ruleId: f.ruleId ?? 'UNKNOWN',
-        category: f.category as FindingDetector.FindingCategory,
+        category: f.category as FindingCategory,
         severity: f.severity,
         message: f.message,
         snippet: '',
         confidence: 1.0,
-        detector: (f.reportedBy[0] ?? 'regex') as FindingDetector.DetectorName,
+        detector: (f.reportedBy[0] ?? 'regex') as DetectorName,
       };
       if (f.column !== undefined) {
         finding.column = f.column;
@@ -375,7 +383,7 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
       await feedbackAdapter.create(
         {
           entityType: 'execution',
-          entityId: 'cli-waiver',
+          entityId: generateExecutionId('cli-waiver', Math.floor(Date.now() / 1000)),
           type: 'approval',
           status: 'resolved',
           content: options.justification,

--- a/packages/cli/src/commands/dashboard/dashboard-command.test.ts
+++ b/packages/cli/src/commands/dashboard/dashboard-command.test.ts
@@ -193,6 +193,8 @@ describe('DashboardCommand - EARS Compliance Tests', () => {
     tasks: [],
     cycles: [],
     actors: [],
+    executions: [],
+    agents: [],
     enrichedTasks: [],
     feedback: [],
     activityHistory: []

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -32,7 +32,7 @@ jest.mock('../../services/dependency-injection', () => ({
         hasPrivateKey: mockHasPrivateKey,
       } as unknown as IKeyProvider),
       getConfigManager: jest.fn().mockResolvedValue({
-        getConfig: mockGetConfig,
+        loadConfig: mockGetConfig,
       }),
     }),
   },

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -141,7 +141,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       let keyStatus: KeyStatusResponse = { hasKey: false, actorExists: false };
       try {
         const configManager = await this.dependencyService.getConfigManager();
-        const config = await configManager.getConfig();
+        const config = await configManager.loadConfig();
         const repoId = config?.projectId ?? '';
         keyStatus = await this.getKeyStatus(saasUrl, token, actorId, repoId);
       } catch {
@@ -220,7 +220,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     options: LoginCommandOptions,
   ): Promise<void> {
     const configManager = await this.dependencyService.getConfigManager();
-    const config = await configManager.getConfig();
+    const config = await configManager.loadConfig();
     const repoId = config?.projectId ?? '';
 
     const hasLocal = await this.hasLocalKey(actorId);
@@ -309,7 +309,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     if (options.url) return options.url;
     try {
       const configManager = await this.dependencyService.getConfigManager();
-      const config = await configManager.getConfig();
+      const config = await configManager.loadConfig();
       if (config?.saasUrl) return config.saasUrl;
     } catch {
       // No config available — use default

--- a/packages/cli/src/commands/task/task-command.test.ts
+++ b/packages/cli/src/commands/task/task-command.test.ts
@@ -133,6 +133,8 @@ function createMockIndexData(
     enrichedTasks,
     cycles: [],
     actors: [],
+    executions: [],
+    agents: [],
     feedback: [],
     derivedStates: {
       stalledTasks: [],

--- a/packages/cli/src/services/dependency-injection.ts
+++ b/packages/cli/src/services/dependency-injection.ts
@@ -216,6 +216,7 @@ export class DependencyInjectionService {
           feedbacks: this.stores.feedbacks,
           executions: this.stores.executions,
           actors: this.stores.actors,
+          agents: this.stores.agents,
         },
         sink,
       });
@@ -700,10 +701,12 @@ export class DependencyInjectionService {
       // Create AgentRunnerModule with dependencies
       // projectRoot = repoRoot (user's repo) so agents scan source files there.
       // gitgovPath = worktree .gitgov/ (where records live).
+      const feedbackAdapter = await this.getFeedbackAdapter();
       this.agentRunnerModule = createAgentRunner({
         gitgovPath: path.join(this.projectRoot, '.gitgov'),
         projectRoot: this.repoRoot ?? this.projectRoot,
         executionAdapter,
+        feedbackAdapter,
         eventBus
       });
 

--- a/packages/core/src/agent_runner/fs/fs_agent_runner.test.ts
+++ b/packages/core/src/agent_runner/fs/fs_agent_runner.test.ts
@@ -864,12 +864,13 @@ describe("FsAgentRunner", () => {
       expect(mockFeedbackAdapter.create).toHaveBeenCalledWith(
         expect.objectContaining({
           entityType: "execution",
-          entityId: "task:1",
+          entityId: expect.stringMatching(/^\d{10}-exec-review-/),
           type: "suggestion",
           status: "open",
           metadata: expect.objectContaining({
             agentId: "agent:review-agent",
             purpose: "review",
+            taskId: "task:1",
             executionStatus: "success",
           }),
         }),

--- a/packages/core/src/agent_runner/fs/fs_agent_runner.ts
+++ b/packages/core/src/agent_runner/fs/fs_agent_runner.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { FsRecordStore, DEFAULT_ID_ENCODER } from "../../record_store/fs/fs_record_store";
+import { generateExecutionId } from "../../utils/id_generator";
 import {
   LocalBackend,
   ApiBackend,
@@ -190,18 +191,26 @@ export class FsAgentRunner implements IAgentRunner {
     // [EARS-L3] Non-review agents always create ExecutionRecord (no regression)
     if (isReviewAgent && this.feedbackAdapter) {
       // [EARS-L1] Create FeedbackRecord(type: 'suggestion') for review agents
-      // Following waiver pattern: entityType=execution, entityId=scanExecutionId,
-      // metadata.fingerprint for per-finding correlation
+      // entityType=execution, entityId=scan execution ID (from input if available)
+      // Schema requires entityId to match ^\d{10}-exec-[a-z0-9-]{1,50}$
+      // entityId references the execution being reviewed. Use scanExecutionId from input
+      // if available (orchestrator passes it), otherwise generate a valid execution-style ID.
+      const inputData = opts.input as Record<string, unknown> | undefined;
+      const scanExecutionId = inputData?.["scanExecutionId"] as string | undefined;
+      const timestamp = Math.floor(Date.now() / 1000);
+      const entityId = scanExecutionId || generateExecutionId(`review-${opts.agentId}`, timestamp);
+
       const feedbackRecord = await this.feedbackAdapter.create(
         {
           entityType: "execution",
-          entityId: opts.taskId, // scan execution context
+          entityId,
           type: "suggestion",
           status: "open",
           content: resultMessage.length >= 10 ? resultMessage : resultMessage.padEnd(10, '.'),
           metadata: {
             agentId: opts.agentId,
             purpose: "review",
+            taskId: opts.taskId,
             runId,
             executionStatus: status,
             output: status === "success" ? output : undefined,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,33 @@ export type { ConfigStore } from "./config_store";
 export type { FileLister as IFileLister, FileListOptions, FileStats } from "./file_lister";
 export { FileListerError } from "./file_lister";
 
+// AuditOrchestrator direct type exports
+export type {
+  AuditOrchestrationOptions,
+  AuditOrchestrationResult,
+  ConsolidatedFinding,
+  PolicyDecision,
+  AuditSummary,
+  AuditOrchestratorDeps,
+} from "./audit_orchestrator";
+
+// FindingDetector direct type exports
+export type {
+  Finding,
+  FindingCategory,
+  DetectorName,
+  RegexRule,
+} from "./finding_detector";
+
+// Sarif direct type exports
+export type { GetLineContentFn } from "./sarif";
+
+// SourceAuditor direct type exports
+export type { ActiveWaiver } from "./source_auditor";
+
+// ID generator utilities (protocol-valid ID creation)
+export { generateTaskId, generateExecutionId, generateFeedbackId, generateCycleId, generateActorId, generateAgentId } from "./utils/id_generator";
+
 // Git direct exports (interface + types + errors)
 export type { IGitModule, ExecOptions, ExecResult, GetCommitHistoryOptions, CommitInfo, ChangedFile, CommitAuthor } from "./git";
 export { GitError, GitCommandError, FileNotFoundError, BranchNotFoundError, BranchAlreadyExistsError, MergeConflictError } from "./git";


### PR DESCRIPTION
## Summary

- Export AuditOrchestrator, FindingDetector, Sarif types and ID generators directly from `@gitgov/core`
- Fix FeedbackRecord entityId to use `generateExecutionId()` (schema-valid pattern)
- Fix all 33 tsc errors in CLI to 0
- Wire feedbackAdapter to AgentRunner in DI
- Fix login-command `getConfig()` → `loadConfig()`

## Test plan

- [x] `npx tsc --noEmit` — 0 errors (was 33)
- [x] CLI tests: 519 passed, 0 failed
- [x] Core agent_runner tests: 33 passed
- [x] E2E gate_agent_flow: 14/15 passed (GF14 skipped — needs worker)