### PR TITLE
feat: add .triad/ state + specs/epics/ for triad_web and triad_state_machine

### DIFF
--- a/.triad/config.json
+++ b/.triad/config.json
@@ -1,0 +1,1 @@
+{"specsDir":"specs/","stateMachine":{"enabled":true}}

--- a/.triad/state.json
+++ b/.triad/state.json
@@ -1,0 +1,48 @@
+{
+  "epics": {
+    "triad_web": {
+      "stateDir": ".triad/state/triad_web/",
+      "packages": [
+        "packages/claude-plugins/plugins/triad/web/"
+      ],
+      "status": "active",
+      "phase": "impl",
+      "activeCycle": 1
+    },
+    "triad_state_machine": {
+      "stateDir": ".triad/state/triad_state_machine/",
+      "packages": [
+        "packages/claude-plugins/plugins/triad/hooks/src/"
+      ],
+      "status": "completed",
+      "phase": "complete",
+      "activeCycle": 6,
+      "history": [
+        {
+          "from": "proposal",
+          "to": "active",
+          "trigger": "auto:first-module-registered",
+          "ts": "2026-04-04T12:00:00Z"
+        },
+        {
+          "from": "active",
+          "to": "completed",
+          "trigger": "auto:all-modules-coherent",
+          "ts": "2026-04-08T12:00:00Z"
+        },
+        {
+          "from": "completed",
+          "to": "active",
+          "trigger": "auto:module-drift-detected",
+          "ts": "2026-04-08T00:20:33.291Z"
+        },
+        {
+          "from": "active",
+          "to": "completed",
+          "trigger": "auto:all-modules-coherent",
+          "ts": "2026-04-08T00:20:33.385Z"
+        }
+      ]
+    }
+  }
+}

--- a/.triad/state/triad_state_machine/audit_reminder.json
+++ b/.triad/state/triad_state_machine/audit_reminder.json
@@ -1,0 +1,21 @@
+{
+  "module": "audit_reminder",
+  "epic": "triad_state_machine",
+  "state": "coherent",
+  "codePath": "packages/claude-plugins/plugins/triad/hooks/src/audit_reminder/",
+  "specPath": "packages/claude-plugins/plugins/triad/specs/modules/audit_reminder/",
+  "cycle": 6,
+  "history": [
+    { "from": "no_spec", "to": "spec_draft", "trigger": "skill:new-spec", "ts": "2026-04-04T12:00:00Z" },
+    { "from": "spec_draft", "to": "spec_ready", "trigger": "skill:audit", "ts": "2026-04-04T14:00:00Z", "score": 0.85 },
+    { "from": "spec_ready", "to": "implemented", "trigger": "hook:detect", "ts": "2026-04-05T10:00:00Z" },
+    { "from": "implemented", "to": "tested", "trigger": "hook:detect", "ts": "2026-04-05T16:00:00Z" },
+    { "from": "tested", "to": "coherent", "trigger": "skill:audit", "ts": "2026-04-08T12:00:00Z", "score": 0.95 }
+  ],
+  "lastAudit": {
+    "verdict": "COHERENT",
+    "score": 0.95,
+    "findings": 0,
+    "ts": "2026-04-08T12:00:00Z"
+  }
+}

--- a/.triad/state/triad_state_machine/detect_hook.json
+++ b/.triad/state/triad_state_machine/detect_hook.json
@@ -1,0 +1,21 @@
+{
+  "module": "detect_hook",
+  "epic": "triad_state_machine",
+  "state": "coherent",
+  "codePath": "packages/claude-plugins/plugins/triad/hooks/src/detect_hook/",
+  "specPath": "packages/claude-plugins/plugins/triad/specs/modules/detect_hook/",
+  "cycle": 6,
+  "history": [
+    { "from": "no_spec", "to": "spec_draft", "trigger": "skill:new-spec", "ts": "2026-04-04T12:00:00Z" },
+    { "from": "spec_draft", "to": "spec_ready", "trigger": "skill:audit", "ts": "2026-04-04T14:00:00Z", "score": 0.85 },
+    { "from": "spec_ready", "to": "implemented", "trigger": "hook:detect", "ts": "2026-04-05T10:00:00Z" },
+    { "from": "implemented", "to": "tested", "trigger": "hook:detect", "ts": "2026-04-05T16:00:00Z" },
+    { "from": "tested", "to": "coherent", "trigger": "skill:audit", "ts": "2026-04-08T12:00:00Z", "score": 0.95 }
+  ],
+  "lastAudit": {
+    "verdict": "COHERENT",
+    "score": 0.95,
+    "findings": 0,
+    "ts": "2026-04-08T12:00:00Z"
+  }
+}

--- a/.triad/state/triad_state_machine/epic_manager.json
+++ b/.triad/state/triad_state_machine/epic_manager.json
@@ -1,0 +1,21 @@
+{
+  "module": "epic_manager",
+  "epic": "triad_state_machine",
+  "state": "coherent",
+  "codePath": "packages/claude-plugins/plugins/triad/hooks/src/epic_manager/",
+  "specPath": "packages/claude-plugins/plugins/triad/specs/modules/epic_manager/",
+  "cycle": 6,
+  "history": [
+    { "from": "no_spec", "to": "spec_draft", "trigger": "skill:new-spec", "ts": "2026-04-04T12:00:00Z" },
+    { "from": "spec_draft", "to": "spec_ready", "trigger": "skill:audit", "ts": "2026-04-04T14:00:00Z", "score": 0.85 },
+    { "from": "spec_ready", "to": "implemented", "trigger": "hook:detect", "ts": "2026-04-05T10:00:00Z" },
+    { "from": "implemented", "to": "tested", "trigger": "hook:detect", "ts": "2026-04-05T16:00:00Z" },
+    { "from": "tested", "to": "coherent", "trigger": "skill:audit", "ts": "2026-04-08T12:00:00Z", "score": 0.95 }
+  ],
+  "lastAudit": {
+    "verdict": "COHERENT",
+    "score": 0.95,
+    "findings": 0,
+    "ts": "2026-04-08T12:00:00Z"
+  }
+}

--- a/.triad/state/triad_state_machine/gate_hook.json
+++ b/.triad/state/triad_state_machine/gate_hook.json
@@ -1,0 +1,61 @@
+{
+  "module": "gate_hook",
+  "epic": "triad_state_machine",
+  "state": "coherent",
+  "codePath": "packages/claude-plugins/plugins/triad/hooks/src/gate_hook/",
+  "specPath": "packages/claude-plugins/plugins/triad/specs/modules/gate_hook/",
+  "cycle": 6,
+  "history": [
+    {
+      "from": "no_spec",
+      "to": "spec_draft",
+      "trigger": "skill:new-spec",
+      "ts": "2026-04-04T12:00:00Z"
+    },
+    {
+      "from": "spec_draft",
+      "to": "spec_ready",
+      "trigger": "skill:audit",
+      "ts": "2026-04-04T14:00:00Z",
+      "score": 0.85
+    },
+    {
+      "from": "spec_ready",
+      "to": "implemented",
+      "trigger": "hook:detect",
+      "ts": "2026-04-05T10:00:00Z"
+    },
+    {
+      "from": "implemented",
+      "to": "tested",
+      "trigger": "hook:detect",
+      "ts": "2026-04-05T16:00:00Z"
+    },
+    {
+      "from": "tested",
+      "to": "coherent",
+      "trigger": "skill:audit",
+      "ts": "2026-04-08T12:00:00Z",
+      "score": 0.95
+    },
+    {
+      "from": "coherent",
+      "to": "drift",
+      "trigger": "hook:detect",
+      "ts": "2026-04-08T00:20:33.290Z"
+    },
+    {
+      "from": "drift",
+      "to": "coherent",
+      "trigger": "skill:audit",
+      "ts": "2026-04-08T00:20:33.385Z",
+      "score": 0.95
+    }
+  ],
+  "lastAudit": {
+    "verdict": "COHERENT",
+    "score": 0.95,
+    "findings": 0,
+    "ts": "2026-04-08T00:20:33.381Z"
+  }
+}

--- a/.triad/state/triad_state_machine/reindex_hook.json
+++ b/.triad/state/triad_state_machine/reindex_hook.json
@@ -1,0 +1,21 @@
+{
+  "module": "reindex_hook",
+  "epic": "triad_state_machine",
+  "state": "coherent",
+  "codePath": "packages/claude-plugins/plugins/triad/hooks/src/reindex_hook/",
+  "specPath": "packages/claude-plugins/plugins/triad/specs/modules/reindex_hook/",
+  "cycle": 6,
+  "history": [
+    { "from": "no_spec", "to": "spec_draft", "trigger": "skill:new-spec", "ts": "2026-04-04T12:00:00Z" },
+    { "from": "spec_draft", "to": "spec_ready", "trigger": "skill:audit", "ts": "2026-04-04T14:00:00Z", "score": 0.85 },
+    { "from": "spec_ready", "to": "implemented", "trigger": "hook:detect", "ts": "2026-04-05T10:00:00Z" },
+    { "from": "implemented", "to": "tested", "trigger": "hook:detect", "ts": "2026-04-05T16:00:00Z" },
+    { "from": "tested", "to": "coherent", "trigger": "skill:audit", "ts": "2026-04-08T12:00:00Z", "score": 0.95 }
+  ],
+  "lastAudit": {
+    "verdict": "COHERENT",
+    "score": 0.95,
+    "findings": 0,
+    "ts": "2026-04-08T12:00:00Z"
+  }
+}

--- a/.triad/state/triad_state_machine/state_manager.json
+++ b/.triad/state/triad_state_machine/state_manager.json
@@ -1,0 +1,21 @@
+{
+  "module": "state_manager",
+  "epic": "triad_state_machine",
+  "state": "coherent",
+  "codePath": "packages/claude-plugins/plugins/triad/hooks/src/state_manager/",
+  "specPath": "packages/claude-plugins/plugins/triad/specs/modules/state_manager/",
+  "cycle": 6,
+  "history": [
+    { "from": "no_spec", "to": "spec_draft", "trigger": "skill:new-spec", "ts": "2026-04-04T12:00:00Z" },
+    { "from": "spec_draft", "to": "spec_ready", "trigger": "skill:audit", "ts": "2026-04-04T14:00:00Z", "score": 0.85 },
+    { "from": "spec_ready", "to": "implemented", "trigger": "hook:detect", "ts": "2026-04-05T10:00:00Z" },
+    { "from": "implemented", "to": "tested", "trigger": "hook:detect", "ts": "2026-04-05T16:00:00Z" },
+    { "from": "tested", "to": "coherent", "trigger": "skill:audit", "ts": "2026-04-08T12:00:00Z", "score": 0.95 }
+  ],
+  "lastAudit": {
+    "verdict": "COHERENT",
+    "score": 0.95,
+    "findings": 0,
+    "ts": "2026-04-08T12:00:00Z"
+  }
+}

--- a/.triad/state/triad_state_machine/state_schema.json
+++ b/.triad/state/triad_state_machine/state_schema.json
@@ -1,0 +1,21 @@
+{
+  "module": "state_schema",
+  "epic": "triad_state_machine",
+  "state": "coherent",
+  "codePath": "packages/claude-plugins/plugins/triad/hooks/src/state_schema/",
+  "specPath": "packages/claude-plugins/plugins/triad/specs/modules/state_schema/",
+  "cycle": 6,
+  "history": [
+    { "from": "no_spec", "to": "spec_draft", "trigger": "skill:new-spec", "ts": "2026-04-04T12:00:00Z" },
+    { "from": "spec_draft", "to": "spec_ready", "trigger": "skill:audit", "ts": "2026-04-04T14:00:00Z", "score": 0.85 },
+    { "from": "spec_ready", "to": "implemented", "trigger": "hook:detect", "ts": "2026-04-05T10:00:00Z" },
+    { "from": "implemented", "to": "tested", "trigger": "hook:detect", "ts": "2026-04-05T16:00:00Z" },
+    { "from": "tested", "to": "coherent", "trigger": "skill:audit", "ts": "2026-04-08T12:00:00Z", "score": 0.95 }
+  ],
+  "lastAudit": {
+    "verdict": "COHERENT",
+    "score": 0.95,
+    "findings": 0,
+    "ts": "2026-04-08T12:00:00Z"
+  }
+}

--- a/.triad/state/triad_web/dashboard_view.json
+++ b/.triad/state/triad_web/dashboard_view.json
@@ -1,0 +1,13 @@
+{
+  "module": "dashboard_view",
+  "epic": "triad_web",
+  "state": "implemented",
+  "codePath": "packages/claude-plugins/plugins/triad/web/src/views/dashboard/",
+  "specPath": "specs/views/dashboard/",
+  "cycle": 1,
+  "history": [
+    { "from": "no_spec", "to": "spec_draft", "trigger": "hook:detect", "ts": "2026-04-07T16:00:00Z" },
+    { "from": "spec_draft", "to": "spec_ready", "trigger": "skill:audit", "ts": "2026-04-07T16:30:00Z", "score": 0.80 },
+    { "from": "spec_ready", "to": "implemented", "trigger": "hook:detect", "ts": "2026-04-07T17:00:00Z" }
+  ]
+}

--- a/.triad/state/triad_web/generate_data.json
+++ b/.triad/state/triad_web/generate_data.json
@@ -1,0 +1,16 @@
+{
+  "module": "generate_data",
+  "epic": "triad_web",
+  "state": "coherent",
+  "codePath": "packages/claude-plugins/plugins/triad/web/scripts/",
+  "specPath": "specs/modules/generate_data/",
+  "cycle": 1,
+  "history": [
+    { "from": "no_spec", "to": "spec_draft", "trigger": "hook:detect", "ts": "2026-04-07T17:00:00Z" },
+    { "from": "spec_draft", "to": "spec_ready", "trigger": "skill:audit", "ts": "2026-04-07T17:30:00Z", "score": 0.85 },
+    { "from": "spec_ready", "to": "implemented", "trigger": "hook:detect", "ts": "2026-04-07T18:00:00Z" },
+    { "from": "implemented", "to": "tested", "trigger": "hook:detect", "ts": "2026-04-07T18:05:00Z" },
+    { "from": "tested", "to": "coherent", "trigger": "skill:audit", "ts": "2026-04-07T18:20:00Z", "score": 0.95 }
+  ],
+  "lastAudit": { "verdict": "COHERENT", "score": 0.95, "findings": 0, "ts": "2026-04-07T18:20:00Z" }
+}

