### PR TITLE
feat(core): direct type exports + GitgovActor metadataJson

### DIFF
--- a/packages/core/prisma/schema.prisma
+++ b/packages/core/prisma/schema.prisma
@@ -123,6 +123,7 @@ model GitgovActor {
   status         String?
   supersededBy   String?
   headerJson     Json
+  metadataJson   Json?
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -102,12 +102,25 @@ export type {
 export type {
   Finding,
   FindingCategory,
+  FindingSeverity,
   DetectorName,
   RegexRule,
 } from "./finding_detector";
 
 // Sarif direct type exports
-export type { GetLineContentFn } from "./sarif";
+export type {
+  GetLineContentFn,
+  SarifLog,
+  SarifResult,
+  SarifResultProperties,
+  SarifRunProperties,
+} from "./sarif";
+
+// SourceAuditor direct type exports (ActiveWaiver already exported above)
+export type { IWaiverReader, WaiverMetadata } from "./source_auditor";
+
+// AuditOrchestrator agent result type
+export type { AgentAuditResult } from "./audit_orchestrator";
 
 // SourceAuditor direct type exports
 export type { ActiveWaiver } from "./source_auditor";


### PR DESCRIPTION
## Summary

- Add direct type exports to `@gitgov/core` index.ts for types that saas-api needs
- Add `metadataJson Json?` to GitgovActor in core Prisma (protocol defines it, was missing)

## Direct type exports added

`FindingSeverity`, `SarifLog`, `SarifResult`, `SarifResultProperties`, `SarifRunProperties`, `IWaiverReader`, `WaiverMetadata`, `AgentAuditResult`

These were previously only accessible via namespace (`Sarif.SarifLog`, `SourceAuditor.ActiveWaiver`), which TypeScript doesn't support when namespaces are re-exported via `export * as`.

## Test plan

- [x] `npx tsc --build` — core compiles
- [x] Core tests: 2734/2737 passing (3 skipped, pre-existing)
- [x] Depends on: gitgovernance/private#12 (saas-api uses these exports)