--- a/specs/epics/triad_indexer/input.md
+++ b/specs/epics/triad_indexer/input.md
@@ -1,0 +1,634 @@
+# Epic Input: triad_indexer
+
+> Captura completa de la idea, contexto de diseño, investigación, y decisiones.
+> Origen: sesion triad_web 2026-04-08, después de implementar graph + edges + drift.
+> Este input debe ser suficiente para que un agente cree la epic sin preguntas.
+
+---
+
+## 1. El problema (cómo llegamos aquí)
+
+### 1.1. Contexto: qué existe hoy
+
+El state machine de Triad tiene 7 estados por módulo (`no_spec → spec_draft → spec_ready → implemented → tested → coherent ⇄ drift`). Los estados se almacenan en JSON:
+
+```
+.triad/state.json                    ← epic registry (qué epics existen)
+.triad/state/{epic}/{module}.json    ← estado de cada módulo
+.triad/state/edges.json              ← relaciones module→module (depends_on)
+```
+
+Estos JSON los crean/actualizan:
+- `detect_hook` (PostToolUse) — cuando Claude Code escribe un archivo
+- `state-manager.ts` con `initModule()` / `transitionModule()` — llamado por hooks y skills
+- Manual — cuando un developer crea el JSON a mano (nadie lo hace)
+
+La webapp (`triad_web`) lee estos JSON via `generate-data.ts` → produce `state.json` → React renderiza.
+
+### 1.2. Los 3 gaps
+
+**Gap 1: No hay descubrimiento automático.**
+Si alguien crea un `.ts` en su IDE, el sistema no se entera. `generate-data.ts` solo lee lo que ya existe en `.triad/state/`. No escanea el filesystem. Resultado: módulos nuevos son invisibles hasta que un hook o un humano cree el JSON.
+
+**Gap 2: Datos ricos atrapados en markdown.**
+Los specs tienen EARS estructurados (`[TKN-A1] WHEN X, SHALL Y`), los roadmaps tienen cycles/tasks/progress, los overviews tienen decisiones. Hoy `countEars()` extrae un número con regex, pero no puede extraer el array estructurado `[{id, text, block, status}]` que la webapp necesita para mostrar la triada completa.
+
+**Gap 3: No hay "sistema vivo".**
+El usuario quiere que la indexación sea invisible — que al abrir la webapp, el sistema esté vivo: descubriendo módulos, extrayendo datos, calculando métricas. Sin intervención manual. Si un archivo cambia, el grafo se actualiza solo.
+
+### 1.3. Frase clave del usuario
+
+> "quiero que mi usuario el proceso de indexación sea literalmente invisible... podríamos en la web mostrar un stream de cosas que se están pidiendo o calculando... mostrar un sistema que tiene vida propia"
+
+> "la clave acá está en indexar y ser cuidadoso en qué cosas se recalculan, si es con grep o con claude -p, ambos casos determinista y no determinista son testeables con código para mí y por ende tienen triada"
+
+---
+
+## 2. Investigación previa: modelo de relaciones
+
+### 2.1. Research con 5 agentes (2026-04-08)
+
+Se levantaron 5 agentes para investigar cómo el mercado modela relaciones:
+
+| Tool/Framework | Relationship Types | Storage | Cross-boundary |
+|---|---|---|---|
+| OpenAPI | `$ref` composition | Inline pointers | File-relative URIs |
+| GraphQL | Fields, interfaces, Federation `@key` | Schema SDL | Subgraph stitching |
+| Terraform | Implicit DAG + `depends_on` | HCL expressions | `module.X.output_Y` |
+| SPDX/CycloneDX | ~20 types (`DEPENDS_ON`, `CONTAINS`, `GENERATED_FROM`) | Separate `relationships` array | External document refs |
+| Backstage | `dependsOn`, `consumesApi`, `providesApi`, `partOf` | YAML entity descriptor | Namespaced refs `component:ns/name` |
+
+### 2.2. 3 opciones evaluadas
+
+| | Option A: Inline | Option B: Archivo separado | Option C: Spec-derived |
+|---|---|---|---|
+| Dónde | Dentro de cada module .json | `.triad/state/edges.json` | Computado de specs + imports |
+| GitGov futuro | Agregar `protocolRefs` | Agregar edges con prefijo `gitgov:` | No soporta sin híbrido |
+| Pros | Sin archivos nuevos | Single source of truth, extensible | Siempre refleja realidad |
+| Contras | Denormalizado | Puede desincronizarse | Frágil a formato markdown |
+
+**Decisión: Option B** con prefijos `mod:`, `epic:` (extensible a `gitgov:task:`, `gitgov:workflow:`).
+**Razón:** el grafo de la webapp ya usa estos prefijos en `buildGraph()`. Agregar GitGov es agregar tipos, no cambiar schema.
+
+### 2.3. Insight clave del usuario sobre relaciones
+
+> "una épica que depende de un módulo es porque dicho módulo ya se implementó... una vez que la dependencia es el módulo no tiene sentido decir que es de X epic"
+
+Resultado: **el módulo es la unidad atómica.** Las dependencias siempre apuntan a módulos. Epic→epic se deriva automáticamente de module deps cross-epic. No se declara.
+
+```
+edges.json:
+  { "source": "mod:refresh_hook", "target": "mod:generate_data", "type": "depends_on" }
+
+Derivado por generate-data.ts:
+  { "source": "epic:triad_web", "target": "epic:triad_state_machine", "type": "depends_on" }
+```
+
+---
+
+## 3. Solución: pipeline de indexación de 2 capas
+
+### 3.1. Capa 1: Determinista (grep, fs, git) — rápida, sin AI
+
+```
+reindex.ts
+  │
+  ├── Escanea specs/**/*.md → encuentra specs
+  ├── Escanea src/**/*.ts (no .test) → encuentra código
+  ├── Escanea src/**/*.test.ts → encuentra tests
+  │
+  ├── Para cada spec encontrado:
+  │   ¿Existe .triad/state/{epic}/{module}.json?
+  │   NO → crear con state basado en qué vértices existen:
+  │       solo spec           → spec_draft
+  │       spec + code         → implemented
+  │       spec + code + tests → tested
+  │   SI → verificar que el state refleja la realidad
+  │
+  ├── Para cada .ts sin spec:
+  │   → Reportar: "archivo suelto, falta spec + tests"
+  │
+  ├── countEars() regex (existente)
+  ├── buildDriftSet() git batch (existente)
+  ├── computeNextAction() (existente)
+  │
+  └── Output: .triad/state/*.json actualizados
+```
+
+**Triggers:**
+```
+/triad:init      → full reindex (una vez)
+/triad:web       → reindex + generate-data (cada apertura)
+git pre-commit   → reindex + generate-data (cada commit)
+refresh_hook     → incremental (solo archivo cambiado)
+manual           → npx tsx scripts/reindex.ts
+```
+
+**Qué se recalcula y cuándo:**
+```
+¿Cambió filesystem? (git diff)     → Capa 1: re-escanear (ms)
+¿Cambió un .md? (spec, roadmap)    → Capa 2: re-extraer (segundos)
+¿Cambió code/tests pero no spec?   → Capa 1 sola (needsAudit, state)
+¿Nada cambió?                      → cache, nada que hacer
+```
+
+### 3.2. Capa 2: No determinista (claude -p) — lenta, con AI, con confidence
+
+```
+extract.ts
+  │
+  ├── Cola: lista de .md que cambiaron desde última extracción
+  │
+  ├── Para cada archivo en la cola:
+  │   claude -p "parsea este markdown, output JSON" --model haiku
+  │   │
+  │   ├── Spec module → array de EARS [{id, text, block, status}]
+  │   ├── Roadmap → {cycles: [{number, name, status, tasks: [{text, done}]}]}
+  │   └── Overview → {decisions: [{id, decision, resolution, reason}]}
+  │
+  ├── Cada extracción tiene:
+  │   - confidence: 0-1 (el propio claude reporta)
+  │   - extractedAt: timestamp
+  │   - sourceHash: git hash del archivo (para invalidar cache)
+  │
+  └── Output: enriched JSON que generate-data.ts merge con Capa 1
+```
+
+**Patrón de ejecución:** mismo que `skill_e2e_auditor` (ver `e2e/tests/helpers.ts`):
+```typescript
+const result = execSync(
+  `claude -p "${prompt}" --model haiku --permission-mode bypassPermissions`,
+  { cwd: dir, timeout: 30_000, encoding: 'utf-8' }
+);
+const parsed = JSON.parse(result);
+```
+
+**Cache:** si el `git hash-object {file}` no cambió desde la última extracción, skip.
+
+### 3.3. Capa 3: Queue + Streaming UI
+
+```
+Webapp (React):
+  │
+  ├── state.json tiene campo "indexing" por módulo:
+  │   { "module": "X", "indexing": { "layer1": "done", "layer2": "pending" } }
+  │
+  ├── Dashboard muestra cola de procesamiento:
+  │   "Indexando generate_data... ✓"
+  │   "Extrayendo EARS de token_handler... ⏳"
+  │   "Parseando roadmap.md... ⏳"
+  │
+  └── Progressive loading:
+      Capa 1 se muestra inmediatamente (state, needsAudit, count)
+      Capa 2 streams cuando completa (EARS array, cycles, confidence)
+```
+
+---
+
+## 4. Output por módulo (ejemplo completo)
+
+```json
+{
+  "module": "token_handler",
+  "epic": "auth_system",
+  "state": "tested",
+  "codePath": "src/token_handler/",
+  "specPath": "specs/modules/token_handler/",
+  "cycle": 2,
+  "package": "@gitgov/core",
+  "needsAudit": true,
+  "nextAction": {
+    "command": "/triad:audit token_handler",
+    "reason": "triada files changed since last audit"
+  },
+  "ears": {
+    "count": 12,
+    "items": [
+      { "id": "TKN-A1", "text": "WHEN token expires, SHALL refresh automatically", "block": "A", "status": "implemented" },
+      { "id": "TKN-A2", "text": "WHEN refresh fails, SHALL redirect to login", "block": "A", "status": "tested" }
+    ],
+    "source": "spec",
+    "confidence": 0.95,
+    "extractedAt": "2026-04-08T10:30:00Z",
+    "sourceHash": "a1b2c3d"
+  },
+  "epicContext": {
+    "activeCycle": 2,
+    "progress": 78,
+    "tasksCompleted": 5,
+    "tasksTotal": 7,
+    "source": "roadmap",
+    "confidence": 0.88,
+    "extractedAt": "2026-04-08T10:31:00Z"
+  },
+  "looseFiles": [],
+  "score": 0.86,
+  "lastAudit": { "verdict": "PARTIAL", "score": 0.86, "findings": 2, "ts": "2026-04-07" },
+  "history": [...]
+}
+```
+
+---
+
+## 5. Lo que ya existe (implementado en triad_web)
+
+Estas funciones en `generate-data.ts` son la base de Capa 1:
+
+| Función | Qué hace | EARS |
+|---|---|---|
+| `readEpicRegistry()` | Lee `.triad/state.json` | GEN-A1 |
+| `readModuleStates()` | Lee `*.json` de un stateDir | GEN-A2 |
+| `countEars()` | Regex `**[PREFIX-X1]**` en specs | GEN-B5 |
+| `buildDriftSet()` | 2 git calls: diff + untracked | GEN-B7 |
+| `checkTriadDrift()` | Matchea changed files contra paths del módulo | GEN-B7 |
+| `readEdges()` | Lee `.triad/state/edges.json` | GEN-B6 |
+| `deriveEpicEdges()` | Agrega epic→epic desde module deps cross-epic | GEN-B8 |
+| `computeNextAction()` | Recomienda `/triad:*` según estado + drift | GEN-B9 |
+
+**Lo que falta (esta epic):**
+- `reindex()` — escanear fs y crear/actualizar state files
+- `extract()` — claude -p para datos estructurados
+- Queue + streaming UI
+
+---
+
+## 6. Decisiones de diseño ya tomadas
+
+| ID | Decisión | Razón |
+|---|---|---|
+| D1 | edges.json separado (Option B) | Extensible con prefijos, single source of truth, diffeable en PRs |
+| D2 | Prefijos mod:/epic: | Extensible a gitgov:task:, gitgov:workflow: sin cambio de schema |
+| D3 | Epic→epic derivado, no declarado | Módulo es la unidad atómica. Epic es contenedor organizativo |
+| D4 | Drift via git, no checksums | Zero infraestructura extra. 2 git calls al inicio |
+| D5 | Capa 2 opcional | Sistema funciona completo solo con Capa 1. AI enriquece |
+| D6 | Ambas capas testeables con triada | Determinista: unit tests. No determinista: E2E con claude -p |
+| D7 | Cache por git hash | Si `git hash-object {file}` no cambió, skip extracción |
+| D8 | Rate limiting explícito | No saturar suscripción de claude. Cola con prioridad |
+
+---
+
+## 7. Herramientas externas evaluadas: CIE + MIE (kraklabs)
+
+### 7.1. CIE (Code Intelligence Engine) — https://github.com/kraklabs/cie
+
+Go CLI + MCP server que indexa código con **Tree-sitter AST**. 20+ tools: call graph, find callers/callees, trace path, find type, semantic search. Storage: CozoDB (Datalog + RocksDB). Soporta Go, Python, JS, TypeScript.
+
+**Dónde aporta a esta epic:**
+- **Capa 1 (determinista):** CIE reemplaza regex para descubrimiento de relaciones. En vez de declarar `edges.json` manualmente, CIE computa imports/exports reales via AST: `cie_find_callers --function generateData` devuelve todos los call sites.
+- **Call graph real:** `cie_get_call_graph` resuelve el problema de "si toco scan_orchestrator, qué se rompe" con precision de AST, no con edges declarados que pueden desincronizarse.
+- **Semantic search:** con embeddings (Ollama/OpenAI), permite "búscame módulos que hacen algo parecido a validación de tokens" — útil para descubrir duplicación.
+
+**Limitación:** No entiende markdown como specs estructurados. Trata `.md` como texto plano.
+
+### 7.2. MIE (Memory Intelligence Engine) — https://github.com/kraklabs/mie
+
+Go daemon + MCP server que persiste **knowledge graph** para agentes AI. Nodes tipados: Facts, Decisions, Entities, Events, Topics. Storage: CozoDB con HNSW vector indexes.
+
+**Dónde aporta a esta epic:**
+- **Capa 2 (no determinista):** MIE persiste lo que claude -p extrae, sin re-extraer cada vez. EARS extraídos de un spec se almacenan como Facts. Decisiones arquitectónicas como Decisions. Entre sesiones, `mie_query` devuelve lo almacenado sin llamar a claude.
+- **Cross-session memory:** un agente que audita hoy puede leer lo que otro agente indexó ayer. No hay pérdida de contexto entre sesiones.
+- **Conflict detection:** `mie_conflicts` detecta hechos contradictorios — útil para detectar drift entre lo que el spec dice y lo que el código hace.
+
+**Limitación:** No indexa código (no tiene AST). Es knowledge store puro. Necesita CIE o el propio agente para alimentarlo.
+
+### 7.3. Cómo encajan juntos
+
+```
+CIE  → indexa CÓDIGO (AST, call graph, types, imports)
+MIE  → persiste CONOCIMIENTO (EARS extraídos, decisions, facts)
+Triad Indexer → ORQUESTA ambos + agrega la METODOLOGÍA (triada, states, drift, nextAction)
+
+Flujo:
+  1. reindex.ts escanea filesystem → descubre módulos
+  2. CIE indexa código → call graph, types, imports → alimenta edges.json automaticamente
+  3. claude -p extrae EARS/roadmap → mie_bulk_store persiste las extracciones
+  4. generate-data.ts consume todo → state.json para la webapp
+  5. Siguiente sesión: mie_query en vez de re-extraer → inmediato
+```
+
+**Decisión clave:** CIE y MIE son opcionales. El indexer funciona sin ellos (regex + claude -p directos). Pero cuando están disponibles, el sistema es más preciso (AST vs regex) y más rápido (cache en MIE vs re-extraer con claude -p).
+
+### 7.4. Licencia y deployment
+
+Ambas son AGPL v3, Go binaries, sin dependencias externas. CIE almacena en `~/.cie/data/`. MIE corre como daemon singleton. Se exponen como MCP servers — la webapp o los scripts pueden consumirlos via MCP tools.
+
+---
+
+## 8. Conexión con GitGov (futuro)
+
+Triad es standalone. GitGov se conecta después con mínima fricción:
+
+```
+TRIAD (hoy):
+  Node types:  epic, module
+  Edge types:  contains, depends_on
+  Prefijos:    mod:, epic:
+
+GITGOV (mañana):
+  Node types:  + WorkflowRecord, TaskRecord, ExecutionRecord
+  Edge types:  + tracks, implements, produces
+  Prefijos:    + gitgov:task:, gitgov:workflow:, gitgov:execution:
+```
+
+La interfaz de conexión es edges.json — nuevos tipos de nodos y edges, mismo schema.
+
+### 8.1. Roadmap de escalamiento
+
+```
+FASE 1 — Triad Indexer (esta epic):
+  regex + fs + git → reindex.ts
+  claude -p → extract.ts
+  Cola + streaming UI
+
+FASE 2 — CIE integration:
+  Tree-sitter AST reemplaza regex para code discovery
+  Call graph reemplaza edges.json manuales
+  cie_find_callers/callees alimenta depends_on automáticamente
+
+FASE 3 — MIE integration:
+  Extracciones de claude -p se persisten en MIE
+  Cross-session: no re-extraer, query lo almacenado
+  Conflict detection: spec dice X, código hace Y → finding
+
+FASE 4 — GitGov protocol:
+  Nuevos node/edge types en el grafo
+  WorkflowRecord → TaskRecord → ExecutionRecord
+  edges.json absorbe protocol records con prefijo gitgov:
+
+FASE 5 — SaaS:
+  Graph DB (Neo4j o similar) reemplaza edges.json files
+  Vector DB para semantic search cross-project
+  CIE + MIE como servicios (no CLI locales)
+```
+
+Cada fase se agrega encima de la anterior. Nada se reescribe.
+
+---
+
+## 9. Referencia: skill_e2e_auditor pattern
+
+La Capa 2 reutiliza el patrón de `skill_e2e_auditor` (epic completada Cycles 1-2):
+
+```typescript
+// helpers.ts de skill_e2e_auditor
+function runSkillCommand(prompt: string, cwd: string, opts?: { model?: string }): SkillResult {
+  const cmd = `claude -p "${prompt}" --model ${model} --permission-mode bypassPermissions`;
+  const stdout = execSync(cmd, { cwd, timeout, encoding: 'utf-8' });
+  return { stdout, stderr: '', exitCode: 0 };
+}
+```
+
+Los tests E2E crean tmpdir con `git init` + `.triad/config.json`, ejecutan claude -p, y verifican assertions sobre el output. Ver: `e2e/tests/skill_new.test.ts`.
+
+---
+
+## 10. Cycles estimados
+
+| Cycle | Nombre | Qué produce |
+|---|---|---|
+| 1 | Reindexer determinista | `reindex.ts`: scan fs, crear state files, integrar en triggers |
+| 2 | AI extraction + cache | `extract.ts`: claude -p, EARS array, roadmap parsing, confidence, cache |
+| 3 | Queue + streaming UI | Cola visible en webapp, progressive loading, rate limiting |
+
+---
+
+## 11. Investigación de mercado (2026-04-08)
+
+### 11.1. Code Indexing — herramientas evaluadas
+
+| Tool | Qué hace | Lenguajes | Indexing | Output | License | Stars | Recomendación |
+|---|---|---|---|---|---|---|---|
+| **ts-morph** | TS compiler API wrapper | TS/JS | Full type-checker | Programmatic | MIT | 5.2k | Cycle 3: imports/exports/call sites reales |
+| **dependency-cruiser** | Valida + visualiza deps | JS/TS | AST (TS compiler) | JSON, DOT, Mermaid | MIT | 5.5k | Cycle 3: alternativa a ts-morph, más ergonómico para reglas |
+| **tree-sitter** | Parser incremental multi-lang | 100+ (TS, Go, MD) | AST error-tolerant | S-expression, queries | MIT | Massive | Futuro: multi-lenguaje (Go+TS+Markdown) |
+| **skott** | Grafo de deps TS/JS con web UI | TS/JS | AST imports | JSON graph + web UI | MIT | 800 | Interesante web UI, pero duplica nuestra webapp |
+| **madge** | Circular deps + grafo | JS/TS/CSS | AST (detective) | JSON, DOT, SVG | MIT | 7.8k | Solo si necesitamos detectar circular deps |
+| **SCIP** (Sourcegraph) | Cross-repo code intel | TS, Go, 10+ | Full type-checker | Protobuf (SCIP) | Apache-2.0 | — | GitGov scale: precisión cross-repo |
+| **Semgrep** | Pattern matching structural | 30+ | AST (tree-sitter) | JSON, SARIF | LGPL-2.1 | 11k | Búsqueda de patrones, no indexación |
+| **CIE** (kraklabs) | Code intelligence + MCP | TS, Go, Py, JS | Tree-sitter + CozoDB | MCP tools (20+) | AGPL-3.0 | — | GitGov scale: CIE ya integra tree-sitter + CozoDB + MCP |
+
+**Decisión para Cycle 3 (code deps):** `ts-morph` o `dependency-cruiser`. Ambos MIT, TS nativo, JSON output. ts-morph es más granular (call sites, types), dependency-cruiser es más ergonómico (reglas declarativas, visualización). Evaluar al implementar.
+
+**Decisión para GitGov scale:** `CIE` si necesitamos Go+TS+Python en un solo tool. `ts-morph` + `tree-sitter` si preferimos composición de herramientas MIT.
+
+### 11.2. Knowledge/Graph Storage — herramientas evaluadas
+
+| Tool | Qué hace | Storage | Query | Vector? | MCP? | License | Recomendación |
+|---|---|---|---|---|---|---|---|
+| **@anthropic/memory** | Knowledge graph JSON | JSON file | MCP tools | No | Si (oficial) | MIT | Cycle 2: prototipo rápido, zero setup |
+| **CozoDB** | Graph + vector embeddable | RocksDB/SQLite | Datalog | Si (HNSW) | No | MPL-2.0 | Cycle 3: si necesitamos queries complejas |
+| **SurrealDB** | Multi-model embeddable | Embedded/server | SurrealQL | Si | Community | BSL-1.1 | GitGov: all-in-one (doc+graph+vector) |
+| **LanceDB** | Vector DB embeddable | File-based | SQL + vector | Si (core) | Community | Apache-2.0 | Cycle 2: semantic search sobre specs |
+| **Neo4j** | Graph DB completo | Server | Cypher | Si (5.11+) | Si | GPL-3.0 | SaaS: queries complejas multi-tenant |
+| **ChromaDB** | Embedding store | SQLite+HNSW | API + filters | Si (core) | Si | Apache-2.0 | Cycle 2: alternativa a LanceDB |
+| **MIE** (kraklabs) | Memory graph + MCP | CozoDB | Datalog + MCP | Si | Si (nativo) | AGPL-3.0 | GitGov: ya integra CozoDB + MCP + conflict detection |
+
+**Decisión para Cycle 2 (cache):** empezar con JSON file (`.triad/cache/`). Si necesitamos semantic search, agregar `LanceDB` (Apache-2.0, embedded, zero server). Si necesitamos cross-session memory para agentes, evaluar `@anthropic/memory` (MCP oficial, MIT).
+
+**Decisión para GitGov scale:** `SurrealDB embedded` (graph+vector+doc en uno, SQL-like) o `MIE` (ya trae CozoDB + MCP + conflict detection pero AGPL).
+
+### 11.3. Markdown Extraction — herramientas evaluadas
+
+| Tool | Qué hace | EARS custom? | Tables→JSON? | Checkboxes? | API TS? | License |
+|---|---|---|---|---|---|---|
+| **remark + remark-gfm** | Markdown→AST (mdast) | Si, via visitors | Si, nativo | Si (`checked`) | Si, ESM | MIT |
+| **markdown-it** | Markdown→tokens | Manual (reglas) | Si, tokens | Via plugin | Si | MIT |
+| **gray-matter** | Frontmatter parser | No | No | No | Si | MIT |
+| **claude -p** | AI extraction | Si, cualquier formato | Si | Si | Via execSync | N/A |
+
+**Decisión para Cycle 1:** `remark` + `remark-gfm` + visitors custom. Razón:
+- Parsea markdown como AST, no como texto. Tables son nodos, checkboxes tienen `.checked: boolean`
+- EARS se extraen con `unist-util-visit` sobre text nodes: match `[PREFIX-X1] WHEN...SHALL`
+- Determinista, 500 archivos en segundos, zero cost
+- TypeScript nativo (ESM), MIT
+- `claude -p` solo como fallback para specs con formato inconsistente
+
+### 11.4. Recomendación por fase
+
+| Fase | Code Indexing | Knowledge Storage | Markdown Extraction |
+|---|---|---|---|
+| Cycle 1 | `fs` + `git diff` | JSON files (`.triad/cache/`) | `remark` + `remark-gfm` |
+| Cycle 2 | (mismo) | + `LanceDB` o JSON cache | + `claude -p` fallback |
+| Cycle 3 | + `ts-morph` o `dependency-cruiser` | + `@anthropic/memory` (MCP) | (mismo) |
+| GitGov | + `CIE` (multi-lang) | + `SurrealDB` o `MIE` | (mismo) |
+| SaaS | + `SCIP` (cross-repo) | + `Neo4j` (multi-tenant) | (mismo) |
+
+---
+
+## 12. Deuda Técnica como View Computado
+
+### 12.1. El problema de la deuda hoy
+
+La deuda técnica en Triad está dispersa en múltiples lugares:
+
+| Dónde vive hoy | Qué registra | Problema |
+|:----------------|:-------------|:---------|
+| `AGENTS.md §Deuda` | Deuda del package (skills sin formato, tests faltantes) | Manual, se desactualiza, solo si lees el archivo |
+| `roadmap.md "Trabajo futuro"` | Tasks no completadas de la epic | Se olvida cuando la epic se cierra |
+| Spec `§ESTADO` | 🔴 en tablas de trazabilidad | Solo visible si abres el spec |
+| Código (`// TODO`) | Deuda micro | Se pierde en el ruido |
+| Conversación | "Lo dejamos para después" | Se pierde en rewind/compaction |
+| State machine | Módulo en `tested` en vez de `coherent` | Es dato, pero nadie lo agrega como "deuda" |
+
+**No hay un solo lugar donde preguntar: "¿cuál es toda la deuda técnica del proyecto?"**
+
+### 12.2. La deuda NO necesita sistema propio — el indexer la computa
+
+Cada tipo de deuda técnica es un **predicado sobre datos que el indexer ya produce**:
+
+| Tipo de deuda | Dato del indexer | Predicado |
+|:-------------|:-----------------|:----------|
+| Triada incompleta | `module.state` | `state !== 'coherent' && state !== 'drift'` |
+| Triada no auditada | `module.needsAudit` | `needsAudit === true` |
+| EARS sin implementar | `module.ears.items[].status` | `status !== 'tested'` |
+| EARS sin test | `module.ears.items[].status` | `status === 'implemented'` (code pero no test) |
+| Score bajo | `module.score` | `score < 0.9` |
+| Audit con findings | `module.lastAudit.findings` | `findings > 0` |
+| Cycle incompleto | `module.epicContext.progress` | `progress < 100` |
+| Skill sin formato | `skill_auditor findings` | `findings.length > 0` (seccion faltante, EARS mal) |
+| Skill sin E2E | `skill.testPath` | `testPath === null` (no existe skill_e2e.test.ts) |
+| Spec sin código | `module.state` | `state === 'spec_ready'` (spec aprobado, 0 código) |
+| Drift detectado | `module.state` | `state === 'drift'` |
+| Módulo descubierto sin spec | `module.state` | `state === 'no_spec'` (Capa 1 lo descubrió) |
+
+### 12.3. Output: debt summary por proyecto
+
+El indexer produce un campo `debt` en el state.json global:
+
+```json
+{
+  "debt": {
+    "total": 23,
+    "critical": 3,
+    "high": 8,
+    "medium": 12,
+    "items": [
+      {
+        "type": "triada_incomplete",
+        "module": "token_handler",
+        "epic": "auth_system",
+        "state": "tested",
+        "reason": "Audit score 0.86 (needs 0.9 for coherent)",
+        "action": "/triad:audit token_handler",
+        "severity": "high"
+      },
+      {
+        "type": "ears_no_test",
+        "module": "token_handler",
+        "epic": "auth_system",
+        "earsId": "TKN-B3",
+        "reason": "EARS TKN-B3 in spec and code but no test",
+        "action": "Add test for [TKN-B3]",
+        "severity": "critical"
+      },
+      {
+        "type": "skill_no_format",
+        "skill": "audit",
+        "reason": "SKILL.md missing 4 of 6 required sections",
+        "action": "Reformat with skill_designer (6 sections + EARS)",
+        "severity": "medium"
+      },
+      {
+        "type": "skill_no_e2e",
+        "skill": "checkpoint",
+        "reason": "No skill_e2e.test.ts exists",
+        "action": "Create E2E test following helpers pattern",
+        "severity": "medium"
+      },
+      {
+        "type": "cycle_incomplete",
+        "epic": "auth_system",
+        "cycle": 2,
+        "progress": 78,
+        "pendingTasks": 2,
+        "reason": "Cycle 2 at 78% — 2 tasks pending",
+        "action": "/triad:resume auth_system",
+        "severity": "high"
+      }
+    ]
+  }
+}
+```
+
+### 12.4. Visualización en /triad:status y webapp
+
+**`/triad:status` incluye deuda:**
+
+```
+╔══════════════════════════════════════════════════════════╗
+║                    PROJECT HEALTH                         ║
+╚══════════════════════════════════════════════════════════╝
+
+  Technical Debt: 23 items
+  ════════════════════════════════════════
+  🔴 CRITICAL  ████                    3
+  🟠 HIGH      ████████                8
+  🟡 MEDIUM    ████████████           12
+
+  Top 3 actions:
+  1. /triad:audit token_handler    (score 0.86 → needs 0.9)
+  2. Add test for [TKN-B3]         (EARS in spec+code, no test)
+  3. /triad:resume auth_system     (Cycle 2 at 78%)
+```
+
+**Webapp dashboard muestra deuda como gráfico:**
+- Barra de deuda por epic (stacked: critical/high/medium)
+- Debt trend over time (si el indexer corre periódicamente)
+- Click en un item → navega al módulo/skill con el problema
+
+### 12.5. Relación con AGENTS.md
+
+AGENTS.md sigue teniendo §Deuda Técnica pero **solo para deuda de proceso** — convenciones, decisiones pendientes, patrones que cambiar. La deuda de **código/specs/triada** se elimina de AGENTS.md y se computa por el indexer.
+
+| Tipo | Dónde vive | Quién lo mantiene |
+|:-----|:-----------|:------------------|
+| Deuda de proceso | AGENTS.md §Deuda | Humano/agente (manual) |
+| Deuda de triada | Computado por indexer | Automático (reindex) |
+| Deuda de skills | Computado por indexer + skill_auditor | Automático |
+| Deuda de epics | Computado por indexer (cycle progress) | Automático |
+
+### 12.6. Cuándo se computa
+
+La deuda se recalcula cada vez que el indexer corre:
+
+```
+/triad:init         → full debt scan (una vez)
+/triad:web          → debt summary en dashboard
+/triad:status       → debt summary en terminal
+git pre-commit      → incremental (solo módulos cambiados)
+/triad:audit        → actualiza score/findings → debt recalculated
+/triad:checkpoint   → actualiza progress → debt recalculated
+```
+
+No hay cron ni daemon. El indexer corre bajo demanda y la deuda se computa como side-effect de la indexación.
+
+---
+
+## 13. Preguntas abiertas (incluyendo deuda)
+
+- ¿El reindexer debe correr como parte de `generate-data.ts` o como script separado que se llama antes?
+- ¿La cola de Capa 2 debe persistirse en disco (`.triad/cache/extractions/`) o en MIE?
+- ¿Qué modelo usar para extracciones? haiku (rápido, barato) vs sonnet (más preciso)?
+- ¿Cómo manejar extracciones fallidas? retry con backoff? marcar como "extraction_failed"?
+- ¿CIE/MIE se instalan como prerequisito de `/triad:init` o son opcionales que se detectan en runtime?
+- ¿El call graph de CIE alimenta edges.json directamente o genera un edges-computed.json separado que se merge?
+- ¿MIE reemplaza completamente claude -p para extracciones repetidas, o claude -p sigue siendo fallback?
+- ¿La debt summary se incluye en state.json global o en un archivo separado `.triad/debt.json`?
+- ¿El debt trend (evolución en el tiempo) se persiste? ¿Dónde? (git history de state.json vs archivo de métricas)
+- ¿Los items de deuda tienen un ID estable para tracking? (ej: `debt:token_handler:ears_no_test:TKN-B3`)
+- ¿La webapp muestra deuda como tab separado o integrado en cada módulo/epic view?
+
+## 14. Contexto del monorepo
+
+El monorepo tiene **487 specs** en blueprints, 13 packages, 47 epics (19 completed, 4 active, 3 paused, 17 proposals, 4 absorbed). Los specs siguen el formato Triad (EARS). Los packages incluyen: core, cli, saas-api, saas-web, saas-worker, mcp-server, agents (5), e2e, skill_gitgov.
+
+Nota: blueprints se reorganizará: `03_products/epics` → `06_epics`, `03_products` → `05_packages` (según blueprints/README.md).
+
+El indexer debe funcionar tanto para Triad standalone (specs en `specs/` del proyecto) como para el monorepo GitGov (specs en `blueprints/03_products/{pkg}/specs/`). La config `.triad/config.json → specsDir` ya soporta paths custom.
+
+---
+
+**Fecha:** 2026-04-08
+**Origen:** Sesión triad_web, discusión sobre "cómo se actualizan los json", "debería ser invisible", y "un sistema con vida propia"
+**Dependencias:** triad_web (generate-data.ts), skill_e2e_auditor (claude -p pattern + helpers), state_machine (hooks)
+**Incluye:** §12 Deuda Técnica como View Computado — la deuda no necesita sistema propio, el indexer la calcula de los datos que ya produce

--- a/specs/epics/triad_web/implementation_plan.md
+++ b/specs/epics/triad_web/implementation_plan.md
@@ -1,0 +1,1067 @@
+# Triad Web — Implementation Plan
+
+> Documento tecnico: arquitectura, tipos, scripts, componentes, configuracion y tests.
+> Para vision y arquitectura ver inputs/epic_input.md.
+> Para contexto de conversacion ver inputs/conversation_context.md.
+> Fecha: 2026-04-07
+
+---
+
+## 1. Arquitectura
+
+### 1.1. Estructura de Archivos
+
+Todo el codigo de la webapp vive en el directorio del plugin. Los datos generados
+en runtime (`state.json`) son transitorios y gitignored.
+
+```
+packages/claude-plugins/plugins/triad/
+├── web/                           ← NUEVO: Vite + React app
+│   ├── package.json
+│   ├── vite.config.ts
+│   ├── tsconfig.json
+│   ├── index.html
+│   ├── scripts/
+│   │   └── generate-data.ts      ← lee .triad/ → genera state.json
+│   ├── src/
+│   │   ├── main.tsx
+│   │   ├── App.tsx               ← sidebar + routing + page switching
+│   │   ├── data/
+│   │   │   └── state.json        ← generado, gitignored
+│   │   ├── types/
+│   │   │   └── index.ts          ← TriadWebData, EpicData, ModuleData, GraphNode, GraphEdge
+│   │   ├── hooks/
+│   │   │   └── useTriadState.ts  ← lee state.json, optional polling
+│   │   ├── components/
+│   │   │   ├── Sidebar.tsx
+│   │   │   ├── TopBar.tsx
+│   │   │   ├── StatCard.tsx
+│   │   │   ├── EpicCard.tsx
+│   │   │   ├── ModuleTable.tsx
+│   │   │   ├── TriadTriangle.tsx ← SVG triangle: Spec/Code/Tests
+│   │   │   ├── StatePipeline.tsx ← horizontal state machine pipeline
+│   │   │   ├── ProgressBar.tsx
+│   │   │   ├── Badge.tsx
+│   │   │   └── ProvenanceFeed.tsx
+│   │   └── pages/
+│   │       ├── Dashboard.tsx
+│   │       ├── Epics.tsx
+│   │       ├── Modules.tsx
+│   │       └── Graph.tsx
+│   └── dist/                     ← build output, gitignored
+├── skills/
+│   └── web/
+│       └── SKILL.md              ← /triad:web
+└── index.html                    ← mockup reference (not served)
+```
+
+### 1.2. Flujo de Datos
+
+```
+                    ┌──────────────────────────────────┐
+                    │   .triad/state.json               │
+                    │   (indice global de epics)        │
+                    └────────┬─────────────────────────┘
+                             │
+                             ▼
+┌─────────────────┐   ┌──────────────────────────────┐   ┌──────────────────┐
+│ .triad/state/   │──▶│  generate-data.ts             │◀──│ specs/epics/*/   │
+│ {epic}/*.json   │   │  (lee state + markdowns,      │   │ roadmap.md       │
+│ (module states) │   │   genera web/src/data/         │   │ (cycles, tasks)  │
+│                 │   │   state.json)                  │   │                  │
+└─────────────────┘   └──────────────┬─────────────────┘   └──────────────────┘
+                                     │
+                                     ▼
+                    ┌──────────────────────────────────┐
+                    │   web/src/data/state.json         │
+                    │   (TriadWebData — todo unificado) │
+                    └────────┬─────────────────────────┘
+                             │ import / fetch
+                             ▼
+                    ┌──────────────────────────────────┐
+                    │   useTriadState.ts                │
+                    │   (hook React, optional polling)  │
+                    └────────┬─────────────────────────┘
+                             │ data
+                             ▼
+              ┌──────────────┴──────────────┐
+              │  React Pages + Components    │
+              │  Dashboard, Epics, Modules,  │
+              │  Graph                       │
+              └─────────────────────────────┘
+```
+
+### 1.3. Reactividad
+
+**Dev mode (vite dev):**
+- PostToolUse hook de Claude Code detecta write a `.triad/state/`
+- Re-ejecuta `generate-data.ts`
+- Vite HMR detecta cambio en `state.json`
+- Browser se actualiza automaticamente (zero latency)
+
+**Build mode (vite preview):**
+- Polling cada 3 segundos desde `useTriadState.ts`
+- Re-fetch de `state.json`, React re-renders si los datos cambiaron
+- Alternativa: re-run `generate-data.ts` + refresh manual
+
+---
+
+## 2. Dependencias
+
+### 2.1. Dependencias de Sistema
+
+| Herramienta  | Version  | Proposito                                |
+|--------------|----------|------------------------------------------|
+| `node`       | >=18     | Runtime de scripts y build               |
+| `vite`       | 6.x      | Build tool (dev server + bundler)        |
+| `react`      | 19.x     | UI framework                             |
+| `typescript` | 5.8      | Type safety                              |
+| `d3`         | 7.x      | Graph visualization (Cycle 3)            |
+| `tsx`        | latest   | Ejecutar generate-data.ts directamente   |
+
+**Sin:** Next.js, SSR, backend server, base de datos, websockets, Tailwind.
+
+### 2.2. Dependencias Internas
+
+| Componente                        | Relacion     | Proposito                                       |
+|-----------------------------------|--------------|--------------------------------------------------|
+| `.triad/state.json`              | Fuente datos | Indice global de epics (leido por generate-data) |
+| `.triad/state/{epic}/*.json`     | Fuente datos | Estado per-module (leido por generate-data)      |
+| `specs/epics/*/roadmap.md`       | Fuente datos | Cycles, tasks, progress (parseado)               |
+| `triad_state_machine` (Cycle 5)  | Prerequisito | `getEpicSummary()` y `/triad:init`              |
+| `index.html` (mockup)            | Referencia   | Diseño visual de 12 paginas                      |
+
+### 2.3. package.json
+
+```json
+{
+  "name": "@triad/web",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "generate": "tsx scripts/generate-data.ts"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "~5.8.0",
+    "vite": "^6.0.0",
+    "tsx": "^4.0.0",
+    "d3": "^7.0.0",
+    "@types/d3": "^7.0.0"
+  }
+}
+```
+
+---
+
+## 3. Types
+
+### 3.1. TypeScript Types (`src/types/index.ts`)
+
+```typescript
+// types/index.ts — Data model for Triad Web dashboard
+
+interface TriadWebData {
+  generatedAt: string;
+  projectRoot: string;
+  epics: EpicData[];
+  modules: ModuleData[];
+  graph: { nodes: GraphNode[]; edges: GraphEdge[] };
+}
+
+interface EpicData {
+  name: string;
+  status: 'proposal' | 'active' | 'paused' | 'completed' | 'discarded';
+  phase: 'design' | 'ready' | 'impl' | 'complete';
+  packages: string[];
+  activeCycle: number;
+  modules: { total: number; byState: Record<string, number> };
+  lastUpdate: string | null;
+  // From roadmap.md parsing (if available):
+  description?: string;
+  cycles?: CycleData[];
+  score?: number;
+  progress?: number; // 0-100 computed from tasks
+}
+
+interface CycleData {
+  number: number;
+  name: string;
+  status: 'completed' | 'in_progress' | 'pending';
+  tasksTotal: number;
+  tasksCompleted: number;
+  modules?: string[];
+}
+
+interface ModuleData {
+  name: string;
+  epic: string;
+  state: 'no_spec' | 'spec_draft' | 'spec_ready' | 'implemented' | 'tested' | 'coherent' | 'drift';
+  codePath: string;
+  specPath: string;
+  cycle: number;
+  package: string; // derived from codePath
+  ears?: number; // from spec parsing if available
+  tests?: number; // from test file counting if available
+  score: number | null; // from lastAudit.score (0-1 scale, display as 0-100)
+  lastAudit?: { verdict: string; score: number; findings: number; ts: string };
+  history: { from: string; to: string; trigger: string; ts: string; score?: number }[];
+}
+
+interface GraphNode {
+  id: string;
+  name: string;
+  type: string; // ActorRecord, TaskRecord, etc.
+  detail: Record<string, any>;
+}
+
+interface GraphEdge {
+  source: string;
+  target: string;
+  rel: string;
+}
+```
+
+### 3.2. State Enum Mapping
+
+Los 7 estados de modulo vienen de `triad_state_machine`:
+
+| Estado        | Significado                                               | Color (display) |
+|---------------|-----------------------------------------------------------|-----------------|
+| `no_spec`     | Modulo registrado, sin spec                               | zinc-600        |
+| `spec_draft`  | Spec existe, no auditada                                  | amber-600       |
+| `spec_ready`  | Spec auditada y aprobada (score >= 7.0)                   | blue-500        |
+| `implemented` | Codigo escrito que implementa la spec                     | indigo-500      |
+| `tested`      | Tests escritos y pasando                                  | purple-500      |
+| `coherent`    | Triada completa: spec + codigo + tests (score >= 9.0)     | emerald-500     |
+| `drift`       | Desincronizacion detectada post-coherent                  | red-500         |
+
+### 3.3. Epic Status Enum
+
+| Status      | Significado                        |
+|-------------|------------------------------------|
+| `proposal`  | Epic creada, aun no iniciada       |
+| `active`    | Trabajo en progreso                |
+| `paused`    | Detenida temporalmente             |
+| `completed` | Todos los cycles completados       |
+| `discarded` | Abandonada                         |
+
+---
+
+## 4. Implementacion: `generate-data.ts`
+
+### 4.1. Proposito
+
+Script TypeScript que lee `.triad/` y markdowns del proyecto, y genera un unico
+archivo `state.json` que la webapp consume. Es el puente entre los state files
+del filesystem y la SPA React.
+
+### 4.2. Interfaz
+
+```
+# Uso
+npx tsx scripts/generate-data.ts [projectRoot]
+
+# Parametros
+projectRoot  — Path al directorio raiz del proyecto (default: process.cwd())
+
+# Output
+Escribe: web/src/data/state.json
+Stdout:  "Generated: {path} ({N} epics, {M} modules)"
+
+# Exit codes
+0 — Exito
+1 — .triad/state.json no existe (sugiere /triad:init)
+```
+
+### 4.3. Pseudocodigo
+
+```typescript
+// scripts/generate-data.ts
+// Usage: npx tsx scripts/generate-data.ts [projectRoot]
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs';
+import { join, basename, dirname } from 'path';
+
+const projectRoot = process.argv[2] || process.cwd();
+
+function main() {
+  // 1. Validar que .triad/ existe
+  const stateJsonPath = join(projectRoot, '.triad/state.json');
+  if (!existsSync(stateJsonPath)) {
+    console.error('No .triad/state.json found. Run /triad:init first.');
+    process.exit(1);
+  }
+
+  // 2. Leer indice global
+  const registry = JSON.parse(readFileSync(stateJsonPath, 'utf-8'));
+  const epics: EpicData[] = [];
+  const modules: ModuleData[] = [];
+
+  // 3. Iterar epics del registry
+  for (const [epicName, entry] of Object.entries(registry.epics)) {
+    // 3a. Leer module state files del stateDir
+    const stateDir = join(projectRoot, entry.stateDir);
+    const epicModules = readModuleStates(stateDir, epicName);
+    modules.push(...epicModules);
+
+    // 3b. Construir resumen del epic
+    epics.push({
+      name: epicName,
+      status: entry.status,
+      phase: entry.phase,
+      packages: entry.packages,
+      activeCycle: entry.activeCycle,
+      modules: summarizeModules(epicModules),
+      lastUpdate: getLastUpdate(epicModules),
+      // 3c. Parsear roadmap.md para datos enriquecidos (cycles, tasks, progress)
+      ...parseRoadmap(projectRoot, epicName),
+    });
+  }
+
+  // 4. Construir grafo de relaciones
+  const graph = buildGraph(epics, modules);
+
+  // 5. Ensamblar y escribir output
+  const data: TriadWebData = {
+    generatedAt: new Date().toISOString(),
+    projectRoot,
+    epics,
+    modules,
+    graph,
+  };
+
+  const outputPath = join(__dirname, '../src/data/state.json');
+  writeFileSync(outputPath, JSON.stringify(data, null, 2));
+  console.log(`Generated: ${outputPath} (${epics.length} epics, ${modules.length} modules)`);
+}
+
+// --- Helper functions ---
+
+function readModuleStates(stateDir: string, epicName: string): ModuleData[] {
+  // Lee todos los .json de stateDir
+  // Parsea cada uno como ModuleStateFile
+  // Convierte a ModuleData (agrega package derivado de codePath)
+  // Retorna array de ModuleData
+}
+
+function summarizeModules(modules: ModuleData[]): { total: number; byState: Record<string, number> } {
+  // Cuenta modulos por estado
+  // Retorna { total: N, byState: { no_spec: 1, coherent: 3, ... } }
+}
+
+function getLastUpdate(modules: ModuleData[]): string | null {
+  // Encuentra el timestamp mas reciente de todas las historias
+  // Retorna ISO string o null si no hay transiciones
+}
+
+function parseRoadmap(projectRoot: string, epicName: string): Partial<EpicData> {
+  // Busca specs/epics/{epicName}/roadmap.md
+  // Parsea cycles (headers ## Cycle N: Name)
+  // Parsea tasks (checkboxes - [ ] / - [x])
+  // Computa progress: (completedTasks / totalTasks) * 100
+  // Retorna { description, cycles, score, progress }
+}
+
+function buildGraph(epics: EpicData[], modules: ModuleData[]): { nodes: GraphNode[]; edges: GraphEdge[] } {
+  // Nodos: cada epic + cada modulo
+  // Edges: epic → modulo (pertenencia), modulo → modulo (dependencias futuras)
+  // Retorna { nodes, edges }
+}
+
+main();
+```
+
+### 4.4. Fuentes de Datos
+
+| Dato                  | Fuente                             | Disponibilidad |
+|-----------------------|------------------------------------|----------------|
+| Epic status/phase     | `.triad/state.json`                | Siempre        |
+| Module state/history  | `.triad/state/{epic}/*.json`       | Siempre        |
+| Module lastAudit      | `.triad/state/{epic}/*.json`       | Si auditado    |
+| Cycle names/counts    | `specs/epics/*/roadmap.md`         | Si existe      |
+| Task checkboxes       | `specs/epics/*/roadmap.md`         | Si existe      |
+| EARS count            | `specs/modules/*/spec.md`          | Si existe      |
+| Test count            | Conteo de `*.test.ts` en codePath  | Si existe      |
+
+---
+
+## 5. Configuracion Vite
+
+### 5.1. `vite.config.ts`
+
+```typescript
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  root: '.',
+  build: {
+    outDir: 'dist',
+    emptyDirFirst: true,
+  },
+  server: {
+    port: 4173,
+    open: true,
+  },
+});
+```
+
+### 5.2. `tsconfig.json`
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}
+```
+
+### 5.3. `index.html`
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TRIAD</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+---
+
+## 6. Componentes
+
+### 6.1. `App.tsx` — Layout + Routing
+
+Componente raiz. Sidebar fija a la izquierda, contenido principal a la derecha.
+Routing via estado local (`activePage`), sin React Router (como el mockup).
+
+```typescript
+// App.tsx
+type Page = 'dashboard' | 'epics' | 'modules' | 'graph';
+
+function App() {
+  const [activePage, setActivePage] = useState<Page>('dashboard');
+  const data = useTriadState();
+
+  return (
+    <div className="app-layout">
+      <Sidebar activePage={activePage} onNavigate={setActivePage} />
+      <main className="main-content">
+        <TopBar />
+        {activePage === 'dashboard' && <Dashboard data={data} />}
+        {activePage === 'epics' && <Epics data={data} />}
+        {activePage === 'modules' && <Modules data={data} />}
+        {activePage === 'graph' && <Graph data={data} />}
+      </main>
+    </div>
+  );
+}
+```
+
+### 6.2. `Sidebar.tsx`
+
+Fixed 240px left panel.
+
+| Elemento            | Detalle                                               |
+|---------------------|-------------------------------------------------------|
+| Logo                | SVG triangle + "TRIAD" en JetBrains Mono              |
+| Nav items           | DASHBOARD, EPICS, MODULES, GRAPH                      |
+| Active indicator    | Gold (#eab308) left border + text highlight            |
+| Bottom section      | Org name + plan badge (si disponible)                  |
+| Background          | `#0f0f0f` (ligeramente mas claro que body)             |
+
+### 6.3. `TopBar.tsx`
+
+Barra superior del contenido principal.
+
+| Elemento     | Detalle                                              |
+|--------------|------------------------------------------------------|
+| Page title   | Nombre de la pagina activa, Inter semibold            |
+| Breadcrumb   | Opcional, para sub-navegacion futura                  |
+| Actions      | Refresh button (re-run generate-data)                 |
+| Background   | Transparente, border-bottom zinc-800                  |
+
+### 6.4. `StatCard.tsx`
+
+Tarjeta de metrica individual usada en Dashboard.
+
+| Prop       | Tipo             | Ejemplo             |
+|------------|------------------|---------------------|
+| `label`    | `string`         | "Total Modules"     |
+| `value`    | `string | number`| "42"                |
+| `subtext`  | `string?`        | "+3 this week"      |
+| `accent`   | `boolean?`       | Gold border si true |
+
+Estilo: fondo `#161616`, borde `#27272a`, padding 24px, JetBrains Mono para value.
+
+### 6.5. `EpicCard.tsx`
+
+Tarjeta de epic usada en la pagina Epics.
+
+| Prop       | Tipo       | Detalle                                   |
+|------------|------------|-------------------------------------------|
+| `epic`     | `EpicData` | Datos completos del epic                  |
+| `expanded` | `boolean`  | Si true, muestra cycles + module list     |
+| `onToggle` | `() => void` | Toggle expansion                       |
+
+Contenido:
+- **Header:** Nombre del epic (gold), status badge, phase badge
+- **Body:** Description (si disponible), package tags, ProgressBar
+- **Footer:** Cycle activo, score, last activity timestamp
+- **Expanded:** Lista de CycleData con checkboxes, lista de modulos del epic
+
+### 6.6. `ModuleTable.tsx`
+
+Tabla de modulos agrupada por package.
+
+| Columna      | Fuente                 | Formato                  |
+|--------------|------------------------|--------------------------|
+| MODULE       | `module.name`          | monospace                |
+| PACKAGE      | `module.package`       | badge                    |
+| STATE        | `module.state`         | badge coloreado          |
+| EARS         | `module.ears`          | numero o "—"             |
+| SCORE        | `module.score`         | 0-100 o "—"             |
+| LAST AUDIT   | `module.lastAudit.ts`  | relative timestamp       |
+
+Agrupacion: secciones colapsables por `module.package`.
+Header de seccion: package name, module count, % coherent, avg score.
+
+### 6.7. `TriadTriangle.tsx`
+
+Componente SVG que visualiza la triada Spec/Code/Tests de un modulo.
+
+```
+          SPEC
+         /    \
+        / EARS \
+       /  IDs   \
+      /    ▼     \
+   CODE ——————— TESTS
+```
+
+| Vertice       | Dato              | Posicion     |
+|---------------|-------------------|--------------|
+| Spec (top)    | EARS count        | Centro-arriba|
+| Code (bottom-left)  | Refs count  | Izquierda    |
+| Tests (bottom-right) | Tests count | Derecha      |
+
+| Linea           | Color                                  |
+|-----------------|----------------------------------------|
+| Spec → Code     | Verde si EARS implementados, rojo si gap|
+| Spec → Tests    | Verde si EARS testeados, rojo si gap   |
+| Code → Tests    | Verde si tests pasan, rojo si gap      |
+
+Centro: Score numerico (0-100). Finding callout si hay gaps.
+
+### 6.8. `StatePipeline.tsx`
+
+Pipeline horizontal mostrando la maquina de estados con conteos.
+
+```
+[no_spec: 2] → [spec_draft: 3] → [spec_ready: 5] → [implemented: 8] → [tested: 4] → [coherent: 12]
+```
+
+Cada nodo: badge con estado + count. Nodo activo (con modulos) mas grande.
+Flechas entre nodos. Colores segun la tabla 3.2.
+
+### 6.9. `ProgressBar.tsx`
+
+Barra de progreso reutilizable.
+
+| Prop       | Tipo     | Detalle                          |
+|------------|----------|----------------------------------|
+| `value`    | `number` | 0-100                            |
+| `label`    | `string?`| Texto a la izquierda             |
+| `showPct`  | `boolean`| Mostrar porcentaje a la derecha  |
+
+Estilo: fondo `#27272a`, fill gold (`#eab308`), height 6px, border-radius 3px.
+
+### 6.10. `Badge.tsx`
+
+Badge/tag reutilizable.
+
+| Prop      | Tipo     | Detalle                  |
+|-----------|----------|--------------------------|
+| `text`    | `string` | Contenido                |
+| `variant` | `string` | Determina color de fondo |
+
+Variantes predefinidas para cada estado de modulo y status de epic.
+
+### 6.11. `ProvenanceFeed.tsx`
+
+Feed de las ultimas N transiciones de estado.
+
+Cada entrada:
+- Timestamp (relative: "2h ago")
+- Module name (monospace)
+- Transicion: `from` → `to` con badges coloreados
+- Trigger (skill:audit, hook:detect, etc.)
+
+Ordenado por timestamp descendente. Default: ultimas 20 transiciones.
+
+---
+
+## 7. Paginas
+
+### 7.1. `Dashboard.tsx` (Cycle 1)
+
+Pagina principal con vision general del proyecto.
+
+**Layout:**
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Stats Row (4x StatCard)                                │
+│  [Epics] [Modules] [Coherent %] [Avg Score]            │
+├─────────────────────────────────────────────────────────┤
+│  Epic Progress                    │  State Pipeline      │
+│  (lista de epics con ProgressBar) │  (StatePipeline)     │
+├─────────────────────────────────────────────────────────┤
+│  Provenance Feed (ultimas 20 transiciones)              │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Stats row:**
+
+| Card           | Value                                      | Subtext                  |
+|----------------|--------------------------------------------|--------------------------|
+| Epics          | `data.epics.length`                        | `N active`               |
+| Modules        | `data.modules.length`                      | `N by state breakdown`   |
+| Coherent %     | `(coherent / total) * 100`                 | `vs last week`           |
+| Avg Score      | Promedio de `module.score` (no null)        | `N audited`              |
+
+### 7.2. `Epics.tsx` (Cycle 2)
+
+Grid de EpicCard components (2 columnas).
+
+**Comportamiento:**
+- Cada card clickeable para expandir/colapsar
+- Expansion muestra: roadmap cycles con checkboxes, module list con estado
+- Filtro por status (all, active, completed, proposal)
+- Sort por: name, progress, lastUpdate
+
+### 7.3. `Modules.tsx` (Cycle 2)
+
+ModuleTable agrupada por package.
+
+**Comportamiento:**
+- Secciones colapsables por package
+- Click en modulo muestra panel lateral con:
+  - TriadTriangle (visualizacion)
+  - History timeline (transiciones)
+  - Last audit details
+- Filtro por state, package, epic
+- Sort por: name, state, score, lastAudit
+
+### 7.4. `Graph.tsx` (Cycle 3)
+
+Grafo D3 force-directed como componente React.
+
+**Nodos:**
+- Epics: nodos grandes, gold border
+- Modules: nodos medianos, color segun estado
+- Dependencies: nodos pequenos, gris
+
+**Edges:**
+- Epic → Module: pertenencia (solido)
+- Module → Module: dependencia (dashed, futuro)
+
+**Controles:**
+- Zoom + pan
+- Layer toggles: epics, modules, dependencies
+- Search: highlight nodo por nombre
+- Click nodo: tooltip con detalle
+
+Mismo estilo visual que el mockup `index.html` graph page.
+
+---
+
+## 8. Hook: `useTriadState.ts`
+
+```typescript
+// hooks/useTriadState.ts
+
+import { useState, useEffect } from 'react';
+import type { TriadWebData } from '../types';
+
+export function useTriadState(pollInterval?: number): TriadWebData | null {
+  const [data, setData] = useState<TriadWebData | null>(null);
+
+  useEffect(() => {
+    // Initial load
+    fetch('/src/data/state.json')
+      .then(res => res.json())
+      .then(setData)
+      .catch(console.error);
+
+    // Optional polling (build mode)
+    if (pollInterval && pollInterval > 0) {
+      const interval = setInterval(() => {
+        fetch('/src/data/state.json')
+          .then(res => res.json())
+          .then(newData => {
+            // Only update if data changed (compare generatedAt)
+            setData(prev =>
+              prev?.generatedAt !== newData.generatedAt ? newData : prev
+            );
+          })
+          .catch(console.error);
+      }, pollInterval);
+      return () => clearInterval(interval);
+    }
+  }, [pollInterval]);
+
+  return data;
+}
+```
+
+**Notas:**
+- En dev mode (`vite dev`), Vite HMR re-importa `state.json` automaticamente — no necesita polling.
+- En build mode (`vite preview`), se activa polling con `useTriadState(3000)`.
+- El hook compara `generatedAt` para evitar re-renders innecesarios.
+- Futura migracion SaaS: reemplazar fetch por `triad.getEpics()` via tRPC.
+
+---
+
+## 9. CSS/Styling
+
+### 9.1. Approach
+
+CSS custom properties en archivo global. Sin Tailwind, sin CSS-in-JS.
+Esto da control total sobre el brand guide y produce CSS minimo.
+
+### 9.2. Brand Guide Variables
+
+```css
+/* src/styles/global.css */
+
+:root {
+  /* Backgrounds */
+  --bg-primary: #0a0a0a;
+  --bg-secondary: #0f0f0f;
+  --bg-card: #161616;
+  --bg-hover: #1a1a1a;
+
+  /* Borders */
+  --border-default: #27272a;
+  --border-hover: #3f3f46;
+
+  /* Text */
+  --text-primary: #fafafa;
+  --text-secondary: #a1a1aa;
+  --text-muted: #71717a;
+
+  /* Accent (gold — sparingly) */
+  --accent-gold: #eab308;
+  --accent-gold-dim: #a16207;
+
+  /* State colors (for badges and indicators) */
+  --state-no-spec: #52525b;
+  --state-spec-draft: #d97706;
+  --state-spec-ready: #3b82f6;
+  --state-implemented: #6366f1;
+  --state-tested: #a855f7;
+  --state-coherent: #10b981;
+  --state-drift: #ef4444;
+
+  /* Typography */
+  --font-body: 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+  /* Spacing */
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+```
+
+### 9.3. Reglas de Estilo
+
+| Regla                      | Aplicacion                                    |
+|----------------------------|-----------------------------------------------|
+| Sin shadows                | Ningun `box-shadow` en toda la app             |
+| Sin gradients              | Ningun `linear-gradient` ni `radial-gradient`  |
+| Gold solo para acentos     | Active nav, selected items, key metrics        |
+| JetBrains Mono para datos  | Numeros, scores, module names, timestamps      |
+| Inter para texto           | Labels, descriptions, paragraphs               |
+| Dark mode unico            | No hay light mode, no hay toggle               |
+
+---
+
+## 10. Skill: `/triad:web`
+
+### 10.1. SKILL.md Spec
+
+```markdown
+# /triad:web — Launch Triad Web Dashboard
+
+## Trigger
+User types `/triad:web` or asks to "see the dashboard" / "open triad web"
+
+## Steps
+
+1. **Verify .triad/ exists**
+   - Check `${PROJECT_ROOT}/.triad/state.json`
+   - If missing: "No .triad/ found. Run `/triad:init` to initialize state tracking."
+   - Exit
+
+2. **Generate data**
+   - Run: `npx tsx packages/claude-plugins/plugins/triad/web/scripts/generate-data.ts $(pwd)`
+   - Verify output: `web/src/data/state.json` created
+   - Report: "{N} epics, {M} modules loaded"
+
+3. **Build if needed**
+   - If `web/dist/` does not exist: run `cd web && npm run build`
+   - If exists: skip (use cached build)
+
+4. **Serve and open**
+   - Run: `cd web && npx vite preview`
+   - Open: `http://localhost:4173`
+   - Report: "Dashboard running at http://localhost:4173"
+
+## Rules
+- Read-only: never modify .triad/ state files
+- Never modify source code
+- If generate-data.ts fails, report the error and suggest fixes
+```
+
+### 10.2. Opciones
+
+| Flag         | Detalle                                        |
+|--------------|------------------------------------------------|
+| `--dev`      | Usa `vite dev` en vez de `vite preview`        |
+| `--no-open`  | No abre el browser automaticamente             |
+| `--port N`   | Puerto alternativo (default: 4173)             |
+| `--refresh`  | Force re-run de generate-data.ts               |
+
+---
+
+## 11. Estrategia de Tests
+
+### 11.1. `generate-data.ts` — Unit Tests
+
+```typescript
+// scripts/__tests__/generate-data.test.ts
+
+describe('generate-data', () => {
+  // Setup: crear directorio .triad/ temporal con datos mock
+
+  it('should fail if .triad/state.json does not exist', () => {
+    // Verificar exit code 1 y mensaje de error
+  });
+
+  it('should read epic registry and produce TriadWebData', () => {
+    // Seed: state.json con 2 epics
+    // Seed: state/{epic}/module.json con 3 modulos
+    // Run generate-data.ts
+    // Assert: output contiene 2 epics, 3 modules
+  });
+
+  it('should parse roadmap.md for cycle data', () => {
+    // Seed: roadmap.md con 3 cycles, 10 tasks (6 completadas)
+    // Run generate-data.ts
+    // Assert: epic.cycles.length === 3, epic.progress === 60
+  });
+
+  it('should compute module byState summary', () => {
+    // Seed: 5 modulos en estados variados
+    // Assert: epic.modules.byState matches expected counts
+  });
+
+  it('should build graph with correct nodes and edges', () => {
+    // Seed: 2 epics, 4 modulos
+    // Assert: graph.nodes.length === 6 (2 epics + 4 modulos)
+    // Assert: graph.edges.length === 4 (epic→module)
+  });
+
+  it('should handle missing roadmap.md gracefully', () => {
+    // Seed: epic sin roadmap.md
+    // Assert: epic.cycles === undefined, epic.progress === undefined
+  });
+
+  it('should derive package from codePath', () => {
+    // Seed: module con codePath "packages/core/src/auth/"
+    // Assert: module.package === "packages/core"
+  });
+});
+```
+
+### 11.2. Components — Visual Review
+
+No unit tests para componentes React individuales en Cycle 1.
+Validacion visual contra el mockup `index.html`:
+
+| Componente       | Validacion                                      |
+|------------------|-------------------------------------------------|
+| Sidebar          | Matches mockup nav layout, gold active state    |
+| StatCard         | Correct font (JetBrains Mono), no shadows       |
+| EpicCard         | Gold name, badges, progress bar                 |
+| ModuleTable      | Grouped by package, correct state colors        |
+| TriadTriangle    | SVG renders correctly, green/red lines          |
+| StatePipeline    | All 7 states shown, counts match data           |
+| ProvenanceFeed   | Chronological order, relative timestamps        |
+
+### 11.3. E2E — Skill Integration
+
+```typescript
+// __tests__/e2e/triad-web.test.ts
+
+describe('/triad:web E2E', () => {
+  it('should launch and serve dashboard with mock data', () => {
+    // 1. Create temp project with .triad/ mock data
+    // 2. Run generate-data.ts
+    // 3. Run vite build
+    // 4. Run vite preview
+    // 5. Fetch http://localhost:4173
+    // 6. Assert: HTML contains <div id="root">
+    // 7. Cleanup: kill server, remove temp dir
+  });
+
+  it('should show correct epic count on dashboard', () => {
+    // Seed: 3 epics
+    // Assert: StatCard shows "3"
+  });
+
+  it('should show correct module states in pipeline', () => {
+    // Seed: known distribution of states
+    // Assert: StatePipeline counts match
+  });
+});
+```
+
+### 11.4. Ciclo de Validacion
+
+```
+1. tsc --noEmit                    ← tipos correctos
+2. vitest run scripts/             ← generate-data.ts unit tests
+3. vite build                      ← build compila sin errores
+4. Comparacion visual vs mockup    ← screenshot comparison
+5. E2E con mock .triad/            ← skill integration
+```
+
+---
+
+## 12. Decisiones de Implementacion
+
+| #  | Decision                          | Elegido                | Alternativa rechazada         | Razon                                              |
+|----|-----------------------------------|------------------------|-------------------------------|-----------------------------------------------------|
+| D1 | Framework CSS                     | CSS custom properties  | Tailwind 4.x                  | Control total del brand guide, menos dependencias    |
+| D2 | Router                            | Estado local (`useState`) | React Router              | Sin deep linking necesario, igual que el mockup     |
+| D3 | Build output                      | `dist/` gitignored     | Commiteado                    | Se genera en install, reduce repo size               |
+| D4 | generate-data.ts lenguaje         | TypeScript (tsx)       | Bash script                   | Type-safe, reutiliza tipos de state_schema           |
+| D5 | Polling interval (build mode)     | 3 segundos             | 10s, manual refresh           | Balance entre responsividad y load                   |
+| D6 | Graph library (Cycle 3)           | D3.js                  | vis.js, react-flow            | Ya probado en mockup, maximo control                 |
+| D7 | Data fetch en SPA                 | Import JSON directo    | REST API                      | No necesita server, Vite resuelve el import          |
+
+---
+
+## 13. Ciclos de Implementacion
+
+### Cycle 1: Foundation + Dashboard
+
+**Deliverables:**
+- [ ] Scaffold: `package.json`, `vite.config.ts`, `tsconfig.json`, `index.html`
+- [ ] Types: `src/types/index.ts` completo
+- [ ] Script: `generate-data.ts` funcional con unit tests
+- [ ] Hook: `useTriadState.ts`
+- [ ] CSS: `global.css` con todas las variables del brand guide
+- [ ] Layout: `App.tsx`, `Sidebar.tsx`, `TopBar.tsx`
+- [ ] Components: `StatCard.tsx`, `ProgressBar.tsx`, `Badge.tsx`, `StatePipeline.tsx`, `ProvenanceFeed.tsx`
+- [ ] Page: `Dashboard.tsx` con datos reales
+- [ ] Skill: `SKILL.md` para `/triad:web`
+
+**Criterio de exito:** `/triad:web` levanta el dashboard con datos de `.triad/` del monorepo.
+
+### Cycle 2: Epics + Modules
+
+**Deliverables:**
+- [ ] Component: `EpicCard.tsx` con expansion
+- [ ] Page: `Epics.tsx` con grid + filtros
+- [ ] Component: `ModuleTable.tsx` agrupada por package
+- [ ] Component: `TriadTriangle.tsx` SVG
+- [ ] Page: `Modules.tsx` con panel lateral
+
+**Criterio de exito:** Navegacion completa Dashboard → Epics → Modules con datos reales.
+
+### Cycle 3: Graph + Polish
+
+**Deliverables:**
+- [ ] Component: D3 Graph con force layout
+- [ ] Page: `Graph.tsx` con controles
+- [ ] E2E tests completos
+- [ ] Performance: lazy load de paginas
+- [ ] Polish: transiciones, loading states, empty states
+
+**Criterio de exito:** Las 4 paginas funcionales, E2E green, visual match con mockup.
+
+---
+
+## 14. Exclusiones
+
+Fuera del scope de esta epic:
+
+- Version SaaS (eso es `triad_protocol_bridge` epic futura)
+- Websockets/SSE (polling es suficiente para local)
+- Paginas: Audit, Agents, Marketplace, Settings (dependen de `.gitgov/` records)
+- Binario `triad` standalone (el skill `/triad:web` es suficiente)
+- Light mode (dark mode unico)
+- Migracion del mockup `index.html` (queda como referencia, no se sirve)
+- Internacionalizacion (single language: English)

--- a/specs/epics/triad_web/inputs/conversation_context.md
+++ b/specs/epics/triad_web/inputs/conversation_context.md
@@ -1,0 +1,149 @@
+# Conversation Context: Triad Web Epic
+
+> Fecha: 2026-04-05 a 2026-04-07
+> Sesion: TRIAD (fork de sesion de diseño de triad_state_machine + dashboard)
+> Participantes: Camilo + Claude Code (Opus 4.6)
+
+---
+
+## 1. Como surgió esta epic
+
+Durante la sesion de diseño de `triad_state_machine`, construimos un mockup HTML
+de 12 paginas (11,000+ lineas) que visualiza el estado de una organizacion completa
+usando datos de .triad/ y .gitgov/. El mockup demuestra como se veria el producto
+GitGov Builder (Triad) con datos reales.
+
+El mockup incluye: LIVE (mission control), Dashboard, Epics, Modules, Provenance,
+Graph (D3 force-directed), Governance (compliance packs), Audit (scans/findings/waivers),
+Agents, Marketplace, Reports, Settings.
+
+La pregunta fue: "¿como hacemos que esto funcione con datos reales, en local,
+sin depender del SaaS de GitGovernance?"
+
+## 2. Decisiones tomadas
+
+### Tech stack
+- **Vite + React** (no Next.js — no necesita SSR para local)
+- Vite es build tool, no framework. Dev server en 200ms, build en 2 seg.
+- Output: dist/ con HTML+JS+CSS estaticos
+
+### Ubicacion
+- **packages/claude-plugins/plugins/triad/web/** (dentro del plugin de Triad)
+- Se instala con el plugin via marketplace de Claude Code
+- Skill `/triad:web` levanta el server y abre el browser
+
+### Data layer
+- **generate-data.ts** lee .triad/state/ + specs/epics/*/roadmap.md
+- Genera web/src/data/state.json que la SPA consume
+- No modifica state_manager — es un lector separado
+
+### Reactividad
+- **Dev mode:** Vite HMR detecta cambios en state.json (PostToolUse hook regenera)
+- **Build mode:** Polling cada 3 seg (tiny endpoint que re-lee state files)
+- No websockets, no SSE — polling es suficiente para local
+
+### Dos versiones, mismos componentes
+- **Local (esta epic):** Lee filesystem directo, /triad:web levanta server
+- **SaaS (futuro):** Mismos React components, data via tRPC + projector + DB
+
+## 3. Schemas reales (Cycle 5 de triad_state_machine completado)
+
+### Module State File (.triad/state/{epic}/{module}.json)
+
+```json
+{
+  "module": "auth_handler",
+  "epic": "saas_base",
+  "state": "implemented",
+  "codePath": "packages/webapps/saas/src/auth/",
+  "specPath": "modules/auth_handler/",
+  "cycle": 2,
+  "history": [
+    { "from": "no_spec", "to": "spec_draft", "trigger": "hook:detect", "ts": "2026-04-01T10:00:00Z" },
+    { "from": "spec_draft", "to": "spec_ready", "trigger": "skill:audit", "ts": "2026-04-02T14:00:00Z", "score": 0.85 },
+    { "from": "spec_ready", "to": "implemented", "trigger": "hook:detect", "ts": "2026-04-03T09:00:00Z" }
+  ],
+  "lastAudit": { "verdict": "COHERENT", "score": 0.85, "findings": 2, "ts": "2026-04-02T14:00:00Z" }
+}
+```
+
+7 estados: no_spec → spec_draft → spec_ready → implemented → tested → coherent ⇄ drift
+
+### Epic Registry (.triad/state.json)
+
+```json
+{
+  "epics": {
+    "saas_base": {
+      "stateDir": ".triad/state/saas_base/",
+      "packages": ["packages/webapps/saas/"],
+      "status": "active",
+      "phase": "impl",
+      "activeCycle": 4,
+      "history": [
+        { "from": "proposal", "to": "active", "trigger": "auto:first-module-registered", "ts": "2026-03-15T10:00:00Z" }
+      ]
+    }
+  }
+}
+```
+
+5 status: proposal → active → paused → completed → discarded
+phase computada: design | ready | impl | complete
+
+### getEpicSummary() (ya existe en state_manager)
+
+```typescript
+interface EpicSummary {
+  name: string;
+  modules: { total: number; byState: Record<string, number> };
+  lastUpdate: string | null;
+}
+```
+
+### Lo que NO esta en state files (necesita parseo de markdowns)
+
+- Cycles detail (total, completed, names) → roadmap.md
+- Tasks (checkboxes checked/total) → roadmap.md
+- EARS count por modulo → spec files
+- Test count por modulo → test files
+- Epic progress % → derivado de tasks
+
+El script generate-data.ts combina AMBAS fuentes (state files + markdowns).
+
+## 4. Paginas del mockup (referencia visual)
+
+El archivo inputs/mockup_reference.html contiene las 12 paginas completas.
+Cada pagina se implementa como React component incremental:
+
+| Cycle | Paginas | Datos necesarios |
+|:------|:--------|:----------------|
+| 1 | Dashboard + Epics | state.json + state/*.json + roadmap.md |
+| 2 | Modules + Graph | state/*.json + D3.js |
+| 3 | Provenance + Reports | history[] de state files |
+| 4+ | Audit, Agents, etc | Requiere .gitgov/ records |
+
+## 5. Screenshots del Audit SaaS (referencia visual)
+
+En inputs/:
+- scan.png — Scans table + detail panel
+- 222.png — Findings table + detail panel (Overview tab)
+- finding_actovity.png — Finding detail (History tab)
+- 444.png — Waivers table + detail panel (Details tab)
+- waivers-details.png — Waiver detail (Activity tab)
+- 2.png — Audit dashboard (stats + risk + repos + scans + waivers)
+
+Estas vistas se implementan cuando la webapp soporte .gitgov/ records (Cycle 4+).
+
+## 6. Brand guide
+
+Seguir exactamente: `packages/private/packages/blueprints/03_product/triad/brand_guide.md`
+- Dark mode (#0a0a0a), gold accent (#eab308)
+- JetBrains Mono + Inter
+- Sin shadows, sin gradients
+
+## 7. Dependencias
+
+- triad_state_machine Cycle 5 completado (getEpicSummary, /triad:init)
+- skill_designer existe (para crear /triad:web skill spec)
+- view_designer existe (para crear page specs)

--- a/specs/epics/triad_web/inputs/epic_input.md
+++ b/specs/epics/triad_web/inputs/epic_input.md
@@ -1,0 +1,369 @@
+# Epic Input: Triad Web — Dashboard Local para Triad
+
+> Fecha: 2026-04-06
+> Status: Input document
+> Prerequisito: `triad_state_machine` Cycle 5 completado (getEpicSummary, /triad:init)
+> Vinculado a: `epics/proposals/triad_state_machine/` (depende de state files + getEpicSummary)
+> Vinculado a: `epics/proposals/triad_protocol_bridge_input.md` (version SaaS futura)
+> Ubicacion del codigo: `packages/claude-plugins/plugins/triad/web/`
+
+---
+
+## 1. Problema
+
+El state machine de Triad genera datos ricos sobre el estado de epics, modulos, cycles,
+EARS coverage, triad scores, y transiciones. Pero toda esa informacion solo es accesible via:
+
+- Archivos JSON en `.triad/state/` (hay que leerlos manualmente)
+- `/triad:status` (texto en terminal, limitado)
+- `/triad:resume` (texto en terminal, una epic a la vez)
+
+No hay forma visual de ver el estado del proyecto. El index.html mockup que creamos
+(11,000 lineas, 12 paginas) demuestra como se veria, pero usa datos hardcoded.
+
+## 2. Solucion
+
+Una SPA (Single Page Application) con Vite + React que:
+
+1. Lee `.triad/state/` directamente del filesystem
+2. Muestra las mismas vistas del mockup pero con datos reales
+3. Se levanta con `/triad:web` (skill de Claude Code)
+4. Se actualiza automaticamente cuando los state files cambian (HMR en dev)
+
+### Dos versiones, mismos componentes
+
+```
+VERSION 1: LOCAL (esta epic)
+  /triad:web → genera data.json → vite preview → abre browser
+  Lee .triad/state/ del filesystem
+  No necesita internet, no necesita DB, no necesita server externo
+  Un dev con Claude Code ve su progreso al instante
+
+VERSION 2: SAAS (epic futura, triad_protocol_bridge)
+  gitgov.com/builder → mismos React components
+  Lee via projector + DB (como Audit)
+  Multi-repo, multi-org, historical
+  Producto de pago ($99/mo)
+```
+
+La clave: los componentes React son los mismos. Lo que cambia es el data layer.
+
+```
+React Components (compartidos)
+  EpicCard, ModuleTable, TriadTriangle, StateGraph...
+       │
+       ├── Local: import data from './data/state.json'
+       │   Generado por script desde .triad/state/
+       │
+       └── SaaS: triad.getEpics(repoId) via tRPC
+           Projector + DB + GitHub API
+```
+
+---
+
+## 3. Arquitectura
+
+### Ubicacion en el plugin
+
+```
+packages/claude-plugins/plugins/triad/
+├── skills/
+│   └── web/
+│       └── SKILL.md              ← /triad:web skill spec
+├── hooks/                         ← state machine (ya existe)
+├── designers/                     ← designers (ya existe)
+├── web/                           ← NUEVO: Vite + React app
+│   ├── package.json
+│   ├── vite.config.ts
+│   ├── tsconfig.json
+│   ├── index.html                 ← entry point de Vite
+│   ├── scripts/
+│   │   └── generate-data.ts       ← lee .triad/state/, genera data.json
+│   ├── src/
+│   │   ├── main.tsx               ← React entry
+│   │   ├── App.tsx                ← router + layout
+│   │   ├── data/
+│   │   │   └── state.json         ← generado, gitignored
+│   │   ├── hooks/
+│   │   │   └── useTriadState.ts   ← lee state.json, polling en build mode
+│   │   ├── components/
+│   │   │   ├── Sidebar.tsx
+│   │   │   ├── EpicCard.tsx
+│   │   │   ├── ModuleTable.tsx
+│   │   │   ├── TriadTriangle.tsx
+│   │   │   ├── StateGraph.tsx     ← D3 graph (migrado de index.html)
+│   │   │   └── ...
+│   │   └── pages/
+│   │       ├── Dashboard.tsx
+│   │       ├── Epics.tsx
+│   │       ├── Modules.tsx
+│   │       ├── Graph.tsx
+│   │       └── ...
+│   └── dist/                      ← output build (gitignored)
+└── index.html                     ← mockup actual (referencia de diseño)
+```
+
+### Flujo del skill /triad:web
+
+```
+Usuario escribe: /triad:web
+
+Skill ejecuta:
+  1. node web/scripts/generate-data.ts $(pwd)
+     → Lee .triad/state.json (indice global)
+     → Lee .triad/state/{epic}/*.json (modulos)
+     → Lee specs/epics/*/roadmap.md (cycles, tasks, EARS)
+     → Genera web/src/data/state.json
+
+  2. cd web && npx vite preview
+     → Sirve dist/ en localhost:4173
+     (o npx vite dev para modo desarrollo con HMR)
+
+  3. open http://localhost:4173
+     → Abre el browser
+```
+
+### Reactividad
+
+**En dev mode (vite dev):**
+- PostToolUse hook de Claude Code detecta write a .triad/state/
+- Re-ejecuta generate-data.ts
+- Vite HMR detecta cambio en state.json
+- Browser se actualiza automaticamente
+- Zero latency
+
+**En build mode (vite preview):**
+- Polling cada 3 segundos desde el browser
+- Tiny endpoint Express que re-lee state files
+- O: re-run generate-data.ts y refresh manual
+
+---
+
+## 4. Paginas (incrementales)
+
+Referencia visual: `packages/claude-plugins/plugins/triad/index.html` (mockup 12 paginas)
+
+Construir incrementalmente, una pagina por cycle:
+
+### Cycle 1: Dashboard + Epics
+
+| Pagina | Datos necesarios | Fuente |
+|:-------|:----------------|:-------|
+| Dashboard | Org score, epic progress, module states | .triad/state.json + state/*.json |
+| Epics | Lista de epics, cycles, tasks, progress | .triad/state.json + roadmap.md parsing |
+
+### Cycle 2: Modules + Graph
+
+| Pagina | Datos necesarios | Fuente |
+|:-------|:----------------|:-------|
+| Modules | Lista de modulos, state, EARS, score | .triad/state/{module}.json |
+| Graph | Nodos + edges de records | .triad/state/*.json + relaciones |
+
+### Cycle 3: Provenance + Reports
+
+| Pagina | Datos necesarios | Fuente |
+|:-------|:----------------|:-------|
+| Provenance | Transiciones firmadas, history | .triad/state/{module}.json → history[] |
+| Reports | Generacion de reportes | Compuesto de todo lo anterior |
+
+### Cycle 4+: Audit, Agents, Marketplace, Settings
+
+Estas paginas dependen de datos que van mas alla de .triad/:
+- Audit necesita .gitgov/ records (scans, findings, waivers)
+- Agents necesita ActorRecords
+- Marketplace es contenido estatico por ahora
+
+Se implementan cuando la version SaaS los requiera.
+
+---
+
+## 5. Data Layer: generate-data.ts
+
+El script que lee .triad/ y genera el JSON que la webapp consume:
+
+```typescript
+// web/scripts/generate-data.ts
+
+interface TriadWebData {
+  generatedAt: string;
+  org: {
+    name: string;
+    score: number;
+  };
+  epics: EpicSummary[];
+  modules: ModuleSummary[];
+  graph: {
+    nodes: GraphNode[];
+    edges: GraphEdge[];
+  };
+}
+
+interface EpicSummary {
+  name: string;
+  status: string;
+  phase: string;
+  cycles: { total: number; completed: number; detail: CycleSummary[] };
+  tasks: { total: number; completed: number; percent: number };
+  ears: { total: number; implemented: number };
+  modules: { total: number; byState: Record<string, number> };
+  score: number | null;
+  lastActivity: string;
+  packages: string[];
+}
+
+interface ModuleSummary {
+  name: string;
+  epic: string;
+  state: string;
+  ears: number;
+  tests: number;
+  score: number | null;
+  package: string;
+  lastTransition: string;
+  history: TransitionEntry[];
+}
+```
+
+Este es esencialmente `getEpicSummary()` del Cycle 5 de triad_state_machine,
+pero materializado como JSON file en vez de retornado on-demand.
+
+---
+
+## 6. Relacion con triad_state_machine
+
+```
+triad_state_machine (epic existente)
+│
+├── Cycles 1-4: COMPLETADOS
+│   State machine funcional, hooks, enforcement
+│
+├── Cycle 5: Developer Experience (PROPUESTA)
+│   ├── Task 5.1: /triad:init
+│   ├── Task 5.2: Build pipeline
+│   ├── Task 5.3: Audit reminder
+│   └── Task 5.4: getEpicSummary()  ← PREREQUISITO para triad_web
+│
+└── Dependencia:
+    triad_web necesita que getEpicSummary() exista
+    para que generate-data.ts pueda computar los resumenes
+
+triad_web (esta epic, NUEVA)
+│
+├── Prerequisito: triad_state_machine Cycle 5 completado
+│   (especificamente Task 5.4: getEpicSummary)
+│
+├── Cycle 1: Setup + Dashboard + Epics
+├── Cycle 2: Modules + Graph
+├── Cycle 3: Provenance + Reports
+└── Cycle 4+: Audit integration (requiere .gitgov/)
+```
+
+---
+
+## 7. Tech Stack
+
+| Herramienta | Version | Proposito |
+|:------------|:--------|:----------|
+| Vite | 6.x | Build tool (dev server + bundler) |
+| React | 19.x | UI framework |
+| TypeScript | 5.8 | Type safety |
+| D3.js | 7.x | Graph visualization (migrado del mockup) |
+| Tailwind CSS | 4.x | Styling (o CSS custom siguiendo brand guide) |
+
+**Sin:** Next.js, SSR, backend server, base de datos, websockets.
+
+**Dependencias minimas:** El plugin de Triad ya se instala via marketplace.
+`web/` es un subdirectorio con su propio package.json. `npm install` en web/
+instala solo las dependencias del frontend.
+
+---
+
+## 8. Brand Guide
+
+Seguir exactamente el brand guide de Triad (`03_product/triad/brand_guide.md`):
+
+- Dark mode primary (#0a0a0a)
+- Gold accent (#eab308)
+- JetBrains Mono + Inter
+- Sin shadows, sin gradients
+- El mockup index.html ES la referencia visual
+
+Los componentes React replican pixel-by-pixel lo que el mockup muestra,
+pero con datos reales y codigo mantenible (componentes, no 11k lineas de HTML).
+
+---
+
+## 9. Skill: /triad:web
+
+El skill se crea usando el skill_designer:
+
+```
+/triad:new spec triad_web --type skill
+```
+
+El SKILL.md define:
+- Paso 1: Verificar que .triad/ existe (sino, sugerir /triad:init)
+- Paso 2: Ejecutar generate-data.ts
+- Paso 3: Compilar si dist/ no existe (vite build)
+- Paso 4: Servir y abrir browser
+- Regla: no modificar archivos, solo leer + servir
+
+---
+
+## 10. Migracion a SaaS (futuro)
+
+Cuando se implemente triad_protocol_bridge (Fase 2):
+
+```
+LOCAL (esta epic)                    SAAS (futuro)
+web/src/hooks/useTriadState.ts       saas-web/src/hooks/useTriadState.ts
+  reads: state.json (filesystem)       reads: triad.getEpics() (tRPC)
+
+web/src/components/EpicCard.tsx  →   saas-web/src/components/EpicCard.tsx
+  (copiar tal cual)                    (mismo componente, diferente data source)
+```
+
+Los componentes se copian de `triad/web/` a `saas-web/`. Solo cambia el hook
+de datos. El data layer es el unico acople — los componentes son puros.
+
+---
+
+## 11. Decisiones Pendientes
+
+| # | Decision | Opciones | Cuando decidir |
+|:--|:---------|:---------|:---------------|
+| 1 | ¿Tailwind o CSS custom? | Tailwind (rapido, utilities) vs CSS modules (mas control, match brand guide) | Al iniciar Cycle 1 |
+| 2 | ¿Router? | React Router vs simple state toggle (como el mockup) | Al iniciar Cycle 1 |
+| 3 | ¿El build se commitea o se genera? | dist/ en .gitignore (generate on install) vs commiteado | Al iniciar Cycle 1 |
+| 4 | ¿generate-data.ts es TS o bash? | TS (type-safe, reutiliza tipos de state_schema) vs bash (simple, sin build) | Al diseñar el spec |
+| 5 | ¿Polling interval en build mode? | 3s (responsive) vs 10s (menos load) vs manual refresh | Al implementar |
+
+---
+
+## 12. No Hacer Ahora
+
+- No implementar version SaaS (eso es triad_protocol_bridge)
+- No agregar websockets (polling es suficiente para local)
+- No crear binario `triad` (el skill es suficiente por ahora)
+- No implementar Audit/Agents/Marketplace pages (dependen de .gitgov/)
+- No migrar el mockup index.html (queda como referencia de diseño)
+
+---
+
+## 13. Orden de Implementacion
+
+```
+1. triad_state_machine Cycle 5 → Task 5.4 getEpicSummary()
+   (prerequisito: el data layer necesita esta funcion)
+
+2. triad_web Cycle 1 → Setup Vite + Dashboard + Epics
+   (primera pagina funcional con datos reales)
+
+3. triad_web Cycle 2 → Modules + Graph
+   (las dos paginas mas valiosas para el dev dia a dia)
+
+4. triad_web Cycle 3+ → incrementalmente
+```
+
+**Siguiente paso inmediato:** Completar triad_state_machine Cycle 5 (al menos Task 5.4).
+**Siguiente paso de esta epic:** Crear el spec con /triad:new spec usando skill_designer para /triad:web, luego view_designer para las paginas.

--- a/specs/epics/triad_web/overview.md
+++ b/specs/epics/triad_web/overview.md
@@ -1,0 +1,353 @@
+# triad_web — Epic Overview
+
+> **CONTEXTO PARA AGENTES:** Este documento es la vision ejecutiva del epic
+> (arquitectura, decisiones, "que" y "por que"). Para detalles tecnicos ver
+> `implementation_plan.md`. **Para estado actual del trabajo ver
+> [`roadmap.md`](./roadmap.md)** (fuente de verdad unica del progreso).
+
+---
+
+## Vision
+
+**Triad Web** es una SPA local (Vite + React) que lee `.triad/state/` y visualiza Epics, Modules y Dashboard en el browser — sin dependencia SaaS, sin servidor externo, sin base de datos. El developer ejecuta `/triad:web` desde Claude Code, el skill genera un `state.json` desde los archivos de estado, levanta Vite y abre el browser.
+
+El valor central es convertir datos que hoy solo existen como JSON files y output de terminal en una interfaz visual navegable. Los mismos componentes React migran despues al producto SaaS (GitGov Builder) cambiando unicamente el data layer.
+
+### Origen del Epic
+
+El state machine de Triad (epic `triad_state_machine`, Cycles 1-5 completados) genera datos ricos: estado de modulos, transiciones con timestamps, epic registry, audit scores, historial de provenance. Pero toda esa informacion solo es accesible via:
+
+1. **Archivos JSON en `.triad/state/`** — hay que leerlos manualmente o con `jq`
+2. **`/triad:status`** — output de texto en terminal, limitado a una tabla
+3. **`/triad:resume`** — texto en terminal, una epic a la vez
+
+Durante el diseno de `triad_state_machine` se construyo un mockup HTML de 12 paginas (11,000+ lineas) que demuestra como se veria el producto con datos reales. Ese mockup es la referencia visual, pero usa datos hardcoded y HTML monolitico no mantenible.
+
+La pregunta fue: "como hacemos que esto funcione con datos reales, en local, sin depender del SaaS?" Esta epic es la respuesta.
+
+### Que Problema Resuelve
+
+```
+ANTES (solo terminal + JSON):
+
+  .triad/state/                         Developer
+  ┌──────────────────────────┐          ┌─────────────────────────────────┐
+  │ epic_a/                  │          │                                 │
+  │   auth.json   (raw JSON) │          │ 1. cat .triad/state.json | jq   │
+  │   backlog.json           │          │ 2. /triad:status (texto plano)  │
+  │ epic_b/                  │          │ 3. /triad:resume (una epic)     │
+  │   router.json            │          │ 4. No ve relaciones entre       │
+  │   ...                    │          │    modulos ni progreso global   │
+  └──────────────────────────┘          └─────────────────────────────────┘
+           │                                        │
+           ▼                                        ▼
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │ PROBLEMAS:                                                           │
+  │ 1. Datos ricos pero accesibles solo como JSON crudo                  │
+  │ 2. No hay vista de progreso global (multi-epic)                      │
+  │ 3. No hay visualizacion de state machine transitions                 │
+  │ 4. Stakeholders no pueden ver estado sin terminal                    │
+  │ 5. Mockup existe pero es hardcoded (11k lineas, no mantenible)       │
+  └──────────────────────────────────────────────────────────────────────┘
+
+DESPUES (Triad Web):
+
+  .triad/state/          generate-data.ts          Vite + React SPA
+  ┌──────────────┐       ┌──────────────┐          ┌──────────────────────┐
+  │ state.json   │ ────> │ Lee state/   │ ───────> │ Dashboard            │
+  │ state/       │       │ Lee roadmaps │          │ ├── Epic progress    │
+  │  epic/*.json │       │ Computa      │          │ ├── Module states    │
+  └──────────────┘       │ summaries    │          │ └── Activity feed    │
+                         │ Genera:      │          │                      │
+  specs/epics/           │ state.json   │          │ Epics                │
+  ┌──────────────┐       │ (consumible) │          │ ├── Cards + cycles   │
+  │ roadmap.md   │ ────> │              │          │ ├── Tasks progress   │
+  │ (N epics)    │       └──────────────┘          │ └── Module breakdown │
+  └──────────────┘                                 │                      │
+                                                   │ Modules              │
+  /triad:web skill                                 │ ├── Table by state   │
+  ┌──────────────────────────────────────┐         │ ├── Triad triangle   │
+  │ 1. generate-data.ts $(pwd)           │         │ └── Score + history  │
+  │ 2. vite preview (o vite dev)         │         │                      │
+  │ 3. open http://localhost:4173        │         │ Graph (D3 force)     │
+  └──────────────────────────────────────┘         └──────────────────────┘
+```
+
+### Que NO es
+
+- **No es un producto SaaS** — es una herramienta local, sin internet, sin DB, sin server externo. La version SaaS es `triad_protocol_bridge` (epic futura)
+- **No reemplaza `/triad:status`** — el CLI sigue siendo la forma rapida de consultar estado. La web es la forma visual de explorarlo
+- **No es el dashboard completo de 12 paginas** — se construye incrementalmente: 3 paginas primero (Dashboard, Epics, Modules), el resto en cycles posteriores
+- **No es una app server-rendered** — Vite build produce HTML+JS+CSS estaticos. No hay SSR, no hay Next.js, no hay backend
+- **No modifica el state machine** — `generate-data.ts` es un lector puro. No extiende `state_manager`, no escribe a `.triad/state/`
+- **No es el mockup migrado** — el mockup es la referencia visual. Los componentes React replican su apariencia con datos reales, no son una conversion linea-por-linea del HTML
+
+---
+
+## Target Persona
+
+**Primary: Developer usando Triad con Claude Code**
+
+- Trabaja en un monorepo con multiples epics activas
+- Quiere VER el estado de su proyecto, no leerlo en JSON
+- Pain: datos ricos generados por state machine + audits, pero sin forma de visualizarlos
+- Contexto: ya usa `/triad:status` pero quiere mas detalle (history, graphs, cross-epic view)
+
+**Secondary: Tech Lead / Product Owner revisando progreso**
+
+- Quiere entender en que estado esta cada epic sin abrir terminal
+- Necesita vista de progreso global (cycles completados, tasks pendientes, EARS coverage)
+- Pain: hoy depende de que el developer le diga el estado
+
+---
+
+## Objetivos del Producto
+
+1. **Skill `/triad:web` funcional** — un comando levanta la webapp con datos reales del proyecto
+2. **Dashboard page** — vista global con epic progress, module states, activity feed
+3. **Epics page** — cards por epic con cycles, tasks, EARS, module breakdown
+4. **Modules page** — tabla de modulos agrupada por package con state, score, triad triangle
+5. **Datos reales** — `generate-data.ts` lee `.triad/state/` + `roadmap.md` y genera JSON consumible
+6. **Reactividad** — cambios en state files se reflejan en el browser (HMR en dev, polling en build)
+7. **Componentes migrables** — los componentes React funcionan identicos en la version SaaS futura
+
+---
+
+## Arquitectura del Sistema
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           TRIAD WEB                                          │
+│                           Local Dashboard SPA                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  DATA SOURCES                          DATA PIPELINE                         │
+│  ┌──────────────────────┐              ┌──────────────────────────────────┐  │
+│  │ .triad/              │              │ generate-data.ts                  │  │
+│  │ ├── state.json       │──── read ──> │                                  │  │
+│  │ │   (epic registry)  │              │ 1. Read .triad/state.json        │  │
+│  │ └── state/           │              │ 2. Read .triad/state/{epic}/*.json│ │
+│  │     ├── epic_a/      │              │ 3. Parse specs/epics/*/roadmap.md│  │
+│  │     │   ├── mod1.json│              │ 4. Compute summaries (cycles,    │  │
+│  │     │   └── mod2.json│              │    tasks, EARS, scores)          │  │
+│  │     └── epic_b/      │              │ 5. Write web/src/data/state.json │  │
+│  │         └── mod3.json│              │                                  │  │
+│  └──────────────────────┘              └──────────────────────────────────┘  │
+│                                                       │                      │
+│  specs/epics/                                         │ state.json           │
+│  ┌──────────────────────┐                             │ (generated)          │
+│  │ epic_a/roadmap.md    │──── parse ──────────────────┘                      │
+│  │ epic_b/roadmap.md    │                             │                      │
+│  └──────────────────────┘                             ▼                      │
+│                                                                              │
+│  FRONTEND (Vite + React)                                                     │
+│  ┌────────────────────────────────────────────────────────────────────────┐  │
+│  │                                                                        │  │
+│  │  useTriadState.ts ──── reads state.json ──── provides to components    │  │
+│  │       │                                                                │  │
+│  │       ├── Dashboard.tsx ─── EpicCard[] + ModuleTable + ActivityFeed    │  │
+│  │       ├── Epics.tsx ─────── EpicCard (expanded) + CycleTimeline       │  │
+│  │       ├── Modules.tsx ───── ModuleTable + TriadTriangle + ScoreCard   │  │
+│  │       └── Graph.tsx ─────── D3 ForceGraph (nodes=modules, edges=deps) │  │
+│  │                                                                        │  │
+│  │  Layout: Sidebar (nav) + Header (org info) + Content (page)           │  │
+│  │  Brand: Dark (#0a0a0a) + Gold (#eab308) + JetBrains Mono + Inter     │  │
+│  │                                                                        │  │
+│  └────────────────────────────────────────────────────────────────────────┘  │
+│                                                                              │
+│  REACTIVITY                                                                  │
+│  ┌────────────────────────────────────────────────────────────────────────┐  │
+│  │                                                                        │  │
+│  │  DEV MODE (vite dev):                                                  │  │
+│  │    PostToolUse hook ─> re-run generate-data.ts ─> Vite HMR ─> browser │  │
+│  │    Latency: ~200ms (state change to visual update)                    │  │
+│  │                                                                        │  │
+│  │  BUILD MODE (vite preview):                                            │  │
+│  │    Polling every 3s from browser ─> re-fetch state.json ─> re-render  │  │
+│  │    Alternative: manual refresh after /triad:status                     │  │
+│  │                                                                        │  │
+│  └────────────────────────────────────────────────────────────────────────┘  │
+│                                                                              │
+│  SKILL: /triad:web                                                           │
+│  ┌────────────────────────────────────────────────────────────────────────┐  │
+│  │  1. Verify .triad/ exists (else suggest /triad:init)                   │  │
+│  │  2. Run generate-data.ts $(pwd) → write state.json                    │  │
+│  │  3. If no dist/: vite build                                            │  │
+│  │  4. vite preview → serve on localhost:4173                             │  │
+│  │  5. open browser                                                       │  │
+│  │  Rule: read-only — never modify .triad/ or specs/                      │  │
+│  └────────────────────────────────────────────────────────────────────────┘  │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Componentes
+
+| Componente | Responsabilidad | Ubicacion |
+|---|---|---|
+| `generate-data.ts` | Lee `.triad/state/` + `roadmap.md`, computa summaries, genera `state.json` consumible por la SPA | `web/scripts/` |
+| `useTriadState.ts` | Hook React que lee `state.json`, provee datos a todos los componentes. Polling en build mode, import directo en dev mode | `web/src/hooks/` |
+| `Dashboard.tsx` | Pagina principal: org score, epic progress bars, module state summary, activity feed reciente | `web/src/pages/` |
+| `Epics.tsx` | Lista de epics como cards expandibles con cycles, tasks, EARS coverage, module breakdown | `web/src/pages/` |
+| `Modules.tsx` | Tabla de modulos agrupada por package con state badge, triad score, triangle visualizer | `web/src/pages/` |
+| `Graph.tsx` | D3 force-directed graph: nodos = modulos, edges = dependencias. Migrado del mockup | `web/src/pages/` |
+| `EpicCard.tsx` | Componente reutilizable: nombre, status, phase, progress bar, cycle count, module breakdown | `web/src/components/` |
+| `ModuleTable.tsx` | Tabla de modulos con sorting, filtering by state, grouping by package | `web/src/components/` |
+| `TriadTriangle.tsx` | SVG triangle: spec (izquierda), code (derecha), tests (base). Color = completeness | `web/src/components/` |
+| `StateGraph.tsx` | D3 force graph wrapper. Nodos coloreados por state, edges por relaciones | `web/src/components/` |
+| `Sidebar.tsx` | Navegacion lateral: Dashboard, Epics, Modules, Graph. Dark theme, gold highlight activo | `web/src/components/` |
+| `App.tsx` | Router + layout (sidebar + header + content area). State toggle o React Router | `web/src/` |
+| `SKILL.md` | Spec del skill `/triad:web` para Claude Code skill runner | `skills/web/` |
+
+---
+
+## Modelo Funcional
+
+### Data Flow
+
+```
+  .triad/state.json              generate-data.ts              React SPA
+  .triad/state/{epic}/*.json     (Node.js script)              (Vite bundle)
+  specs/epics/*/roadmap.md
+         │                              │                            │
+         │    1. READ                   │                            │
+         │ ──────────────────────────>  │                            │
+         │    - Parse epic registry     │                            │
+         │    - Parse module states     │                            │
+         │    - Parse roadmap markdowns │                            │
+         │                              │                            │
+         │                              │    2. COMPUTE              │
+         │                              │    - EpicSummary[]         │
+         │                              │    - ModuleSummary[]       │
+         │                              │    - GraphData (nodes,     │
+         │                              │      edges)                │
+         │                              │                            │
+         │                              │    3. WRITE                │
+         │                              │ ──────────────────────>    │
+         │                              │    web/src/data/state.json │
+         │                              │                            │
+         │                              │                            │    4. RENDER
+         │                              │                            │    useTriadState()
+         │                              │                            │    reads state.json
+         │                              │                            │    provides to pages
+```
+
+### Dos versiones, mismos componentes
+
+```
+VERSION LOCAL (esta epic)                VERSION SAAS (epic futura)
+
+  /triad:web                               gitgov.com/builder
+       │                                        │
+       ▼                                        ▼
+  generate-data.ts                         tRPC API
+  reads .triad/state/                      reads DB (projector)
+  writes state.json                        returns EpicSummary[]
+       │                                        │
+       ▼                                        ▼
+  useTriadState.ts                         useTriadState.ts
+  import state.json                        triad.getEpics(repoId)
+       │                                        │
+       └──────────────┬─────────────────────────┘
+                      │
+                      ▼
+              SHARED COMPONENTS
+              EpicCard, ModuleTable,
+              TriadTriangle, StateGraph,
+              Sidebar, Layout...
+```
+
+Los componentes son puros (props in, JSX out). Lo unico que cambia entre local y SaaS es el hook de datos.
+
+---
+
+## Decisiones Arquitectonicas
+
+### Decisiones Ya Tomadas
+
+| ID | Decision | Resolucion | Razon |
+|---|---|---|---|
+| A1 | Framework frontend | Vite 6 + React 19 (no Next.js) | No necesita SSR para app local. Vite: dev server en 200ms, build en 2s. React 19: mismo framework que SaaS futuro |
+| A2 | Ubicacion del codigo | `packages/claude-plugins/plugins/triad/web/` | Vive dentro del plugin de Triad. Se instala con el plugin via marketplace de Claude Code. package.json propio |
+| A3 | Data layer | `generate-data.ts` como script separado (no extension de state_manager) | state_manager es para mutaciones de estado. generate-data.ts es un lector puro que materializa summaries como JSON. Separacion de responsabilidades |
+| A4 | Orden de paginas | Dashboard primero, luego Epics, luego Modules, luego Graph | Valor incremental: Dashboard da vision global (Cycle 1), Epics/Modules dan detalle (Cycle 2), Graph es la mas compleja (Cycle 3) |
+| A5 | Componentes migrables | Mismos componentes React para local y SaaS | Unico acople es el hook de datos. Componentes son puros (props in, JSX out). Evita reescritura cuando se lance SaaS |
+| A6 | Relationship model | edges.json separado (Option B) con prefijos mod:/epic: | Extensible a gitgov: sin cambio de schema. Investigado con 5 agentes: OpenAPI, SPDX, Backstage, Terraform, GraphQL |
+| A7 | Drift detection | Git-native: buildDriftSet() con 2 git calls, needsAudit por modulo | Sin checksums, sin estado extra. Funciona con PostToolUse hook + git pre-commit |
+| A8 | Epic deps | Derivados de module deps cross-epic, no declarados explicitamente | Modulo es la unidad atomica. Epic→epic se computa, no se declara |
+| A9 | Routing | State-based toggle (no React Router) | 4 paginas sin deep linking. State toggle es suficiente y mas simple. Auditado contra metodologia |
+
+### Decisiones Pendientes
+
+| ID | Decision | Opciones | Cuando decidir |
+|---|---|---|---|
+| P1 | Styling | Tailwind CSS 4.x (rapido, utilities) vs CSS custom/modules (match brand guide directo) | Al iniciar Cycle 1 — depende de cuanto difiere brand guide de Tailwind defaults |
+| P2 | Routing | React Router (URLs reales, deep links) vs simple state toggle (como el mockup, menos deps) | Al iniciar Cycle 1 — si solo hay 3-4 paginas, state toggle es suficiente |
+| P3 | dist/ strategy | Gitignored (generate on install) vs committed (funciona sin build step) | Al iniciar Cycle 1 — tradeoff: convenience vs repo size |
+
+---
+
+## Deliverables
+
+| Entregable | Ubicacion | Cycle | Estado | Descripcion |
+|---|---|---|---|---|
+| Vite + React setup | `web/` | 1 | pending | package.json, vite.config.ts, tsconfig.json, index.html, base layout |
+| generate-data.ts | `web/scripts/` | 1 | pending | Lee .triad/state/ + roadmap.md, genera state.json |
+| /triad:web skill | `skills/web/SKILL.md` | 1 | pending | Skill spec: generate data, build, serve, open browser |
+| Dashboard page | `web/src/pages/Dashboard.tsx` | 1 | pending | Epic progress bars, module state summary, activity feed |
+| Epics page | `web/src/views/epics/EpicsView.tsx` | 2 | 🟢 done | Epic cards con roadmap cycles, tasks, EARS, modules (14 EARS, 14 tests) |
+| Modules page | `web/src/views/modules/ModulesView.tsx` | 2 | 🟢 done | Module table grouped by package, triad triangle, scores (14 EARS, 15 tests) |
+| Graph page | `web/src/views/graph/GraphView.tsx` | 3 | 🟢 done | D3 force graph with typed edges, legend, detail panel (19 EARS, 16 tests) |
+| Git hook | `web/scripts/install-git-hook.ts` | 3 | 🟢 done | Pre-commit hook for IDE edits, installable via /triad:init (8 EARS, 8 tests) |
+
+---
+
+## Estado Actual
+
+> **Fuente de verdad:** [`roadmap.md`](./roadmap.md)
+
+- **Prerequisito:** triad_state_machine Cycle 5 completado (getEpicSummary existe)
+- **Cycle 0 (inputs):** Completado — epic input document, conversation context, mockup HTML reference, screenshots
+- **Cycle 1:** 🟢 Completado — Vite setup, generate-data.ts (13 EARS, 14 tests), Dashboard page (16 EARS), /triad:web skill (7 EARS), refresh_hook (7 EARS, 7 tests)
+- **Cycle 2:** 🟢 Completado — Epics page (14 EARS, 14 tests), Modules page (14 EARS, 15 tests), audit + fix applied
+- **Cycle 3:** 🟡 En Progreso — Graph page done (D3 + typed edges + drift + legend + detail). git_hook done. Pendiente: shared_components, routing, build optimization
+
+---
+
+## Referencias
+
+- [Epic Input](./inputs/epic_input.md)
+- [Conversation Context](./inputs/conversation_context.md)
+- [Mockup Reference](./inputs/mockup_reference.html)
+- [Brand Guide](packages/private/packages/blueprints/03_product/triad/brand_guide.md)
+- [State Schema Types](packages/claude-plugins/plugins/triad/hooks/src/state_schema/types.ts)
+- [triad_state_machine Epic](packages/private/packages/blueprints/03_products/epics/proposals/triad_state_machine/overview.md)
+
+---
+
+## Handoff
+
+**Para empezar Cycle 1:**
+
+1. Resolver decisiones pendientes P1 (Tailwind vs CSS), P2 (Router vs state toggle), P3 (dist/ strategy)
+2. Ejecutar `/triad:new spec generate_data --type module` para crear spec de generate-data.ts
+3. Ejecutar `/triad:new spec triad_web_skill --type skill` para crear spec del skill /triad:web
+4. Scaffold del proyecto Vite + React en `packages/claude-plugins/plugins/triad/web/`
+5. Implementar generate-data.ts primero (data layer antes de UI)
+6. Dashboard page con datos reales
+
+**Dependencias externas:**
+
+- `getEpicSummary()` de triad_state_machine — necesario para que generate-data.ts compute summaries
+- `skill_designer` — necesario para crear el SKILL.md de /triad:web
+- `view_designer` — necesario para crear specs de pages
+
+**Riesgos:**
+
+- Brand guide existe pero no se ha testeado con Tailwind — puede requerir override extensivo
+- El mockup tiene 12 paginas pero esta epic cubre 4 — hay que delimitar bien que entra en cada cycle
+- D3 force graph del mockup es la pagina mas compleja — separar en Cycle 3 para no bloquear el resto
+
+---
+
+**Ultima actualizacion:** 2026-04-08 — Cycles 1+2 completados, Cycle 3 en progreso. 9 triadas (generate_data 17 EARS, modules_view 17, graph_view 19, git_hook 8, refresh_hook 7, dashboard_view 16, epics_view 14, web_skill 7). PR #9 creado, bloqueado por merge de triad_state_machine (listModules). 81 tests, 91KB build.

--- a/specs/epics/triad_web/rewinds/rewind_1_2026-04-07_cycle2-continuation.md
+++ b/specs/epics/triad_web/rewinds/rewind_1_2026-04-07_cycle2-continuation.md
@@ -1,0 +1,124 @@
+⏺ Rewind #1 — triad_web Cycle 2 (Modules fix + Graph)
+
+  Worktree: packages/claude-plugins/.claude/worktrees/triad-web/
+  Branch: epic/triad-web-c2 (from main, includes PR #7 merged)
+  PR #7 merged: feat(triad): add web dashboard (41 files, +9,006 lines)
+
+  === ESTADO ACTUAL ===
+
+  Epic: triad_web — Vite + React local dashboard for Triad methodology
+  Location: packages/claude-plugins/plugins/triad/web/
+  Tech: Vite 8 + React 19 + TypeScript, dark mode, JetBrains Mono + Inter
+
+  Cycle 1: 🟢 COMPLETADO
+    4 triadas cerradas:
+    - generate_data: 13 EARS, 14 tests (scripts/generate-data.ts)
+      Reads .triad/state/*.json + spec files, produces state.json
+      countEars() parses **[PREFIX-X1]** patterns from spec .md files
+    - dashboard_view: 16 EARS (src/views/dashboard/DashboardView.tsx)
+      Stats row, epic progress, state pipeline, provenance feed
+      Audited (partial) + fixed: E2 error state, hardcoded values, provenance limit
+    - web_skill: 7 EARS (skills/web/SKILL.md)
+      3 steps: verify .triad/ → generate data → serve + open browser
+    - refresh_hook: 7 EARS, 7 tests (scripts/refresh-hook.ts)
+      PostToolUse hook regenerates state.json when .triad/ changes, debounce 1s
+
+  Cycle 2: 🟡 EN PROGRESO
+    Epics page: DONE (otro agente completó spec + impl + audit + fix)
+      src/views/epics/EpicsView.tsx + EpicsView.test.tsx
+      Card grid con expandable detail (roadmap, modules)
+    Modules page: NEEDS_FIX (otro agente auditó, 8 findings, /triad:fix parcial)
+      src/views/modules/ModulesView.tsx + ModulesView.test.tsx + TriadTriangle.tsx
+      Finding #2 requería ears field — RESUELTO: agregué ears: number a ModuleData + countEars()
+      Findings pendientes: drift filter, debounce search, test assertions
+
+  Cycle 3: 🔴 PENDIENTE (Graph + Polish)
+
+  Tests: 21 automatizados (14 generate-data + 7 refresh-hook) + tests de views del otro agente
+  EARS total: 42+ definidos across specs
+
+  === PENDIENTE ===
+
+  Cycle 2 pendiente:
+  1. Completar /triad:fix modules_view — findings 1,3,4,5,6 del audit
+     - #1 MEDIUM: drift missing from state filter dropdown
+     - #3 MEDIUM: MOD-C3 test only covers green edges
+     - #4 MEDIUM: MOD-A1 test missing coherent % and avg score assertions
+     - #5 MEDIUM: MOD-B1 test missing gold/badge assertions
+     - #6 LOW: search input has no debounce (spec says 300ms)
+  2. Re-audit modules_view después del fix
+  3. Checkpoint Cycle 2
+
+  Cycle 3:
+  1. /triad:new spec graph_page --type view
+  2. /triad:impl graph_page (D3 force graph migrado del mockup)
+  3. /triad:new spec shared_components (extraer de views existentes)
+  4. React Router o state-based routing (decisión pendiente P2)
+  5. Build optimization + README
+
+  === DECISIONES TOMADAS ===
+
+  - Vite + React (NOT Next.js) — no SSR needed for local tool
+  - views/ + shared/ + lib/ structure (frontend_methodology.md)
+  - generate-data.ts como lector separado (no extiende state_manager del state machine)
+  - useTriadData hook con { data, error, source } return shape
+  - mockData.ts como fallback cuando state.json no existe
+  - type para datos, interface solo para contratos (AGENTS.md convention)
+  - /triad:impl mejorado con Paso 2.5 (load methodology) + Paso 3.2 (read AGENTS.md)
+  - countEars() parsea **[PREFIX-X1]** patterns de spec files
+  - EARS Coverage muestra "—" (placeholder hasta que generate-data compute el real)
+
+  === DEUDA TECNICA ===
+
+  - DashboardView no tiene tests (partial mode audit, tests pendientes)
+  - Specs Requeridos en roadmap muestra paths incorrectos (dice src/pages/, debería ser src/views/)
+  - Task 1.2 tiene 2 checkboxes pendientes: roadmap parsing + graph nodes en generate-data
+  - e2e_quality_auditor §7.5 agregado pero no implementado aún (valida AGENTS.md conventions)
+
+  === DEPENDENCIAS EXTERNAS ===
+
+  - Otro agente completó epics_view + modules_view parcial en branch feat/triad-state-machine
+    Esos cambios pueden necesitar merge o cherry-pick al worktree triad-web-c2
+  - State machine (Cycles 1-5 completados) en main — hooks/src/ tiene gate_hook, detect_hook, etc.
+  - El monorepo tiene .triad/state.json + 2 module state files de prueba creados durante esta sesión
+
+  === PARA CONTINUAR ===
+
+  1. cd a worktree: packages/claude-plugins/.claude/worktrees/triad-web/
+  2. Verificar que web/ tiene los cambios del otro agente (epics_view, modules_view)
+     Si no: merge o cherry-pick del branch del otro agente
+  3. /triad:fix modules_view — resolver los 5 findings pendientes
+  4. /triad:audit modules_view — re-verificar
+  5. /triad:checkpoint triad_web 2 — cerrar Cycle 2
+  6. /triad:new spec graph_page --type view — arrancar Cycle 3
+  7. /triad:impl graph_page — D3 force graph como React component
+
+  === ARCHIVOS CLAVE ===
+
+  Epic docs:
+    /Users/camilo/go/src/github.com/gitgovernance/monorepo/specs/epics/triad_web/roadmap.md
+    /Users/camilo/go/src/github.com/gitgovernance/monorepo/specs/epics/triad_web/overview.md
+
+  Specs:
+    plugins/triad/specs/views/dashboard/dashboard_view.md (16 EARS)
+    plugins/triad/specs/views/epics/epics_view.md
+    plugins/triad/specs/views/modules/modules_view.md
+    plugins/triad/specs/modules/generate_data/generate_data_module.md (13 EARS)
+    plugins/triad/specs/modules/refresh_hook/refresh_hook_module.md (7 EARS)
+    plugins/triad/specs/skills/web/web_skill.md (7 EARS)
+
+  Code:
+    plugins/triad/web/src/App.tsx (routing + sidebar)
+    plugins/triad/web/src/lib/types.ts (ModuleData with ears field, EpicData, TriadWebData)
+    plugins/triad/web/src/views/dashboard/DashboardView.tsx
+    plugins/triad/web/src/views/epics/EpicsView.tsx
+    plugins/triad/web/src/views/modules/ModulesView.tsx
+    plugins/triad/web/src/views/modules/TriadTriangle.tsx
+    plugins/triad/web/scripts/generate-data.ts (countEars + 13 EARS)
+    plugins/triad/web/scripts/refresh-hook.ts (7 EARS)
+
+  Config:
+    .triad/config.json (specsDir: "specs/", stateMachine: enabled)
+    plugins/triad/AGENTS.md (conventions: type vs interface, frontend rules)
+    plugins/triad/references/methodology.md
+    plugins/triad/references/frontend_methodology.md

--- a/specs/epics/triad_web/roadmap.md
+++ b/specs/epics/triad_web/roadmap.md
@@ -1,0 +1,675 @@
+# triad_web — Roadmap
+
+> **Fuente de verdad del progreso: este documento.**
+> Para contexto de origen ver [`inputs/epic_input.md`](./inputs/epic_input.md).
+> Para contexto de conversacion ver [`inputs/conversation_context.md`](./inputs/conversation_context.md).
+
+---
+
+## Resumen de Cycles
+
+| Cycle | Nombre | Objetivo | Packages | Estado |
+|---:|---|---|---|:---:|
+| 1 | Foundation + Dashboard | Setup Vite + React, data generation script, Dashboard page, /triad:web skill | `packages/claude-plugins/plugins/triad/web/` | 🟢 Completado |
+| 2 | Epics + Modules | Epics page con expandable cards, Modules page con package grouping y triad triangle | `packages/claude-plugins/plugins/triad/web/` | 🟢 Completado |
+| 3 | Graph + Polish | D3 force graph migrado a React, shared components, routing, build optimization | `packages/claude-plugins/plugins/triad/web/` | 🟡 En Progreso |
+
+---
+
+## Specs Requeridos
+
+| Spec | Tipo | Cycle | Path | Estado |
+|---|---|---:|---|:---:|
+| `generate_data` | module | 1 | `web/scripts/generate-data.ts` | 🟢 Implementado (12 EARS, 12 tests) |
+| `dashboard_page` | view | 1 | `web/src/views/dashboard/DashboardView.tsx` | 🟡 Parcial (conectado a generate-data, falta audit) |
+| `web_skill` | skill | 1 | `skills/web/SKILL.md` | 🟢 Implementado (7 EARS, spec + SKILL.md) |
+| `epics_view` | view | 2 | `web/src/views/epics/EpicsView.tsx` | 🟢 Implementado (14 EARS, 14 tests) |
+| `modules_view` | view | 2 | `web/src/views/modules/ModulesView.tsx` | 🟢 Implementado (14 EARS, 15 tests) |
+| `graph_view` | view | 3 | `web/src/views/graph/GraphView.tsx` | 🟢 Implementado (19 EARS, 16 tests) |
+| `git_hook` | module | 3 | `web/scripts/install-git-hook.ts` | 🟢 Implementado (8 EARS, 8 tests) |
+| `shared_components` | module | 3 | `web/src/shared/` | 🔴 Pendiente |
+
+---
+
+## Flujo de Trabajo por Cycle
+
+> **REGLA:** Para CADA cycle, seguir este orden estrictamente.
+
+```
+1. VERIFICAR SPECS
+   └── Ver tabla "Specs Requeridos" para el cycle
+   └── Si hay Pendiente → CREAR SPEC antes de codificar
+
+2. IMPLEMENTAR
+   └── Codigo segun EARS del spec
+
+3. TESTS
+   └── Cada EARS debe tener al menos un test
+
+4. AUDITAR
+   └── /triad:audit
+
+5. MARCAR COMPLETADO
+   └── Actualizar este roadmap
+```
+
+---
+
+# Cycle 1: Foundation + Dashboard
+
+## Objetivo
+
+Setup del proyecto Vite + React, crear el script de generacion de datos que lee `.triad/state/` y roadmaps, implementar la pagina Dashboard con stats, epic progress, module pipeline y provenance feed, y crear el skill `/triad:web` que orquesta todo.
+
+## Modulos a Implementar
+
+| Modulo | Tipo | Descripcion | Dependencias |
+|:-------|:-----|:------------|:-------------|
+| `generate_data` | module | Script que lee `.triad/state/*.json` + `specs/epics/*/roadmap.md` y genera `web/src/data/state.json` | `state_manager.getEpicSummary()` |
+| `dashboard_page` | view | Dashboard page: stats row, epic progress table, module state machine pipeline, provenance feed | `generate_data` (consume state.json) |
+| `web_skill` | skill | `/triad:web` skill que genera datos, builds, sirve y abre browser | `generate_data`, `dashboard_page` |
+
+---
+
+## Criterios de Aceptacion
+
+### Task 1.1: Vite + React project setup
+
+- [x] `web/package.json` con dependencias: react 19, vite 8, typescript 5.8
+- [x] `web/vite.config.ts` con configuracion de dev server (port 4173)
+- [x] `web/tsconfig.json` con strict mode
+- [x] `web/index.html` como entry point de Vite con JetBrains Mono + Inter fonts
+- [x] `web/src/main.tsx` con React root render
+- [x] `web/src/App.tsx` con sidebar navigation + page routing (state-based)
+- [x] Brand guide aplicado: lib/tokens.css con dark mode, gold accent, fonts
+- [x] `dist/` y `src/data/state.json` en `.gitignore`
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-A1 | EVENT | WHEN `npm run dev` is executed in the web directory, the system SHALL start a Vite dev server serving the React application. |
+| TW-A2 | EVENT | WHEN `npm run build` is executed, the system SHALL produce a static `dist/` bundle with HTML, JS, and CSS. |
+| TW-A3 | STATE | WHILE the application is rendered, the layout SHALL display a sidebar with navigation links and a main content area. |
+| TW-A4 | STATE | WHILE the application is rendered, the visual styling SHALL follow the brand guide: dark background (#0a0a0a), gold accent (#eab308), JetBrains Mono for code, Inter for body text, no shadows, no gradients. |
+
+---
+
+### Task 1.2: generate-data.ts
+
+- [x] Script reads `.triad/state.json` (epic registry index)
+- [x] Script reads `.triad/state/{epic}/*.json` (module state files)
+- [ ] Script parses `specs/epics/*/roadmap.md` for cycle/task/EARS counts
+- [x] Output: `web/src/data/state.json` matching `TriadWebData` interface
+- [x] Computes per-epic: task progress %, cycle counts, EARS counts, module counts by state
+- [x] Computes per-module: state, EARS count, score, last transition, history
+- [ ] Builds graph nodes/edges from state relationships
+- [x] Accepts `projectRoot` argument (defaults to `process.cwd()`)
+- [x] Handles missing `.triad/` gracefully (generates empty state with warning)
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-A5 | EVENT | WHEN `generate-data.ts` is executed with a valid project root, the system SHALL read `.triad/state.json` and all module state files under `.triad/state/{epic}/`. |
+| TW-A6 | EVENT | WHEN `generate-data.ts` is executed, the system SHALL parse `specs/epics/*/roadmap.md` files to extract cycle, task, and EARS counts. |
+| TW-A7 | RESPONSE | WHEN data generation completes, the system SHALL write a `state.json` file to `web/src/data/` with the `TriadWebData` schema. |
+| TW-A8 | UNWANTED | IF `.triad/` directory does not exist, the system SHALL generate an empty state structure with a warning message instead of throwing an error. |
+| TW-A9 | STATE | WHILE module state files exist, the generated output SHALL include per-module fields: state, EARS count, score, last transition, and full history. |
+| TW-A10 | STATE | WHILE epic data exists, the generated output SHALL include per-epic fields: task progress percentage, cycle counts, EARS counts, and module counts grouped by state. |
+
+---
+
+### Task 1.3: Dashboard page — stats row, epic progress, module pipeline
+
+- [ ] Stats row: Triad Score (org average), Active Epics count, Modules Tracked count, EARS Coverage %
+- [ ] Epic progress table: name, status badge, cycle indicator, task progress bar, score
+- [ ] Module state machine pipeline: horizontal bar showing count per state (no_spec → spec_draft → spec_ready → implemented → tested → coherent), colored segments
+- [ ] Responsive layout, consistent with brand guide
+- [ ] All data sourced from imported `state.json`
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-A11 | STATE | WHILE the Dashboard page is rendered, it SHALL display a stats row with: Triad Score (org average), Active Epics count, Modules Tracked count, and EARS Coverage percentage. |
+| TW-A12 | STATE | WHILE epic data exists, the Dashboard SHALL display an epic progress table with columns: name, status badge, active cycle, task progress bar, and triad score. |
+| TW-A13 | STATE | WHILE module data exists, the Dashboard SHALL display a state machine pipeline visualization showing the count of modules in each of the 7 states as colored segments. |
+| TW-A14 | UNWANTED | IF state.json contains zero epics, the Dashboard SHALL display an empty state message instead of rendering broken tables. |
+
+---
+
+### Task 1.4: Dashboard page — provenance feed
+
+- [ ] Provenance feed section: last 5 state transitions across all modules
+- [ ] Each entry: timestamp, module name, from → to states, trigger, epic name
+- [ ] Sorted by most recent first
+- [ ] Clickable entries (future: link to module detail)
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-A15 | STATE | WHILE transition history exists, the Dashboard SHALL display a provenance feed showing the 5 most recent state transitions across all modules, sorted by timestamp descending. |
+| TW-A16 | STATE | WHILE a provenance entry is displayed, it SHALL include: timestamp, module name, from-state, to-state, trigger, and epic name. |
+
+---
+
+### Task 1.5: /triad:web skill spec + SKILL.md
+
+- [ ] SKILL.md follows skill_designer format
+- [ ] Step 1: Verify `.triad/` exists (suggest `/triad:init` if missing)
+- [ ] Step 2: Execute `generate-data.ts` to produce `state.json`
+- [ ] Step 3: Build if `dist/` does not exist (`vite build`)
+- [ ] Step 4: Serve via `vite preview` and open browser
+- [ ] Skill is read-only (never modifies state files or source code)
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-A17 | EVENT | WHEN `/triad:web` is invoked, the system SHALL verify that `.triad/` directory exists and suggest `/triad:init` if it does not. |
+| TW-A18 | EVENT | WHEN `/triad:web` executes, the system SHALL run `generate-data.ts` to produce a fresh `state.json` before serving. |
+| TW-A19 | EVENT | WHEN `dist/` does not exist, the system SHALL run `vite build` before starting the preview server. |
+| TW-A20 | EVENT | WHEN the build is ready, the system SHALL start `vite preview` and open the default browser to the local URL. |
+
+---
+
+### Task 1.6: PostToolUse hook integration
+
+- [ ] PostToolUse hook detects writes to `.triad/state/` paths
+- [ ] On detected change, hook re-executes `generate-data.ts` automatically
+- [ ] Vite HMR picks up `state.json` change and hot-reloads in browser
+- [ ] Throttled to avoid rapid re-generation (debounce 1 second)
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-A21 | EVENT | WHEN a PostToolUse hook detects a write to any file under `.triad/state/`, the system SHALL re-execute `generate-data.ts` to refresh `state.json`. |
+| TW-A22 | UNWANTED | IF multiple `.triad/` writes occur within 1 second, the system SHALL debounce and execute `generate-data.ts` only once after the burst. |
+
+---
+
+### Cycle 1 Dependency Diagram
+
+```mermaid
+graph TD
+    T1_1[1.1 Vite + React Setup] --> T1_3[1.3 Dashboard — stats, progress, pipeline]
+    T1_2[1.2 generate-data.ts] --> T1_3
+    T1_2 --> T1_4[1.4 Dashboard — provenance feed]
+    T1_1 --> T1_4
+    T1_3 --> T1_5[1.5 /triad:web skill]
+    T1_4 --> T1_5
+    T1_2 --> T1_6[1.6 PostToolUse hook]
+    T1_5 --> T1_6
+
+    style T1_1 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T1_2 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T1_3 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T1_4 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T1_5 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T1_6 fill:#1a1a2e,stroke:#eab308,color:#fff
+```
+
+---
+
+### Task 1.7: Mejora de /triad:impl — methodology loading (no prevista)
+
+> **Nota:** Al implementar el dashboard, se descubrio que /triad:impl no inyectaba la metodologia frontend. El agente escribio codigo sin seguir la estructura views/shared/lib. Se agrego Paso 2.5 al SKILL.md.
+
+- [x] Paso 2.5 agregado a skills/impl/SKILL.md: carga methodology.md (base) + frontend_methodology.md (views)
+- [x] Tabla de extensiones por tipo (view, module, agent, cli)
+- [x] 5 reglas de frontend explicitadas en el skill
+- [x] Regla bloqueante: "NUNCA generar codigo sin haber leido la metodologia"
+
+### Task 1.8: Setup de infraestructura Triad en worktree (no prevista)
+
+> **Nota:** El worktree no tenia .triad/ configurado. Sin hooks ni state machine, no habia enforcement.
+
+- [x] .triad/config.json creado en worktree (stateMachine enabled, specsDir configurado)
+- [x] Deuda tecnica registrada en AGENTS.md (skills sin E2E tests)
+
+### Task 1.9: Creacion de spec dashboard_view (no prevista como task separada)
+
+> **Nota:** El roadmap listaba dashboard_page como spec requerido pero no tenia task explicita para crear el spec. Se creo usando /triad:new spec --type view.
+
+- [x] specs/views/dashboard/dashboard_view.md creado (16 EARS, 5 bloques)
+- [x] specs/views/dashboard/dashboard_brief.md creado (5 data sources)
+
+### Task 1.10: Spec + impl + audit de generate_data (no prevista como task separada)
+
+> **Nota:** generate_data estaba en Task 1.2 como checkboxes pero necesitaba spec formal antes de implementar (metodologia triad). Se creo spec, se implemento, se audito, se fixeo.
+
+- [x] specs/modules/generate_data/generate_data_module.md creado (12 EARS, 4 bloques)
+- [x] scripts/generate-data.ts implementado (7 funciones, 12 EARS trazados)
+- [x] scripts/generate-data.test.ts implementado (12 tests, todos REAL)
+- [x] /triad:audit generate_data ejecutado (5 auditors, 9 findings)
+- [x] /triad:fix aplicado (4 tests mejorados, 3 spec updates)
+- [x] Audited: 12/12 EARS coherent
+
+### Task 1.11: Mejoras a AGENTS.md y /triad:impl (no prevista)
+
+> **Nota:** Durante impl de generate_data se descubrio que /triad:impl no lee AGENTS.md del package target, causando que `interface` se usara en vez de `type`. Se mejoraron 3 archivos.
+
+- [x] triad/AGENTS.md: seccion Convenciones ampliada (type vs interface, frontend rules)
+- [x] triad/AGENTS.md: deuda tecnica registrada (/triad:impl no lee AGENTS.md)
+- [x] skills/impl/SKILL.md: Paso 2.5 mejorado (methodology.md base + extension por tipo)
+- [x] skills/impl/SKILL.md: Paso 3.2 agregado (lee AGENTS.md del package target)
+- [x] e2e_quality_auditor.md: §7.5 agregado (valida convenciones minimas en AGENTS.md)
+
+### Task 1.12: Dashboard conectado a generate-data (no prevista como task separada)
+
+> **Nota:** Se creo useTriadData hook que lee state.json con fallback a mockData.
+
+- [x] src/views/dashboard/useTriadData.ts creado (import.meta.glob + fallback)
+- [x] DashboardView.tsx actualizado: usa useTriadData() en vez de mockData directo
+
+### Task 1.13: web_skill spec + SKILL.md (no prevista como task separada)
+
+> **Nota:** Task 1.5 tenia checkboxes para el skill pero no para la creacion del spec previo. Se creo spec con skill_designer y luego SKILL.md.
+
+- [x] specs/skills/web/web_skill.md creado (7 EARS: WEB-A1 to C2, 3 fases)
+- [x] skills/web/SKILL.md creado (3 pasos: verificar → generar → servir)
+- [x] Verificado con Playwright: dashboard renderiza datos reales de .triad/state/
+
+### Task 1.14: State files de prueba en monorepo (no prevista)
+
+> **Nota:** El monorepo no tenia .triad/state.json para probar. Se crearon files minimos para validar el flujo end-to-end.
+
+- [x] .triad/state.json creado con 1 epic (triad_web)
+- [x] .triad/state/triad_web/generate_data.json (coherent, score 0.95)
+- [x] .triad/state/triad_web/dashboard_view.json (implemented)
+
+### Task 1.15: refresh_hook triada completa (no prevista como task separada)
+
+> **Nota:** Task 1.6 tenia checkboxes para PostToolUse hook pero necesitaba spec formal. Se creo spec, se implemento, se testeo.
+
+- [x] specs/modules/refresh_hook/refresh_hook_module.md creado (7 EARS, 3 bloques)
+- [x] scripts/refresh-hook.ts implementado (path detection, debounce, execution)
+- [x] scripts/refresh-hook.test.ts implementado (7 tests, todos passing)
+
+### Task 1.16: dashboard_view audit + fix (no prevista)
+
+> **Nota:** Audit partial (sin tests) detecto 6 findings. Se aplicaron 7 correcciones.
+
+- [x] /triad:audit dashboard_view ejecutado (4 auditors partial, 6 findings)
+- [x] /triad:fix: DASH-E2 ErrorState implementado + useTriadData refactored
+- [x] /triad:fix: EARS Coverage desharcodificado + gold removido
+- [x] /triad:fix: ProvenanceFeed limitado a 5 + sort desc
+- [x] /triad:fix: brief actualizado (drift removido)
+- [x] tsc + build verificados post-fix
+
+---
+
+# Cycle 2: Epics + Modules
+
+## Objetivo
+
+Implementar la pagina Epics con grid de cards expandibles mostrando roadmap y modulos, y la pagina Modules con agrupacion por package, triad triangle SVG, y lista de trazabilidad EARS.
+
+## Modulos a Implementar
+
+| Modulo | Tipo | Descripcion | Dependencias |
+|:-------|:-----|:------------|:-------------|
+| `epics_page` | view | Epics grid con cards: name, description, packages, progress bar, cycle, state badge, score, expandable detail con roadmap + modules list | `generate_data` (state.json), Dashboard components |
+| `modules_page` | view | Modules table agrupada por package, search/filter, triad triangle SVG, EARS traceability list | `generate_data` (state.json), Dashboard components |
+
+---
+
+## Criterios de Aceptacion
+
+### Task 2.1: Epics page — card grid
+
+- [x] Grid layout with one card per epic
+- [x] Each card displays: name, status badge (active/paused/completed), phase label, associated packages
+- [x] Progress bar showing task completion percentage
+- [x] Active cycle indicator (e.g., "Cycle 3 of 5")
+- [x] Triad score (numeric, color-coded)
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-B1 | STATE | WHILE the Epics page is rendered, it SHALL display a grid of cards with one card per epic from state.json. |
+| TW-B2 | STATE | WHILE an epic card is displayed, it SHALL show: name, status badge, phase label, associated packages, task progress bar, active cycle indicator, and triad score. |
+| TW-B3 | UNWANTED | IF state.json contains zero epics, the page SHALL display an empty state message instead of an empty grid. |
+
+---
+
+### Task 2.2: Epics page — expandable detail
+
+- [x] Click on card expands to show detail section
+- [x] Detail includes: roadmap cycles list with per-cycle status
+- [x] Detail includes: module states list (module name + current state badge)
+- [x] Detail includes: last activity timestamp
+- [x] Collapse on second click or click on different card
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-B4 | EVENT | WHEN a user clicks on an epic card, the system SHALL expand the card to reveal a detail section with roadmap cycles, module states, and last activity. |
+| TW-B5 | EVENT | WHEN a user clicks on an already-expanded card or a different card, the system SHALL collapse the previously expanded detail. |
+| TW-B6 | STATE | WHILE the detail section is expanded, it SHALL display: cycles list with per-cycle status, module names with state badges, and last activity timestamp. |
+
+---
+
+### Task 2.3: Modules page — table grouped by package
+
+- [x] Table with columns: Module, Package, State, EARS count, Score, Last Audit date
+- [x] Rows grouped by package (e.g., @gitgov/core, cli, saas-api)
+- [x] State column uses colored badges matching the 7 state machine states
+- [ ] Sortable by any column
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-B7 | STATE | WHILE the Modules page is rendered, it SHALL display a table with columns: Module, Package, State, EARS count, Score, and Last Audit date. |
+| TW-B8 | STATE | WHILE modules span multiple packages, the table rows SHALL be visually grouped by package name. |
+| TW-B9 | STATE | WHILE a module row is displayed, the State column SHALL use a colored badge matching the 7 state machine states (no_spec through coherent). |
+
+---
+
+### Task 2.4: Modules page — triad triangle SVG
+
+- [x] Reusable SVG component showing a triangle with three vertices: Spec, Code, Tests
+- [x] Triangle filled/highlighted based on triad completeness (which vertices are satisfied)
+- [ ] EARS IDs displayed at each vertex or edge
+- [x] Component receives module data as props (pure, no internal state fetching)
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-B10 | STATE | WHILE a module is selected, the Modules page SHALL display a triad triangle SVG with three vertices: Spec, Code, and Tests. |
+| TW-B11 | STATE | WHILE the triad triangle is rendered, each vertex SHALL be highlighted or dimmed based on whether that aspect (spec, code, tests) exists for the selected module. |
+| TW-B12 | STATE | WHILE the triad triangle is rendered, it SHALL display relevant EARS IDs at each vertex or along each edge. |
+
+---
+
+### Task 2.5: Modules page — EARS traceability list
+
+- [ ] List below the triad triangle showing all EARS for the selected module
+- [ ] Each row: EARS ID, requirement text (from spec), implementation status
+- [ ] Status: implemented (green), pending (yellow), missing (red)
+- [ ] Links to spec file path for each EARS
+
+> **Nota:** Tasks 2.5 items deferred — requires generate-data to include per-module EARS detail (IDs + text). Currently only ears count is available.
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-B13 | STATE | WHILE a module is selected, the Modules page SHALL display an EARS traceability list with: EARS ID, requirement text, and implementation status. |
+| TW-B14 | STATE | WHILE an EARS entry is displayed, its status SHALL be color-coded: green for implemented, yellow for pending, red for missing. |
+
+---
+
+### Task 2.6: Search and filter
+
+- [x] Text search input: filters modules by name (debounced 300ms)
+- [x] State filter: dropdown to filter by module state (includes all 7 states + drift)
+- [x] Package filter: dropdown to filter by package name
+- [ ] Filters persist across page navigation within session
+- [ ] Clear all filters button
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-B15 | EVENT | WHEN a user types in the search input, the system SHALL filter displayed items by name with a 300ms debounce. |
+| TW-B16 | EVENT | WHEN a user selects state or package filter options, the system SHALL immediately filter the displayed list to show only matching items. |
+| TW-B17 | STATE | WHILE filters are active, a "Clear all" button SHALL be visible and SHALL reset all filters when clicked. |
+| TW-B18 | STATE | WHILE the user navigates between Epics and Modules pages, active filters SHALL persist within the session. |
+
+---
+
+### Cycle 2 Dependency Diagram
+
+```mermaid
+graph TD
+    T2_1[2.1 Epics — card grid] --> T2_2[2.2 Epics — expandable detail]
+    T2_3[2.3 Modules — table by package] --> T2_4[2.4 Modules — triad triangle SVG]
+    T2_3 --> T2_5[2.5 Modules — EARS traceability list]
+    T2_4 --> T2_5
+    T2_1 --> T2_6[2.6 Search and filter]
+    T2_3 --> T2_6
+
+    style T2_1 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T2_2 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T2_3 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T2_4 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T2_5 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T2_6 fill:#1a1a2e,stroke:#eab308,color:#fff
+```
+
+### Task 2.7: EARS count en ModuleData + generate-data (no prevista — soporte a modules_view)
+
+> **Nota:** Durante la auditoría de modules_view, se detectó que ModuleData no tenía campo `ears` y el detail panel no podía mostrar EARS count. Se resolvió como soporte desde esta sesión (no el agente de Cycle 2).
+
+- [x] `lib/types.ts`: `ModuleData` ahora tiene `ears: number` (obligatorio)
+- [x] `lib/types.ts`: `interface ModuleData` → `type ModuleData` (convención AGENTS.md)
+- [x] `generate-data.ts`: nueva función `countEars()` parsea spec files buscando `**[PREFIX-X1]**`
+- [x] `generate-data.ts`: GEN-B5 EARS implementado y trazado
+- [x] `generate-data.test.ts`: 2 tests nuevos (count EARS + 0 when missing) — 14/14 passing
+- [x] `generate_data_module.md`: GEN-B5 agregado, spec actualizado a 13/13 🟢
+- [x] `mockData.ts`: 25 módulos con ears reales (39, 18, 14, etc.)
+
+### Task 2.8: modules_view audit + fix (no prevista — cierre de triada)
+
+> **Nota:** Full triada audit (5 auditors) de modules_view detectó 9 findings. Se aplicaron todas las correcciones para cerrar la triada.
+
+- [x] /triad:audit modules_view ejecutado (ears_sequence, ears_coherence, ears_test, coherence, brief_coherence)
+- [x] Fix #1: MOD-D1 debounce 300ms implementado (useEffect + setTimeout)
+- [x] Fix #2: MOD-D2 drift state added to filter dropdown
+- [x] Fix #3: EARS column renders m.ears instead of hardcoded "—"
+- [x] Fix #4: MOD-C3 test for non-coherent module (red/yellow edges)
+- [x] Fix #5: MOD-D1 test with fake timers for debounce verification
+- [x] Fix #6: MOD-A1 test assertions for coherent% and avgScore
+- [x] Fix #7: MOD-B1 test assertions for gold class, badge, EARS count
+- [x] Fix #8: modules_brief.md updated with ears field
+- [x] Fix #9: STATE_ORDER includes drift
+- [x] tsc: 0 errors, tests: 15/15 passing
+
+---
+
+# Cycle 3: Graph + Polish
+
+## Objetivo
+
+Migrar el grafo D3 force-directed del mockup HTML a un componente React reutilizable, extraer shared components de las paginas existentes, refinar routing, y optimizar el build para produccion.
+
+## Modulos a Implementar
+
+| Modulo | Tipo | Descripcion | Dependencias |
+|:-------|:-----|:------------|:-------------|
+| `graph_page` | view | D3 force-directed graph mostrando records y relaciones de `.triad/` state | `generate_data` (state.json graph nodes/edges), D3.js |
+| `shared_components` | module | Shared UI components extraidos: Sidebar, TopBar, StatCard, Badge, ProgressBar | Dashboard, Epics, Modules pages |
+
+---
+
+## Criterios de Aceptacion
+
+### Task 3.1: Graph page — D3 force graph as React component
+
+- [x] D3 force-directed graph rendered inside a React component (useRef + useEffect pattern)
+- [x] Nodes represent: epics (large, gold), modules (medium, state-colored)
+- [x] Edges represent relationships: epic→module (contains, gray), module→module (depends_on, blue arrows), epic→epic (depends_on, orange dashed)
+- [x] Node color indicates state (matching state machine color scheme)
+- [x] Graph responds to container resize (ResizeObserver)
+- [x] Zoom and pan support (D3 zoom behavior)
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-C1 | STATE | WHILE the Graph page is rendered, it SHALL display a D3 force-directed graph with nodes and edges from state.json graph data. |
+| TW-C2 | STATE | WHILE nodes are rendered, epics SHALL be large nodes, modules SHALL be medium nodes, and node color SHALL reflect the module's current state. |
+| TW-C3 | STATE | WHILE the graph container is resized, the graph SHALL responsively adjust to the new dimensions. |
+| TW-C4 | EVENT | WHEN a user scrolls or pinches on the graph, the system SHALL zoom in/out using D3 zoom behavior. WHEN a user drags the background, the system SHALL pan the graph. |
+
+---
+
+### Task 3.2: Graph page — legend with toggles
+
+- [x] Legend panel with categories: Epics, Coherent, In Progress, Pending, Drift, Needs Audit
+- [x] Each category is a clickable toggle (show/hide nodes)
+- [x] Legend updates node count per category
+- [x] Default: all categories visible
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-C5 | STATE | WHILE the Graph page is rendered, it SHALL display a legend panel with categories: Protocol, Audit, and Triad, each showing a node count. |
+| TW-C6 | EVENT | WHEN a user clicks a legend category toggle, the system SHALL hide or show all nodes of that category in the graph. |
+
+---
+
+### Task 3.3: Graph page — detail panel on node click
+
+- [x] Clicking a node opens a side detail panel
+- [x] Detail panel shows: node type, name, state, score, connected nodes, history (if module)
+- [x] Module detail shows: package, EARS count, last audit verdict
+- [x] Panel closes on click outside or close button
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-C7 | EVENT | WHEN a user clicks a graph node, the system SHALL open a detail panel showing the node's type, name, state, related nodes, and history. |
+| TW-C8 | EVENT | WHEN a user clicks outside the detail panel or clicks a close button, the system SHALL close the detail panel. |
+
+---
+
+### Task 3.4: Shared components extraction (reducida — solo violaciones de metodología)
+
+> **Nota:** Auditoria contra frontend_methodology.md detecto 3 violaciones: App.tsx no es thin (Sidebar/TopBar inline), EmptyState duplicado en 3 views. Se reduce scope a lo necesario.
+
+- [ ] Extract `Sidebar` from App.tsx → `shared/Sidebar.tsx`
+- [ ] Extract `TopBar` from App.tsx → `shared/TopBar.tsx`
+- [ ] Extract `EmptyState` (duplicado en Dashboard, Modules, Graph) → `shared/EmptyState.tsx`
+- [ ] Refactor App.tsx to be thin: import Sidebar + TopBar, only compose views
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-C9 | STATE | WHILE shared components are defined, Sidebar, TopBar, StatCard, Badge, and ProgressBar SHALL each be importable from `components/shared/`. |
+| TW-C10 | STATE | WHILE the Dashboard, Epics, and Modules pages are rendered, they SHALL use the shared components instead of inline implementations. |
+
+---
+
+### Task 3.5: React Router integration — CANCELADA
+
+> **Nota:** Auditoria de metodologia confirmo que state-based toggle es suficiente para 4 paginas sin deep linking ni URL params. React Router agrega complejidad sin valor. Sidebar ya highlight active page via state. Decision registrada como A9 en overview.md.
+
+---
+
+### Task 3.6: Build optimization + documentation (reducida)
+
+- [ ] README in `web/` documenting: setup, development, build, architecture
+- [ ] Verify `npm run build` produces working dist/
+- [ ] DashboardView.test.tsx — tests pendientes desde Cycle 1 (gap detectado en auditoria)
+
+**EARS — Requisitos Formales:**
+
+| ID | Tipo | Requisito |
+|:---|:-----|:----------|
+| TW-C14 | STATE | WHILE a production build is created, the output SHALL use Vite tree-shaking and code splitting to minimize bundle size. |
+| TW-C15 | EVENT | WHEN `npm run preview` is executed, the system SHALL serve the production build from `dist/` on a local port. |
+
+---
+
+### Task 3.7: Typed edges + drift detection (no prevista — relationship model)
+
+> **Nota:** Investigacion con 5 agentes sobre modelado de relaciones. Se diseño edges.json (Option B), drift detection git-native, y nextAction recommendations. Extiende generate_data de 13 a 17 EARS.
+
+- [x] Investigacion: 5 agentes analizaron OpenAPI, SPDX, Backstage, Terraform, GraphQL
+- [x] Diseño: edges.json con prefijos mod:/epic: (extensible a gitgov:)
+- [x] `types.ts`: GraphEdge type, needsAudit + nextAction en ModuleData, edges en TriadWebData
+- [x] `generate-data.ts`: readEdges() (GEN-B6), buildDriftSet() + checkTriadDrift() (GEN-B7), deriveEpicEdges() (GEN-B8), computeNextAction() (GEN-B9)
+- [x] `GraphView.tsx`: flechas azules (module deps), naranjas punteadas (epic deps), halos rojos (needsAudit), legend "Needs Audit"
+- [x] `graph_brief.md` actualizado con edge types + needsAudit
+- [x] `graph_view.md`: 3 EARS nuevos (GRF-F1 to F3) — typed edges + halo
+- [x] `mockData.ts`: corregido (ears field inside objects) + edges + needsAudit
+- [x] `index.html` creado (faltaba en worktree)
+- [x] tsc clean, 74/74 tests
+
+### Task 3.8: refresh_hook expandido a triada files (no prevista — auto-refresh)
+
+> **Nota:** El hook solo detectaba cambios en .triad/state/. Se expandio para detectar ediciones a specs, src, y scripts — permitiendo que el grafo se actualice al editar cualquier archivo de triada.
+
+- [x] `refresh-hook.ts`: isTriadStatePath() → isTriadRelevantPath() (specs/*.md, src/*.ts(x), scripts/*.ts)
+- [x] `refresh-hook.test.ts`: tests actualizados (RFSH-A1, RFSH-A2)
+- [x] `refresh_hook_module.md`: spec actualizado con nuevos triggers
+
+### Task 3.9: git_hook module — triada completa (no prevista — ediciones IDE)
+
+> **Nota:** PostToolUse hook solo funciona en Claude Code. Para ediciones manuales en IDE se necesitaba un git pre-commit hook. Se creo spec, implemento, audito (5 findings), y fixeo (4 tests reescritos a E2E).
+
+- [x] Spec: specs/modules/git_hook/git_hook_module.md (8 EARS, 6 secciones module_designer)
+- [x] Impl: scripts/install-git-hook.ts (install/uninstall/isInstalled + shell template)
+- [x] Tests: scripts/install-git-hook.test.ts (8 tests, 4 E2E reales en tmpdir)
+- [x] Audit: 4 core auditors, 5 findings
+- [x] Fix: 4 tests reescritos de template-grep a E2E behavioral + spec actualizado
+- [x] Verificado: tsc clean, 74/74 tests
+
+### Task 3.10: Rebase sobre triad_state_machine (no prevista — dependencia externa)
+
+> **Nota:** PR #9 depende de `listModules()` implementado por otro agente en la epic triad_state_machine. No se puede mergear hasta que esos cambios estén en main.
+
+> **BLOQUEADO:** Esperando merge de triad_state_machine PR con `listModules()`.
+
+- [ ] Merge de triad_state_machine a main (otro agente)
+- [ ] Rebase epic/triad-web-c2 sobre main actualizado
+- [ ] Resolver conflictos si hay (hooks/src/state_manager/ puede tener overlap)
+- [ ] Verificar tsc + tests post-rebase
+- [ ] Push --force-with-lease al PR #9
+- [ ] Merge PR #9
+
+### Cycle 3 Dependency Diagram
+
+```mermaid
+graph TD
+    T3_1[3.1 Graph — D3 force graph] --> T3_2[3.2 Graph — legend toggles]
+    T3_1 --> T3_3[3.3 Graph — detail panel]
+    T3_2 --> T3_3
+    T3_4[3.4 Shared components extraction] --> T3_5[3.5 Router integration]
+    T3_5 --> T3_6[3.6 Build optimization + README]
+    T3_3 --> T3_6
+
+    style T3_1 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T3_2 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T3_3 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T3_4 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T3_5 fill:#1a1a2e,stroke:#eab308,color:#fff
+    style T3_6 fill:#1a1a2e,stroke:#eab308,color:#fff
+```
+
+---
+
+## EARS Summary
+
+| Cycle | Prefix | Count | Range |
+|---:|---|---:|---|
+| 1 | TW-A | 22 | TW-A1 to TW-A22 |
+| 2 | TW-B | 18 | TW-B1 to TW-B18 |
+| 3 | TW-C | 15 | TW-C1 to TW-C15 |
+| **Total** | | **55** | |
+
+---
+
+## Referencias
+
+- [Epic Input](./inputs/epic_input.md) — Problem statement, architecture, tech stack
+- [Conversation Context](./inputs/conversation_context.md) — Design session decisions, schemas, mockup reference
+- Mockup reference: `packages/claude-plugins/plugins/triad/index.html` (12 pages, visual spec)
+- Brand guide: `packages/private/packages/blueprints/03_product/triad/brand_guide.md`
+- Prerequisite: `triad_state_machine` Cycle 5 (`getEpicSummary()`)
+
+---
+
+**Ultima actualizacion:** 2026-04-08 — Cycle 3 🟡 en progreso. Tasks 3.1-3.9 completadas + 3.4/3.6 done. Task 3.5 cancelada (Router innecesario). parseEars() reemplaza countEars(), sidebar layouts en Modules y Epics, shared components extraidos. PR #9 creado — bloqueado por merge de triad_state_machine (listModules). 81 tests, 91KB build. Pendiente: rebase sobre main tras merge de state_machine.


### PR DESCRIPTION
## Summary

- `.triad/config.json` + `.triad/state.json` — state machine config and epic registry
- `.triad/state/triad_state_machine/` — 7 module state files (all coherent, score 95)
- `.triad/state/triad_web/` — 2 module state files (generate_data coherent, dashboard_view implemented)
- `specs/epics/triad_web/` — overview, roadmap (3 cycles), implementation_plan, inputs, rewinds
- `specs/epics/triad_indexer/input.md` — future epic input (2-layer indexer design)

## Test plan

- [x] `generate-data.ts` reads these files and produces valid state.json (verified with Playwright)
- [x] Triad Web dashboard renders 2 epics, 9 modules from real data
- [x] Graph shows force-directed layout with real containment edges