### PR TITLE
feat(core): KeyProvider.sign() and key lifecycle improvements

### DIFF
--- a/packages/cli/src/services/dependency-injection.test.ts
+++ b/packages/cli/src/services/dependency-injection.test.ts
@@ -296,25 +296,28 @@ jest.doMock('@gitgov/core', () => {
     // 🎭 MOCK KEY PROVIDER: Mock key storage operations
     KeyProvider: {
       FsKeyProvider: jest.fn().mockImplementation(() => ({
+        sign: jest.fn().mockResolvedValue(new Uint8Array(64)),
         getPrivateKey: jest.fn().mockResolvedValue('mock-private-key-base64'),
         setPrivateKey: jest.fn().mockResolvedValue(undefined),
         hasPrivateKey: jest.fn().mockResolvedValue(true),
         deletePrivateKey: jest.fn().mockResolvedValue(true)
       })),
       EnvKeyProvider: jest.fn().mockImplementation(() => ({
+        sign: jest.fn().mockResolvedValue(new Uint8Array(64)),
         getPrivateKey: jest.fn().mockResolvedValue('mock-private-key-base64'),
         setPrivateKey: jest.fn().mockResolvedValue(undefined),
         hasPrivateKey: jest.fn().mockResolvedValue(true),
         deletePrivateKey: jest.fn().mockResolvedValue(true)
       })),
       MockKeyProvider: jest.fn().mockImplementation(() => ({
+        sign: jest.fn().mockResolvedValue(new Uint8Array(64)),
         getPrivateKey: jest.fn().mockResolvedValue('mock-private-key-base64'),
         setPrivateKey: jest.fn().mockResolvedValue(undefined),
         hasPrivateKey: jest.fn().mockResolvedValue(true),
         deletePrivateKey: jest.fn().mockResolvedValue(true)
       })),
       KeyProviderError: class KeyProviderError extends Error {
-        constructor(message: string, public code: string, public actorId?: string) {
+        constructor(message: string, public code: string, public context: Record<string, unknown> = {}) {
           super(message);
           this.name = 'KeyProviderError';
         }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -300,7 +300,7 @@ Adapters are orchestrators that compose modules. All receive dependencies via co
 | `hook_handler/` | Hook event handling for agent triggers |
 | `git/` | `IGitModule` interface + local/memory implementations |
 | `crypto/` | Checksums, digital signatures, verification |
-| `key_provider/` | Key storage abstraction (fs/memory) |
+| `key_provider/` | Key signing and storage abstraction (fs/env/memory/prisma) |
 | `file_lister/` | File listing abstraction (fs/memory) |
 | `lint/` | Structural + referential validation |
 | `event_bus/` | Typed pub/sub with 9 event types |

--- a/packages/core/src/adapters/agent_adapter/agent_adapter.test.ts
+++ b/packages/core/src/adapters/agent_adapter/agent_adapter.test.ts
@@ -101,6 +101,7 @@ describe('AgentAdapter', () => {
 
     // Mock key provider
     mockKeyProvider = {
+      sign: jest.fn().mockResolvedValue(new Uint8Array(64)),
       getPrivateKey: jest.fn().mockResolvedValue('mock-private-key'),
       setPrivateKey: jest.fn().mockResolvedValue(undefined),
       deletePrivateKey: jest.fn().mockResolvedValue(undefined),

--- a/packages/core/src/adapters/backlog_adapter/backlog_adapter.integration.test.ts
+++ b/packages/core/src/adapters/backlog_adapter/backlog_adapter.integration.test.ts
@@ -186,6 +186,7 @@ describe.each(backends)('BacklogAdapter Integration Tests with %s backend', (_na
 
     // Create mock KeyProvider for integration test
     const mockKeyProvider = {
+      sign: jest.fn().mockResolvedValue(new Uint8Array(64)),
       getPrivateKey: jest.fn().mockResolvedValue('mock-private-key'),
       setPrivateKey: jest.fn().mockResolvedValue(undefined),
       hasPrivateKey: jest.fn().mockResolvedValue(true),

--- a/packages/core/src/adapters/backlog_adapter/backlog_adapter.integration.test.ts
+++ b/packages/core/src/adapters/backlog_adapter/backlog_adapter.integration.test.ts
@@ -188,6 +188,7 @@ describe.each(backends)('BacklogAdapter Integration Tests with %s backend', (_na
     const mockKeyProvider = {
       sign: jest.fn().mockResolvedValue(new Uint8Array(64)),
       getPrivateKey: jest.fn().mockResolvedValue('mock-private-key'),
+      getPublicKey: jest.fn().mockResolvedValue('mock-public-key'),
       setPrivateKey: jest.fn().mockResolvedValue(undefined),
       hasPrivateKey: jest.fn().mockResolvedValue(true),
       deletePrivateKey: jest.fn().mockResolvedValue(true),

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
@@ -3,7 +3,8 @@ import type { ActorRecord, GitGovRecord, GitGovActorRecord } from '../../record_
 import type { RecordStore } from '../../record_store/record_store';
 import { createActorRecord } from '../../record_factories/actor_factory';
 import { validateFullActorRecord } from '../../record_validations/actor_validator';
-import { generateKeys, signPayload, generateMockSignature } from '../../crypto/signatures';
+import { generateKeys, signPayload } from '../../crypto/signatures';
+import { KeyProviderError } from '../../key_provider/key_provider';
 import { calculatePayloadChecksum } from '../../crypto/checksum';
 import { generateActorId } from '../../utils/id_generator';
 import type { ISessionManager } from '../../session_manager';
@@ -19,6 +20,7 @@ import type { KeyProvider } from '../../key_provider/key_provider';
 
 // Mock KeyProvider
 interface MockKeyProvider extends KeyProvider {
+  sign: jest.MockedFunction<(actorId: string, data: Uint8Array) => Promise<Uint8Array>>;
   getPrivateKey: jest.MockedFunction<(actorId: string) => Promise<string | null>>;
   setPrivateKey: jest.MockedFunction<(actorId: string, key: string) => Promise<void>>;
   hasPrivateKey: jest.MockedFunction<(actorId: string) => Promise<boolean>>;
@@ -28,7 +30,6 @@ const mockedCreateActorRecord = createActorRecord as jest.MockedFunction<typeof 
 const mockedValidateFullActorRecord = validateFullActorRecord as jest.MockedFunction<typeof validateFullActorRecord>;
 const mockedGenerateKeys = generateKeys as jest.MockedFunction<typeof generateKeys>;
 const mockedSignPayload = signPayload as jest.MockedFunction<typeof signPayload>;
-const mockedGenerateMockSignature = generateMockSignature as jest.MockedFunction<typeof generateMockSignature>;
 const mockedCalculatePayloadChecksum = calculatePayloadChecksum as jest.MockedFunction<typeof calculatePayloadChecksum>;
 const mockedGenerateActorId = generateActorId as jest.MockedFunction<typeof generateActorId>;
 
@@ -77,6 +78,7 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
 
     // Create mock KeyProvider
     mockKeyProvider = {
+      sign: jest.fn().mockResolvedValue(new Uint8Array(64)),
       getPrivateKey: jest.fn().mockResolvedValue('mock-private-key'),
       setPrivateKey: jest.fn().mockResolvedValue(undefined),
       hasPrivateKey: jest.fn().mockResolvedValue(true),
@@ -120,8 +122,6 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
       eventBus: mockEventBus,
     });
 
-    // Mock generateMockSignature to return valid Ed25519-like signature (64 bytes = 86 chars + ==)
-    mockedGenerateMockSignature.mockReturnValue('oro1j+DqU3XtJrkW4eNqP4gXqHtygAgSaRfuBuW19YAxAAR083ktaWpSBJk4AIof13gO3butj5L4n30XTn+Spg==');
   });
 
   const sampleActorPayload: ActorRecord = {
@@ -322,7 +322,7 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
   });
 
   describe('signRecord', () => {
-    it('[EARS-E1] should sign record with real cryptographic signature when private key is available', async () => {
+    it('[EARS-E1] should delegate signing to keyProvider.sign() producing Ed25519 signature', async () => {
       const mockRecord: GitGovRecord = {
         header: {
           version: '1.0',
@@ -336,53 +336,40 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
             timestamp: 1234567890
           }]
         },
-        payload: sampleActorPayload // Use valid ActorRecord payload
+        payload: sampleActorPayload
       };
-
-      const testPrivateKey = 'test-private-key-base64';
 
       // Mock actor exists
       mockActorStore.get.mockResolvedValue(sampleRecord);
-
-      // Mock KeyProvider to return private key
-      mockKeyProvider.getPrivateKey.mockResolvedValue(testPrivateKey);
-
-      // Mock signPayload to return real signature
-      mockedSignPayload.mockReturnValue({
-        keyId: 'human:test-user',
-        role: 'author',
-        notes: 'Record signed',
-        signature: 'real-cryptographic-signature',
-        timestamp: Math.floor(Date.now() / 1000)
-      });
       mockedCalculatePayloadChecksum.mockReturnValue('calculated-checksum');
+
+      // [EARS-E1] Mock keyProvider.sign() to return signature bytes
+      const fakeSignatureBytes = new Uint8Array(64).fill(42);
+      mockKeyProvider.sign.mockResolvedValue(fakeSignatureBytes);
 
       const signedRecord = await identityAdapter.signRecord(mockRecord, 'human:test-user', 'author', 'Record signed');
 
       // Should have 2 signatures: original + new real signature
       expect(signedRecord.header.signatures).toHaveLength(2);
 
-      // Check the new signature (second one) - should be real, not mock
+      // [IKS-B7] Verify keyProvider.sign() was called (not getPrivateKey + signPayload)
+      expect(mockKeyProvider.sign).toHaveBeenCalledWith(
+        'human:test-user',
+        expect.any(Uint8Array) // SHA-256 digest hash
+      );
+      expect(mockKeyProvider.getPrivateKey).not.toHaveBeenCalled();
+
+      // Check the new signature
       const newSignature = signedRecord.header.signatures[1];
       expect(newSignature).toBeDefined();
       expect(newSignature!.keyId).toBe('human:test-user');
       expect(newSignature!.role).toBe('author');
-      expect(newSignature!.signature).toBe('real-cryptographic-signature');
-      expect(newSignature!.signature).not.toContain('mock-signature-');
+      expect(newSignature!.notes).toBe('Record signed');
+      expect(newSignature!.signature).toBe(Buffer.from(fakeSignatureBytes).toString('base64'));
       expect(newSignature!.timestamp).toBeGreaterThan(0);
-
-      // Verify private key was loaded via KeyProvider
-      expect(mockKeyProvider.getPrivateKey).toHaveBeenCalledWith('human:test-user');
-      expect(mockedSignPayload).toHaveBeenCalledWith(
-        sampleActorPayload,
-        testPrivateKey,
-        'human:test-user',
-        'author',
-        'Record signed'
-      );
     });
 
-    it('[EARS-E2] should sign record with mock signature as fallback when private key is not available', async () => {
+    it('[EARS-E2] should throw KeyProviderError when no private key exists', async () => {
       const mockRecord: GitGovRecord = {
         header: {
           version: '1.0',
@@ -396,35 +383,27 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
             timestamp: 1234567890
           }]
         },
-        payload: sampleActorPayload // Use valid ActorRecord payload
+        payload: sampleActorPayload
       };
 
       // Mock actor exists
       mockActorStore.get.mockResolvedValue(sampleRecord);
+      mockedCalculatePayloadChecksum.mockReturnValue('calculated-checksum');
 
-      // Mock KeyProvider to return null (no private key)
-      mockKeyProvider.getPrivateKey.mockResolvedValue(null);
+      // [EARS-E2] [IKS-B6] keyProvider.sign() throws KEY_NOT_FOUND
+      mockKeyProvider.sign.mockRejectedValue(
+        new KeyProviderError(
+          'Private key not found for human:test-user',
+          'KEY_NOT_FOUND',
+          { actorId: 'human:test-user', hint: 'Run gitgov init or gitgov login to configure keys' }
+        )
+      );
 
-      // Suppress console.warn for tests
-      const originalWarn = console.warn;
-      console.warn = jest.fn();
-
-      const signedRecord = await identityAdapter.signRecord(mockRecord, 'human:test-user', 'author', 'Record signed');
-
-      // Should have 2 signatures: original + new mock signature
-      expect(signedRecord.header.signatures).toHaveLength(2);
-
-      // Check the new signature (second one) - should be mock
-      const newSignature = signedRecord.header.signatures[1];
-      expect(newSignature).toBeDefined();
-      expect(newSignature!.keyId).toBe('human:test-user');
-      expect(newSignature!.role).toBe('author');
-      // Mock signature should be valid base64 Ed25519 format (86 chars + ==)
-      expect(newSignature!.signature).toMatch(/^[A-Za-z0-9+/]{86}==$/);
-      expect(newSignature!.timestamp).toBeGreaterThan(0);
-
-      // Restore console.warn
-      console.warn = originalWarn;
+      // [IKS-B2] signRecord NEVER generates mock signature — throws
+      await expect(identityAdapter.signRecord(mockRecord, 'human:test-user', 'author', 'Record signed'))
+        .rejects.toThrow(KeyProviderError);
+      await expect(identityAdapter.signRecord(mockRecord, 'human:test-user', 'author', 'Record signed'))
+        .rejects.toMatchObject({ code: 'KEY_NOT_FOUND', context: { actorId: 'human:test-user' } });
     });
 
     it('[EARS-E3] should throw error when actor not found', async () => {
@@ -469,13 +448,11 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
 
       // Mock actor exists
       mockActorStore.get.mockResolvedValue(sampleRecord);
+      mockedCalculatePayloadChecksum.mockReturnValue('calculated-checksum');
 
-      // Mock KeyProvider to return null (no private key) - will use mock signature
-      mockKeyProvider.getPrivateKey.mockResolvedValue(null);
-
-      // Suppress console.warn for tests
-      const originalWarn = console.warn;
-      console.warn = jest.fn();
+      // [EARS-E4] keyProvider.sign() returns real signature bytes
+      const fakeSignatureBytes = new Uint8Array(64).fill(7);
+      mockKeyProvider.sign.mockResolvedValue(fakeSignatureBytes);
 
       const signedRecord = await identityAdapter.signRecord(mockRecord, 'human:test-user', 'author', 'Placeholder replacement');
 
@@ -488,12 +465,8 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
       expect(finalSignature!.keyId).toBe('human:test-user');
       expect(finalSignature!.role).toBe('author');
       expect(finalSignature!.signature).not.toBe('placeholder');
-      // Mock signature should be valid base64 Ed25519 format (86 chars + ==)
-      expect(finalSignature!.signature).toMatch(/^[A-Za-z0-9+/]{86}==$/);
+      expect(finalSignature!.signature).toBe(Buffer.from(fakeSignatureBytes).toString('base64'));
       expect(finalSignature!.timestamp).toBeGreaterThan(0);
-
-      // Restore console.warn
-      console.warn = originalWarn;
     });
   });
 

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
@@ -80,6 +80,7 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
     mockKeyProvider = {
       sign: jest.fn().mockResolvedValue(new Uint8Array(64)),
       getPrivateKey: jest.fn().mockResolvedValue('mock-private-key'),
+      getPublicKey: jest.fn().mockResolvedValue('mock-public-key'),
       setPrivateKey: jest.fn().mockResolvedValue(undefined),
       hasPrivateKey: jest.fn().mockResolvedValue(true),
       deletePrivateKey: jest.fn().mockResolvedValue(true),

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.ts
@@ -16,7 +16,8 @@ import type { IIdentityAdapter, IdentityAdapterDependencies } from './identity_a
 
 import { createActorRecord } from '../../record_factories/actor_factory';
 import { validateFullActorRecord } from '../../record_validations/actor_validator';
-import { generateKeys, signPayload, generateMockSignature } from '../../crypto/signatures';
+import { generateKeys, signPayload } from '../../crypto/signatures';
+import { createHash } from 'crypto';
 import { calculatePayloadChecksum } from '../../crypto/checksum';
 import { generateActorId } from '../../utils/id_generator';
 import type { ISessionManager } from '../../session_manager';
@@ -162,61 +163,46 @@ export class IdentityAdapter implements IIdentityAdapter {
     role: string,
     notes: string
   ): Promise<T> {
-    // Verify actor exists
+    // [EARS-E3] Verify actor exists
     const actor = await this.getActor(actorId);
     if (!actor) {
       throw new Error(`Actor not found: ${actorId}`);
     }
 
-    // Calculate payload checksum (real)
+    // [EARS-E1] Calculate payload checksum and build digest
     const payloadChecksum = calculatePayloadChecksum(record.payload);
+    const timestamp = Math.floor(Date.now() / 1000);
+    const digest = `${payloadChecksum}:${actorId}:${role}:${notes}:${timestamp}`;
+    const digestHash = createHash('sha256').update(digest).digest();
 
-    // Try to load private key via KeyProvider for real signing
-    let privateKey: string | null = null;
-    try {
-      privateKey = await this.keyProvider.getPrivateKey(actorId);
-    } catch (error) {
-      // Private key not found - fallback to mock signature for backward compatibility
-      console.warn(`⚠️  Private key not found for ${actorId}, using mock signature`);
-    }
+    // [EARS-E1] [IKS-B7] Delegate signing to keyProvider.sign() — NOT getPrivateKey() + signPayload()
+    // [EARS-E2] [IKS-B6] sign() throws KeyProviderError('KEY_NOT_FOUND') if no key exists
+    const signatureBytes = await this.keyProvider.sign(actorId, new Uint8Array(digestHash));
 
-    // Create signature (real if private key available, mock otherwise)
-    let signature: Signature;
-    if (privateKey) {
-      // Real cryptographic signing
-      signature = signPayload(record.payload, privateKey, actorId, role, notes);
-    } else {
-      // Fallback to mock signature for backward compatibility
-      signature = {
-        keyId: actorId,
-        role: role,
-        notes: notes,
-        signature: generateMockSignature(),
-        timestamp: Math.floor(Date.now() / 1000)
-      };
-    }
+    const signature: Signature = {
+      keyId: actorId,
+      role,
+      notes,
+      signature: Buffer.from(signatureBytes).toString('base64'),
+      timestamp,
+    };
 
-    // Replace placeholder signatures or add new signature if no placeholders exist
+    // [EARS-E4] Replace placeholder signatures or add new signature
     const existingSignatures = record.header.signatures || [];
     const hasPlaceholder = existingSignatures.some(sig => sig.signature === 'placeholder');
 
     let finalSignatures: [Signature, ...Signature[]];
     if (hasPlaceholder) {
-      // Replace placeholder signatures with the real signature
       const replaced = existingSignatures.map(sig =>
         sig.signature === 'placeholder' ? signature : sig
       );
-      // Ensure at least one signature (should always be true after replacement)
       finalSignatures = replaced.length > 0
         ? replaced as [Signature, ...Signature[]]
         : [signature];
     } else {
-      // No placeholders: append new signature (multi-signature scenario)
       finalSignatures = [...existingSignatures, signature] as [Signature, ...Signature[]];
     }
 
-    // Create signed record with real checksum + signature
-    // Type assertion safe: we only modify header, payload type T is preserved
     const signedRecord = {
       ...record,
       header: {

--- a/packages/core/src/audit/audit_types.test.ts
+++ b/packages/core/src/audit/audit_types.test.ts
@@ -12,17 +12,9 @@ import * as path from 'path';
 import type {
   Finding,
   FindingSeverity,
-  FindingCategory,
-  DetectorName,
   Waiver,
-  WaiverMetadata,
   PolicyDecision,
-  PolicyRuleResult,
   Scan,
-  AuditOrchestrationResult,
-  AuditSummary,
-  AgentAuditResult,
-  ReviewAgentResult,
 } from './types';
 
 // ─── Schema Parser ──────────────────────────────────────────────────────────
@@ -47,7 +39,7 @@ function parsePrismaSchema(schemaPath: string): PrismaModel[] {
   for (const line of content.split('\n')) {
     const modelMatch = line.match(/^model\s+(\w+)\s*\{/);
     if (modelMatch) {
-      currentModel = { name: modelMatch[1], fields: [] };
+      currentModel = { name: modelMatch[1]!, fields: [] };
       continue;
     }
 
@@ -60,8 +52,8 @@ function parsePrismaSchema(schemaPath: string): PrismaModel[] {
     if (currentModel) {
       const fieldMatch = line.match(/^\s+(\w+)\s+([\w[\]?]+)/);
       if (fieldMatch && !line.trim().startsWith('//') && !line.trim().startsWith('@@')) {
-        const name = fieldMatch[1];
-        const rawType = fieldMatch[2];
+        const name = fieldMatch[1]!;
+        const rawType = fieldMatch[2]!;
         if (rawType.match(/^[A-Z]/) && !['String', 'Int', 'Float', 'Boolean', 'DateTime', 'Json', 'BigInt', 'Decimal', 'Bytes'].includes(rawType.replace('?', '').replace('[]', ''))) {
           const knownEnums = ['FindingSeverity', 'FindingCategory', 'DetectorName'];
           if (!knownEnums.includes(rawType.replace('?', '').replace('[]', ''))) {
@@ -160,7 +152,7 @@ describe('Audit Record Types (audit_record_types_module.md)', () => {
       expect(finding.reportedBy).toBeDefined();
       expect(typeof finding.isWaived).toBe('boolean');
       // Optional fields compile without error
-      const withOptionals: Finding = { ...finding, column: 5, snippet: 'code', fixes: [{ description: 'fix' }], legalReference: 'GDPR', waiver: undefined };
+      const withOptionals: Finding = { ...finding, column: 5, snippet: 'code', fixes: [{ description: 'fix' }], legalReference: 'GDPR' };
       expect(withOptionals.column).toBe(5);
     });
 
@@ -177,7 +169,7 @@ describe('Audit Record Types (audit_record_types_module.md)', () => {
         fingerprint: 'sha256:test',
         ruleId: 'SEC-001',
         feedback: {
-          header: { version: '1.0', type: 'feedback', payloadChecksum: 'sha256:mock', signatures: [] },
+          header: { version: '1.0', type: 'feedback', payloadChecksum: 'sha256:mock', signatures: [{ keyId: 'human:test', role: 'approver', notes: '', signature: 'mock', timestamp: 1700000000 }] },
           payload: {
             id: '1700000000-feedback-test',
             entityType: 'execution',

--- a/packages/core/src/crypto/checksum.test.ts
+++ b/packages/core/src/crypto/checksum.test.ts
@@ -1,15 +1,68 @@
-import { sha256 } from "./checksum";
+import { sha256, calculatePayloadChecksum } from "./checksum";
+import type { TaskRecord } from "../record_types";
 
-describe("sha256", () => {
-  it("[EARS-7] sha256 should return 64-character lowercase hex digest", () => {
-    const result = sha256("test input");
-    expect(result).toHaveLength(64);
-    expect(result).toMatch(/^[0-9a-f]{64}$/);
+describe("checksum", () => {
+  describe("4.1. sha256 (EARS-7 to EARS-8)", () => {
+    it("[EARS-7] sha256 should return 64-character lowercase hex digest", () => {
+      const result = sha256("test input");
+      expect(result).toHaveLength(64);
+      expect(result).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("[EARS-8] sha256 should be deterministic (same input same output)", () => {
+      const a = sha256("hello world");
+      const b = sha256("hello world");
+      expect(a).toBe(b);
+    });
   });
 
-  it("[EARS-8] sha256 should be deterministic (same input same output)", () => {
-    const a = sha256("hello world");
-    const b = sha256("hello world");
-    expect(a).toBe(b);
+  describe("4.2. calculatePayloadChecksum (EARS-1)", () => {
+    it("[EARS-1] should return same checksum when TaskRecord fields are in different order", () => {
+      // Same logical TaskRecord with different declaration order → canonicalization
+      // must produce identical checksums (keys sorted alphabetically before hashing).
+      const payloadA: TaskRecord = {
+        id: '1000000000-task-test',
+        title: 'Hello',
+        status: 'draft',
+        priority: 'medium',
+        description: 'Sample task',
+        tags: ['a', 'b'],
+      };
+      const payloadB: TaskRecord = {
+        tags: ['a', 'b'],
+        description: 'Sample task',
+        priority: 'medium',
+        status: 'draft',
+        title: 'Hello',
+        id: '1000000000-task-test',
+      };
+      const checksumA = calculatePayloadChecksum(payloadA);
+      const checksumB = calculatePayloadChecksum(payloadB);
+      expect(checksumA).toBe(checksumB);
+      expect(checksumA).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("[EARS-1] should return same checksum for nested fields in different order", () => {
+      // Nested objects also must be canonicalized (recursive key sort).
+      const payloadA: TaskRecord = {
+        id: '1000000000-task-nested',
+        title: 'Nested',
+        status: 'draft',
+        priority: 'high',
+        description: 'with metadata',
+        tags: ['a', 'b'],
+        references: ['ref:1', 'ref:2'],
+      };
+      const payloadB: TaskRecord = {
+        references: ['ref:1', 'ref:2'],
+        tags: ['a', 'b'],
+        description: 'with metadata',
+        priority: 'high',
+        status: 'draft',
+        title: 'Nested',
+        id: '1000000000-task-nested',
+      };
+      expect(calculatePayloadChecksum(payloadA)).toBe(calculatePayloadChecksum(payloadB));
+    });
   });
 });

--- a/packages/core/src/crypto/checksum.test.ts
+++ b/packages/core/src/crypto/checksum.test.ts
@@ -1,13 +1,13 @@
 import { sha256 } from "./checksum";
 
 describe("sha256", () => {
-  it("[EARS-8] sha256 should return 64-character lowercase hex digest", () => {
+  it("[EARS-7] sha256 should return 64-character lowercase hex digest", () => {
     const result = sha256("test input");
     expect(result).toHaveLength(64);
     expect(result).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it("[EARS-9] sha256 should be deterministic (same input same output)", () => {
+  it("[EARS-8] sha256 should be deterministic (same input same output)", () => {
     const a = sha256("hello world");
     const b = sha256("hello world");
     expect(a).toBe(b);

--- a/packages/core/src/crypto/checksum.ts
+++ b/packages/core/src/crypto/checksum.ts
@@ -42,8 +42,8 @@ export function calculatePayloadChecksum(payload: GitGovRecordPayload): string {
 
 /**
  * Computes SHA-256 hex digest of a string input.
- * EARS-8: returns 64-character lowercase hex string.
- * EARS-9: deterministic (same input → same output).
+ * EARS-7: returns 64-character lowercase hex string.
+ * EARS-8: deterministic (same input → same output).
  */
 export function sha256(input: string): string {
   return createHash("sha256").update(input, "utf8").digest("hex");

--- a/packages/core/src/crypto/signatures.test.ts
+++ b/packages/core/src/crypto/signatures.test.ts
@@ -1,4 +1,4 @@
-import { generateKeys, signPayload, verifySignatures, generateMockSignature } from './signatures';
+import { generateKeys, signPayload, verifySignatures } from './signatures';
 import type { GitGovRecord, GitGovRecordPayload, GitGovRecordType } from '../record_types';
 import type { ActorRecord } from '../record_types';
 import type { AgentRecord } from '../record_types';
@@ -355,23 +355,4 @@ describe('Crypto Module (Signatures)', () => {
     });
   });
 
-  describe('Mock Signature Generation', () => {
-    it('[EARS-7] should generate a valid base64 string of 64 bytes', () => {
-      const mockSig = generateMockSignature();
-
-      // Should be valid base64
-      expect(() => Buffer.from(mockSig, 'base64')).not.toThrow();
-
-      // Should decode to exactly 64 bytes (Ed25519 signature length)
-      const decoded = Buffer.from(mockSig, 'base64');
-      expect(decoded.length).toBe(64);
-    });
-
-    it('[EARS-7] should generate unique signatures on each call', () => {
-      const sig1 = generateMockSignature();
-      const sig2 = generateMockSignature();
-
-      expect(sig1).not.toBe(sig2);
-    });
-  });
 });

--- a/packages/core/src/crypto/signatures.test.ts
+++ b/packages/core/src/crypto/signatures.test.ts
@@ -1,4 +1,4 @@
-import { generateKeys, signPayload, verifySignatures } from './signatures';
+import { generateKeys, signPayload, verifySignatures, derivePublicKey } from './signatures';
 import type { GitGovRecord, GitGovRecordPayload, GitGovRecordType } from '../record_types';
 import type { ActorRecord } from '../record_types';
 import type { AgentRecord } from '../record_types';
@@ -352,6 +352,42 @@ describe('Crypto Module (Signatures)', () => {
         payload: feedbackPayload,
       } as GitGovRecord;
       await expect(verifySignatures(record, getActorPublicKey)).resolves.toBe(false);
+    });
+  });
+
+  describe('4.3. derivePublicKey (EARS-9)', () => {
+    it('[EARS-9] should derive public key matching generateKeys() output', async () => {
+      // Generate a keypair and derive its public key from the private key.
+      // The derived public key must match the one generateKeys() returned directly.
+      const { publicKey, privateKey } = await generateKeys();
+      const derived = derivePublicKey(privateKey);
+      expect(derived).toBe(publicKey);
+      expect(derived).toHaveLength(44); // base64 of 32 raw bytes
+    });
+
+    it('[EARS-9] should produce a public key that verifies signatures made with its matching private key', async () => {
+      // Sanity check: derived public key must successfully verify a signature
+      // created with the original private key. This is the contract that KeyProvider.getPublicKey() relies on.
+      const { privateKey } = await generateKeys();
+      const derivedPublicKey = derivePublicKey(privateKey);
+
+      const samplePayload: GitGovRecordPayload = { id: 'task:sample', title: 'sample' } as unknown as GitGovRecordPayload;
+      const sig = signPayload(samplePayload, privateKey, 'actor:test', 'author', 'unit-test');
+
+      const record = {
+        header: {
+          version: '1.0',
+          type: 'task',
+          payloadChecksum: calculatePayloadChecksum(samplePayload),
+          signatures: [sig],
+        },
+        payload: samplePayload,
+      } as GitGovRecord;
+
+      const getDerivedKey = async (keyId: string): Promise<string | null> =>
+        keyId === 'actor:test' ? derivedPublicKey : null;
+
+      await expect(verifySignatures(record, getDerivedKey)).resolves.toBe(true);
     });
   });
 

--- a/packages/core/src/crypto/signatures.ts
+++ b/packages/core/src/crypto/signatures.ts
@@ -1,4 +1,4 @@
-import { generateKeyPair, sign, verify, createHash } from "crypto";
+import { generateKeyPair, sign, verify, createHash, createPrivateKey, createPublicKey } from "crypto";
 import { promisify } from "util";
 import { calculatePayloadChecksum } from "./checksum";
 import type { GitGovRecordPayload, Signature } from "../record_types";
@@ -30,6 +30,31 @@ export async function generateKeys(): Promise<{ publicKey: string; privateKey: s
     publicKey: rawPublicKey.toString('base64'), // 32 bytes -> 44 chars
     privateKey: Buffer.from(privateKey).toString('base64'),
   };
+}
+
+/**
+ * Derives the raw Ed25519 public key (base64) from a private key stored in
+ * PKCS8 PEM format (base64-encoded, the format used by generateKeys()).
+ *
+ * Used by KeyProvider.getPublicKey() implementations that do NOT cache the
+ * public key separately (FsKeyProvider, MockKeyProvider, EnvKeyProvider).
+ * PrismaKeyProvider caches publicKey as a column and does NOT need this.
+ *
+ * @param privateKeyBase64 Base64-encoded PKCS8 PEM private key
+ * @returns Base64-encoded raw Ed25519 public key (44 chars, 32 bytes)
+ */
+export function derivePublicKey(privateKeyBase64: string): string {
+  const privateKeyObject = createPrivateKey({
+    key: Buffer.from(privateKeyBase64, 'base64'),
+    type: 'pkcs8',
+    format: 'pem',
+  });
+  const publicKeyDer = createPublicKey(privateKeyObject).export({
+    type: 'spki',
+    format: 'der',
+  }) as Buffer;
+  // SPKI DER: [algorithm identifier (12 bytes)] + [raw public key (32 bytes)]
+  return publicKeyDer.subarray(-32).toString('base64');
 }
 
 /**

--- a/packages/core/src/crypto/signatures.ts
+++ b/packages/core/src/crypto/signatures.ts
@@ -1,4 +1,4 @@
-import { generateKeyPair, sign, verify, createHash, randomBytes } from "crypto";
+import { generateKeyPair, sign, verify, createHash } from "crypto";
 import { promisify } from "util";
 import { calculatePayloadChecksum } from "./checksum";
 import type { GitGovRecordPayload, Signature } from "../record_types";
@@ -112,12 +112,3 @@ export async function verifySignatures(
   return true;
 }
 
-/**
- * Generates a mock signature with valid Ed25519 format.
- * Used as fallback when private key is not available.
- *
- * [EARS-7] Returns a base64-encoded string of 64 random bytes (86 chars + ==)
- */
-export function generateMockSignature(): string {
-  return randomBytes(64).toString('base64');
-}

--- a/packages/core/src/crypto/signatures.ts
+++ b/packages/core/src/crypto/signatures.ts
@@ -1,4 +1,4 @@
-import { generateKeyPair, sign, verify, createHash, createPrivateKey, createPublicKey } from "crypto";
+import { generateKeyPair, sign, verify, createHash, createPrivateKey, createPublicKey, hkdf } from "crypto";
 import { promisify } from "util";
 import { calculatePayloadChecksum } from "./checksum";
 import type { GitGovRecordPayload, Signature } from "../record_types";
@@ -55,6 +55,50 @@ export function derivePublicKey(privateKeyBase64: string): string {
   }) as Buffer;
   // SPKI DER: [algorithm identifier (12 bytes)] + [raw public key (32 bytes)]
   return publicKeyDer.subarray(-32).toString('base64');
+}
+
+/**
+ * Derives a fixed-length symmetric key from a master key using HKDF-SHA256.
+ *
+ * Used by the 3-level key hierarchy in PrismaKeyProvider (Cycle 2 of
+ * identity_key_sync epic): the MASTER_KEY env var is expanded via HKDF with
+ * a purpose-specific `info` string to produce the key-wrapping key that
+ * encrypts per-org `OrgEncryptionKey` rows.
+ *
+ * HKDF (RFC 5869) provides proper key derivation: secure expansion from
+ * high-entropy keying material, binding by `info`, and no reliance on
+ * UTF-8 truncation (which would be fragile with multi-byte characters).
+ *
+ * @param masterKeyBase64 - Base64-encoded input keying material (32+ bytes).
+ *                         Generate with `openssl rand -base64 32`.
+ * @param info - Context/purpose binding string (e.g. 'gitgov-org-key').
+ *               Different `info` values produce different derived keys from
+ *               the same master key, enabling safe reuse across purposes.
+ * @param length - Derived key length in bytes. Default 32 (AES-256).
+ * @returns Promise resolving to the derived key as a Buffer.
+ */
+export function deriveHkdfKey(
+  masterKeyBase64: string,
+  info: string,
+  length: number = 32,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    let keyMaterial: Buffer;
+    try {
+      keyMaterial = Buffer.from(masterKeyBase64, 'base64');
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error('Invalid base64 master key'));
+      return;
+    }
+    // Empty salt is intentional: the `info` parameter provides domain separation.
+    hkdf('sha256', keyMaterial, Buffer.alloc(0), info, length, (err, derivedKey) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(Buffer.from(derivedKey));
+    });
+  });
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,10 @@ export type { IAgentRunner, RunOptions, AgentResponse } from "./agent_runner/ind
 
 // KeyProvider type exports
 export type { KeyProvider as IKeyProvider } from "./key_provider/index";
+export type { KeyProviderErrorCode, KeyProviderErrorContext } from "./key_provider/index";
+export { KeyProviderError } from "./key_provider/index";
+// KeyPair type — used by storeKey() in PrismaKeyProvider + createActor() in IdentityAdapter
+export type { KeyPair } from "./key_provider/index";
 
 // Lint type exports (pure types only - Fs types are in @gitgov/core/fs)
 export type { RecordStores, LintOptions, FixReport, LintResult, ValidatorType, LintReport, ILintModule } from "./lint/index";

--- a/packages/core/src/integration/feedback_backlog_integration.test.ts
+++ b/packages/core/src/integration/feedback_backlog_integration.test.ts
@@ -101,6 +101,7 @@ describe('FeedbackAdapter <-> BacklogAdapter Integration (Real Event Communicati
 
     // Create mock KeyProvider for integration test
     const mockKeyProvider = {
+      sign: jest.fn().mockResolvedValue(new Uint8Array(64)),
       getPrivateKey: jest.fn().mockResolvedValue('mock-private-key'),
       setPrivateKey: jest.fn().mockResolvedValue(undefined),
       hasPrivateKey: jest.fn().mockResolvedValue(true),

--- a/packages/core/src/key_provider/fs/fs_key_provider.test.ts
+++ b/packages/core/src/key_provider/fs/fs_key_provider.test.ts
@@ -2,7 +2,7 @@
  * FsKeyProvider Tests
  *
  * Tests for filesystem-based KeyProvider implementation.
- * EARS: KP01-KP04 (interface), FKP01-FKP11 (fs-specific)
+ * EARS: KP01-KP04 (interface), FKP01-FKP13 (fs-specific, includes getPublicKey)
  */
 
 import * as fs from 'fs/promises';
@@ -235,6 +235,24 @@ describe('FsKeyProvider', () => {
       // Throws KEY_NOT_FOUND for missing actor
       await expect(provider.sign('human:nonexistent', data))
         .rejects.toMatchObject({ code: 'KEY_NOT_FOUND', context: { actorId: 'human:nonexistent' } });
+    });
+  });
+
+  describe('Public Key Derivation (EARS-FKP12 to FKP13)', () => {
+    it('[EARS-FKP12] should derive public key from stored private key', async () => {
+      // Generate a real Ed25519 keypair and store the private key.
+      // getPublicKey() should derive the same public key that generateKeys() produced.
+      const { publicKey, privateKey } = await generateKeys();
+      await provider.setPrivateKey('human:alice', privateKey);
+
+      const derived = await provider.getPublicKey('human:alice');
+      expect(derived).toBe(publicKey);
+      expect(derived).toHaveLength(44); // base64 of 32 raw bytes
+    });
+
+    it('[EARS-FKP13] should return null when no private key exists', async () => {
+      const result = await provider.getPublicKey('human:nonexistent');
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/core/src/key_provider/fs/fs_key_provider.test.ts
+++ b/packages/core/src/key_provider/fs/fs_key_provider.test.ts
@@ -2,14 +2,16 @@
  * FsKeyProvider Tests
  *
  * Tests for filesystem-based KeyProvider implementation.
- * EARS: KP01-KP04 (interface), FKP01-FKP10 (fs-specific)
+ * EARS: KP01-KP04 (interface), FKP01-FKP11 (fs-specific)
  */
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
+import { verify, createHash } from 'crypto';
 import { FsKeyProvider } from './fs_key_provider';
 import { KeyProviderError } from '../key_provider';
+import { generateKeys } from '../../crypto/signatures';
 
 describe('FsKeyProvider', () => {
   let tempDir: string;
@@ -205,6 +207,34 @@ describe('FsKeyProvider', () => {
       const content = await fs.readFile(keyPath, 'utf-8');
 
       expect(content).toBe('customKey');
+    });
+  });
+
+  describe('Signing (EARS-FKP11)', () => {
+    it('[EARS-FKP11] should sign data with Ed25519 key read internally and throw KEY_NOT_FOUND when missing', async () => {
+      // Generate real Ed25519 keypair
+      const { publicKey, privateKey } = await generateKeys();
+
+      // Store key via provider
+      await provider.setPrivateKey('human:signer', privateKey);
+
+      // Sign arbitrary data
+      const data = new Uint8Array(createHash('sha256').update('test-payload').digest());
+      const signature = await provider.sign('human:signer', data);
+
+      // Verify signature is valid Ed25519
+      expect(signature).toBeInstanceOf(Uint8Array);
+      expect(signature.length).toBe(64);
+
+      // Reconstruct SPKI DER to verify
+      const algorithmId = Buffer.from([0x30,0x2a,0x30,0x05,0x06,0x03,0x2b,0x65,0x70,0x03,0x21,0x00]);
+      const spki = Buffer.concat([algorithmId, Buffer.from(publicKey, 'base64')]);
+      const isValid = verify(null, data, { key: spki, type: 'spki', format: 'der' }, Buffer.from(signature));
+      expect(isValid).toBe(true);
+
+      // Throws KEY_NOT_FOUND for missing actor
+      await expect(provider.sign('human:nonexistent', data))
+        .rejects.toMatchObject({ code: 'KEY_NOT_FOUND', context: { actorId: 'human:nonexistent' } });
     });
   });
 });

--- a/packages/core/src/key_provider/fs/fs_key_provider.ts
+++ b/packages/core/src/key_provider/fs/fs_key_provider.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import { sign } from 'crypto';
 import type { KeyProvider } from '../key_provider';
 import { KeyProviderError } from '../key_provider';
+import { derivePublicKey } from '../../crypto/signatures';
 
 /**
  * Options for FsKeyProvider.
@@ -68,6 +69,27 @@ export class FsKeyProvider implements KeyProvider {
       format: 'pem',
     });
     return new Uint8Array(signature);
+  }
+
+  /**
+   * [EARS-KP07] Derives and returns the raw Ed25519 public key from the stored private key.
+   * [EARS-KP08] Returns null if no private key exists for the actor.
+   * FsKeyProvider does not cache the public key — it's derived on-demand via ed25519 SPKI extraction.
+   */
+  async getPublicKey(actorId: string): Promise<string | null> {
+    const privateKey = await this.getPrivateKey(actorId);
+    if (!privateKey) {
+      return null;
+    }
+    try {
+      return derivePublicKey(privateKey);
+    } catch (error) {
+      throw new KeyProviderError(
+        `Failed to derive public key for ${this.sanitizeForLog(actorId)}: ${(error as Error).message}`,
+        'KEY_READ_ERROR',
+        { actorId }
+      );
+    }
   }
 
   /**

--- a/packages/core/src/key_provider/fs/fs_key_provider.ts
+++ b/packages/core/src/key_provider/fs/fs_key_provider.ts
@@ -9,6 +9,7 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { sign } from 'crypto';
 import type { KeyProvider } from '../key_provider';
 import { KeyProviderError } from '../key_provider';
 
@@ -47,6 +48,29 @@ export class FsKeyProvider implements KeyProvider {
   }
 
   /**
+   * [EARS-FKP11] Signs data with the actor's Ed25519 private key.
+   * Reads key internally — private key never leaves this provider.
+   * Throws KeyProviderError('KEY_NOT_FOUND') if no key exists.
+   */
+  async sign(actorId: string, data: Uint8Array): Promise<Uint8Array> {
+    const privateKey = await this.getPrivateKey(actorId);
+    if (!privateKey) {
+      throw new KeyProviderError(
+        `Private key not found for ${this.sanitizeForLog(actorId)}`,
+        'KEY_NOT_FOUND',
+        { actorId, hint: 'Run gitgov init or gitgov login to configure keys' }
+      );
+    }
+
+    const signature = sign(null, data, {
+      key: Buffer.from(privateKey, 'base64'),
+      type: 'pkcs8',
+      format: 'pem',
+    });
+    return new Uint8Array(signature);
+  }
+
+  /**
    * [EARS-KP01] Retrieves the private key for an actor.
    * [EARS-FKP07] Trims whitespace from content.
    * [EARS-FKP08] Returns null for empty key file.
@@ -72,7 +96,7 @@ export class FsKeyProvider implements KeyProvider {
       throw new KeyProviderError(
         `Failed to read private key for ${this.sanitizeForLog(actorId)}: ${(error as Error).message}`,
         'KEY_READ_ERROR',
-        actorId
+        { actorId }
       );
     }
   }
@@ -99,7 +123,7 @@ export class FsKeyProvider implements KeyProvider {
       throw new KeyProviderError(
         `Failed to write private key for ${this.sanitizeForLog(actorId)}: ${(error as Error).message}`,
         'KEY_WRITE_ERROR',
-        actorId
+        { actorId }
       );
     }
   }
@@ -136,7 +160,7 @@ export class FsKeyProvider implements KeyProvider {
       throw new KeyProviderError(
         `Failed to delete private key for ${this.sanitizeForLog(actorId)}: ${(error as Error).message}`,
         'KEY_DELETE_ERROR',
-        actorId
+        { actorId }
       );
     }
   }
@@ -167,7 +191,7 @@ export class FsKeyProvider implements KeyProvider {
       throw new KeyProviderError(
         'Invalid actorId: empty after sanitization',
         'INVALID_ACTOR_ID',
-        actorId
+        { actorId }
       );
     }
 

--- a/packages/core/src/key_provider/key_provider.ts
+++ b/packages/core/src/key_provider/key_provider.ts
@@ -86,11 +86,22 @@ export interface KeyProvider {
 
   /**
    * Retrieves the private key for an actor.
-   * Used for sync/export, NOT for signing (use sign() instead).
+   * Used for sync/export, NOT for signing (use sign() instead — HSM-ready).
    * @param actorId - The actor's ID (e.g., 'actor:human:alice')
    * @returns The base64-encoded private key, or null if not found
    */
   getPrivateKey(actorId: string): Promise<string | null>;
+
+  /**
+   * [EARS-KP07] Retrieves the public key for an actor.
+   * Required for key verification flows (KEY_MISMATCH detection in IdentityService).
+   * Implementations MAY cache this field directly (PrismaKeyProvider) or derive from the
+   * private key via derivePublicKey() (FsKeyProvider, MockKeyProvider, EnvKeyProvider).
+   * [EARS-KP08] Returns null if the actor has no key (fail-safe, same as getPrivateKey).
+   * @param actorId - The actor's ID
+   * @returns The base64-encoded public key (44 chars, raw Ed25519), or null if not found
+   */
+  getPublicKey(actorId: string): Promise<string | null>;
 
   /**
    * Stores a private key for an actor.

--- a/packages/core/src/key_provider/key_provider.ts
+++ b/packages/core/src/key_provider/key_provider.ts
@@ -46,6 +46,15 @@ export class KeyProviderError extends Error {
 }
 
 /**
+ * Ed25519 key pair — used by PrismaKeyProvider.storeKey() and IdentityAdapter.createActor().
+ * Both publicKey and privateKey are base64-encoded raw Ed25519 bytes (32 bytes each).
+ */
+export type KeyPair = {
+  publicKey: string;
+  privateKey: string;
+};
+
+/**
  * Interface for managing private key storage.
  * Implementations handle the actual persistence mechanism.
  *
@@ -66,9 +75,9 @@ export class KeyProviderError extends Error {
  */
 export interface KeyProvider {
   /**
-   * [IKS-B5] Signs data with the actor's private key without exposing it.
+   * [EARS-KP05] Signs data with the actor's private key without exposing it.
    * Primary signing method — HSM-ready (key never leaves the provider).
-   * [IKS-B6] Throws KeyProviderError('KEY_NOT_FOUND') if no key exists.
+   * [EARS-KP06] Throws KeyProviderError('KEY_NOT_FOUND') if no key exists.
    * @param actorId - The actor's ID
    * @param data - Raw bytes to sign (typically a SHA-256 digest)
    * @returns Ed25519 signature bytes

--- a/packages/core/src/key_provider/key_provider.ts
+++ b/packages/core/src/key_provider/key_provider.ts
@@ -17,7 +17,19 @@ export type KeyProviderErrorCode =
   | 'KEY_WRITE_ERROR'
   | 'KEY_DELETE_ERROR'
   | 'INVALID_KEY_FORMAT'
-  | 'INVALID_ACTOR_ID';
+  | 'INVALID_ACTOR_ID'
+  | 'DECRYPTION_FAILED'
+  | 'STORE_FAILED';
+
+/**
+ * Context for KeyProvider errors.
+ */
+export type KeyProviderErrorContext = {
+  actorId?: string;
+  orgId?: string;
+  hint?: string;
+  cause?: Error;
+};
 
 /**
  * Error thrown when key operations fail.
@@ -26,7 +38,7 @@ export class KeyProviderError extends Error {
   constructor(
     message: string,
     public readonly code: KeyProviderErrorCode,
-    public readonly actorId?: string
+    public readonly context: KeyProviderErrorContext = {}
   ) {
     super(message);
     this.name = 'KeyProviderError';
@@ -54,7 +66,18 @@ export class KeyProviderError extends Error {
  */
 export interface KeyProvider {
   /**
+   * [IKS-B5] Signs data with the actor's private key without exposing it.
+   * Primary signing method — HSM-ready (key never leaves the provider).
+   * [IKS-B6] Throws KeyProviderError('KEY_NOT_FOUND') if no key exists.
+   * @param actorId - The actor's ID
+   * @param data - Raw bytes to sign (typically a SHA-256 digest)
+   * @returns Ed25519 signature bytes
+   */
+  sign(actorId: string, data: Uint8Array): Promise<Uint8Array>;
+
+  /**
    * Retrieves the private key for an actor.
+   * Used for sync/export, NOT for signing (use sign() instead).
    * @param actorId - The actor's ID (e.g., 'actor:human:alice')
    * @returns The base64-encoded private key, or null if not found
    */

--- a/packages/core/src/key_provider/memory/env_key_provider.test.ts
+++ b/packages/core/src/key_provider/memory/env_key_provider.test.ts
@@ -215,4 +215,22 @@ describe('EnvKeyProvider', () => {
         .rejects.toMatchObject({ code: 'KEY_NOT_FOUND' });
     });
   });
+
+  describe('Public Key Derivation (EARS-EKP14 to EKP15)', () => {
+    it('[EARS-EKP14] should derive public key from stored private key', async () => {
+      const { publicKey, privateKey } = await generateKeys();
+      const env: Record<string, string | undefined> = { GITGOV_KEY_HUMAN_ALICE: privateKey };
+      const provider = new EnvKeyProvider({ env });
+
+      const derived = await provider.getPublicKey('human:alice');
+      expect(derived).toBe(publicKey);
+      expect(derived).toHaveLength(44);
+    });
+
+    it('[EARS-EKP15] should return null when no private key env var exists', async () => {
+      const provider = new EnvKeyProvider({ env: {} });
+      const result = await provider.getPublicKey('human:nonexistent');
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/packages/core/src/key_provider/memory/env_key_provider.test.ts
+++ b/packages/core/src/key_provider/memory/env_key_provider.test.ts
@@ -2,11 +2,13 @@
  * EnvKeyProvider Tests
  *
  * Tests for environment variable-based KeyProvider implementation.
- * EARS: KP01-KP04 (interface), EKP01-EKP12 (env-specific)
+ * EARS: KP01-KP04 (interface), EKP01-EKP13 (env-specific)
  */
 
+import { verify, createHash } from 'crypto';
 import { EnvKeyProvider } from './env_key_provider';
 import { KeyProviderError } from '../key_provider';
+import { generateKeys } from '../../crypto/signatures';
 
 describe('EnvKeyProvider', () => {
   describe('KeyProvider Interface (EARS-KP01 to KP04)', () => {
@@ -187,6 +189,30 @@ describe('EnvKeyProvider', () => {
       await expect(provider.setPrivateKey('::::', 'key'))
         .rejects
         .toMatchObject({ code: 'INVALID_ACTOR_ID' });
+    });
+  });
+
+  describe('Signing (EARS-EKP13)', () => {
+    it('[EARS-EKP13] should sign data with Ed25519 key from env and throw KEY_NOT_FOUND when missing', async () => {
+      const { publicKey, privateKey } = await generateKeys();
+      const env: Record<string, string | undefined> = { GITGOV_KEY_HUMAN_SIGNER: privateKey };
+      const provider = new EnvKeyProvider({ env, allowWrites: true });
+
+      const data = new Uint8Array(createHash('sha256').update('test-payload').digest());
+      const signature = await provider.sign('human:signer', data);
+
+      expect(signature).toBeInstanceOf(Uint8Array);
+      expect(signature.length).toBe(64);
+
+      // Verify Ed25519 signature
+      const algorithmId = Buffer.from([0x30,0x2a,0x30,0x05,0x06,0x03,0x2b,0x65,0x70,0x03,0x21,0x00]);
+      const spki = Buffer.concat([algorithmId, Buffer.from(publicKey, 'base64')]);
+      const isValid = verify(null, data, { key: spki, type: 'spki', format: 'der' }, Buffer.from(signature));
+      expect(isValid).toBe(true);
+
+      // Throws KEY_NOT_FOUND for missing actor
+      await expect(provider.sign('human:nonexistent', data))
+        .rejects.toMatchObject({ code: 'KEY_NOT_FOUND' });
     });
   });
 });

--- a/packages/core/src/key_provider/memory/env_key_provider.ts
+++ b/packages/core/src/key_provider/memory/env_key_provider.ts
@@ -7,6 +7,7 @@
  * @module key_provider/memory/env_key_provider
  */
 
+import { sign } from 'crypto';
 import type { KeyProvider } from '../key_provider';
 import { KeyProviderError } from '../key_provider';
 
@@ -53,6 +54,28 @@ export class EnvKeyProvider implements KeyProvider {
   }
 
   /**
+   * [EARS-EKP13] Signs data with an Ed25519 private key from environment variable.
+   * Throws KeyProviderError('KEY_NOT_FOUND') if env var not set.
+   */
+  async sign(actorId: string, data: Uint8Array): Promise<Uint8Array> {
+    const privateKey = await this.getPrivateKey(actorId);
+    if (!privateKey) {
+      throw new KeyProviderError(
+        `Private key not found in env for ${actorId}`,
+        'KEY_NOT_FOUND',
+        { actorId, hint: 'Set environment variable with the private key' }
+      );
+    }
+
+    const signature = sign(null, data, {
+      key: Buffer.from(privateKey, 'base64'),
+      type: 'pkcs8',
+      format: 'pem',
+    });
+    return new Uint8Array(signature);
+  }
+
+  /**
    * [EARS-KP01] Retrieves the private key from environment variable.
    * [EARS-EKP01] Reads from {prefix}{SANITIZED_ACTOR_ID}.
    * [EARS-EKP07] Returns null for empty or whitespace-only value.
@@ -80,7 +103,7 @@ export class EnvKeyProvider implements KeyProvider {
         'Cannot write to environment variables in read-only mode. ' +
         'Use a custom env object with allowWrites: true for writable storage.',
         'KEY_WRITE_ERROR',
-        actorId
+        { actorId }
       );
     }
 
@@ -106,7 +129,7 @@ export class EnvKeyProvider implements KeyProvider {
       throw new KeyProviderError(
         'Cannot delete environment variables in read-only mode.',
         'KEY_DELETE_ERROR',
-        actorId
+        { actorId }
       );
     }
 
@@ -135,7 +158,7 @@ export class EnvKeyProvider implements KeyProvider {
       throw new KeyProviderError(
         'Invalid actorId: empty after sanitization',
         'INVALID_ACTOR_ID',
-        actorId
+        { actorId }
       );
     }
 

--- a/packages/core/src/key_provider/memory/env_key_provider.ts
+++ b/packages/core/src/key_provider/memory/env_key_provider.ts
@@ -10,6 +10,7 @@
 import { sign } from 'crypto';
 import type { KeyProvider } from '../key_provider';
 import { KeyProviderError } from '../key_provider';
+import { derivePublicKey } from '../../crypto/signatures';
 
 /**
  * Options for EnvKeyProvider.
@@ -90,6 +91,26 @@ export class EnvKeyProvider implements KeyProvider {
     }
 
     return value.trim();
+  }
+
+  /**
+   * [EARS-KP07] Derives the raw Ed25519 public key from the stored private key.
+   * [EARS-KP08] Returns null if no private key env var is set for the actor.
+   */
+  async getPublicKey(actorId: string): Promise<string | null> {
+    const privateKey = await this.getPrivateKey(actorId);
+    if (!privateKey) {
+      return null;
+    }
+    try {
+      return derivePublicKey(privateKey);
+    } catch (error) {
+      throw new KeyProviderError(
+        `Failed to derive public key for ${actorId}: ${(error as Error).message}`,
+        'KEY_READ_ERROR',
+        { actorId }
+      );
+    }
   }
 
   /**

--- a/packages/core/src/key_provider/memory/mock_key_provider.test.ts
+++ b/packages/core/src/key_provider/memory/mock_key_provider.test.ts
@@ -2,7 +2,7 @@
  * MockKeyProvider Tests
  *
  * Tests for in-memory KeyProvider implementation (for testing).
- * EARS: KP01-KP04 (interface), MKP01-MKP08 (mock-specific)
+ * EARS: KP01-KP08 (interface incl. getPublicKey), MKP01-MKP10 (mock-specific)
  */
 
 import { verify, createHash } from 'crypto';
@@ -178,6 +178,23 @@ describe('MockKeyProvider', () => {
         .rejects.toThrow(KeyProviderError);
       await expect(provider.sign('human:nonexistent', data))
         .rejects.toMatchObject({ code: 'KEY_NOT_FOUND' });
+    });
+  });
+
+  describe('Public Key Derivation (EARS-MKP09 to MKP10)', () => {
+    it('[EARS-MKP09] should derive public key from stored private key', async () => {
+      const { publicKey, privateKey } = await generateKeys();
+      const provider = new MockKeyProvider({ keys: { 'human:alice': privateKey } });
+
+      const derived = await provider.getPublicKey('human:alice');
+      expect(derived).toBe(publicKey);
+      expect(derived).toHaveLength(44);
+    });
+
+    it('[EARS-MKP10] should return null when no private key exists', async () => {
+      const provider = new MockKeyProvider();
+      const result = await provider.getPublicKey('human:nonexistent');
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/core/src/key_provider/memory/mock_key_provider.test.ts
+++ b/packages/core/src/key_provider/memory/mock_key_provider.test.ts
@@ -2,10 +2,13 @@
  * MockKeyProvider Tests
  *
  * Tests for in-memory KeyProvider implementation (for testing).
- * EARS: KP01-KP04 (interface), MKP01-MKP07 (mock-specific)
+ * EARS: KP01-KP04 (interface), MKP01-MKP08 (mock-specific)
  */
 
+import { verify, createHash } from 'crypto';
 import { MockKeyProvider } from './mock_key_provider';
+import { KeyProviderError } from '../key_provider';
+import { generateKeys } from '../../crypto/signatures';
 
 describe('MockKeyProvider', () => {
   describe('KeyProvider Interface (EARS-KP01 to KP04)', () => {
@@ -150,6 +153,31 @@ describe('MockKeyProvider', () => {
       await provider.setPrivateKey('actor:test', 'key');
 
       expect(await provider.hasPrivateKey('actor:test')).toBe(true);
+    });
+  });
+
+  describe('Signing (EARS-MKP08)', () => {
+    it('[EARS-MKP08] should sign data with stored Ed25519 key and throw KEY_NOT_FOUND when missing', async () => {
+      const { publicKey, privateKey } = await generateKeys();
+      const provider = new MockKeyProvider({ keys: { 'human:signer': privateKey } });
+
+      const data = new Uint8Array(createHash('sha256').update('test-payload').digest());
+      const signature = await provider.sign('human:signer', data);
+
+      expect(signature).toBeInstanceOf(Uint8Array);
+      expect(signature.length).toBe(64);
+
+      // Verify Ed25519 signature
+      const algorithmId = Buffer.from([0x30,0x2a,0x30,0x05,0x06,0x03,0x2b,0x65,0x70,0x03,0x21,0x00]);
+      const spki = Buffer.concat([algorithmId, Buffer.from(publicKey, 'base64')]);
+      const isValid = verify(null, data, { key: spki, type: 'spki', format: 'der' }, Buffer.from(signature));
+      expect(isValid).toBe(true);
+
+      // Throws KEY_NOT_FOUND for missing actor
+      await expect(provider.sign('human:nonexistent', data))
+        .rejects.toThrow(KeyProviderError);
+      await expect(provider.sign('human:nonexistent', data))
+        .rejects.toMatchObject({ code: 'KEY_NOT_FOUND' });
     });
   });
 });

--- a/packages/core/src/key_provider/memory/mock_key_provider.ts
+++ b/packages/core/src/key_provider/memory/mock_key_provider.ts
@@ -6,7 +6,9 @@
  * @module key_provider/memory/mock_key_provider
  */
 
+import { sign } from 'crypto';
 import type { KeyProvider } from '../key_provider';
+import { KeyProviderError } from '../key_provider';
 
 /**
  * Options for MockKeyProvider.
@@ -46,6 +48,28 @@ export class MockKeyProvider implements KeyProvider {
     } else {
       this.keys = new Map();
     }
+  }
+
+  /**
+   * [EARS-MKP08] Signs data with a stored Ed25519 private key.
+   * Throws KeyProviderError('KEY_NOT_FOUND') if no key stored for actorId.
+   */
+  async sign(actorId: string, data: Uint8Array): Promise<Uint8Array> {
+    const privateKey = this.keys.get(actorId);
+    if (!privateKey) {
+      throw new KeyProviderError(
+        `Private key not found for ${actorId}`,
+        'KEY_NOT_FOUND',
+        { actorId, hint: 'Use setPrivateKey() to seed a key in MockKeyProvider' }
+      );
+    }
+
+    const signature = sign(null, data, {
+      key: Buffer.from(privateKey, 'base64'),
+      type: 'pkcs8',
+      format: 'pem',
+    });
+    return new Uint8Array(signature);
   }
 
   /**

--- a/packages/core/src/key_provider/memory/mock_key_provider.ts
+++ b/packages/core/src/key_provider/memory/mock_key_provider.ts
@@ -9,6 +9,7 @@
 import { sign } from 'crypto';
 import type { KeyProvider } from '../key_provider';
 import { KeyProviderError } from '../key_provider';
+import { derivePublicKey } from '../../crypto/signatures';
 
 /**
  * Options for MockKeyProvider.
@@ -77,6 +78,26 @@ export class MockKeyProvider implements KeyProvider {
    */
   async getPrivateKey(actorId: string): Promise<string | null> {
     return this.keys.get(actorId) ?? null;
+  }
+
+  /**
+   * [EARS-KP07] Derives the raw Ed25519 public key from the stored private key.
+   * [EARS-KP08] Returns null if no private key exists for the actor.
+   */
+  async getPublicKey(actorId: string): Promise<string | null> {
+    const privateKey = this.keys.get(actorId);
+    if (!privateKey) {
+      return null;
+    }
+    try {
+      return derivePublicKey(privateKey);
+    } catch (error) {
+      throw new KeyProviderError(
+        `Failed to derive public key for ${actorId}: ${(error as Error).message}`,
+        'KEY_READ_ERROR',
+        { actorId }
+      );
+    }
   }
 
   /**

--- a/packages/core/src/key_provider/prisma/index.ts
+++ b/packages/core/src/key_provider/prisma/index.ts
@@ -1,2 +1,14 @@
-export { PrismaKeyProvider } from './prisma_key_provider';
-export type { PrismaKeyProviderOptions, ActorKeyDelegate, ActorKeyRow } from './prisma_key_provider.types';
+export {
+  PrismaKeyProvider,
+  createOrgEncryptionKey,
+  rotateOrgEncryptionKey,
+} from './prisma_key_provider';
+export type {
+  ActorKeyStatus,
+  ActorKeyRow,
+  ActorKeyDelegate,
+  OrgEncryptionKeyRow,
+  OrgEncryptionKeyDelegate,
+  OrgEncryptionKeyClient,
+  PrismaClientLike,
+} from './prisma_key_provider.types';

--- a/packages/core/src/key_provider/prisma/prisma_key_provider.test.ts
+++ b/packages/core/src/key_provider/prisma/prisma_key_provider.test.ts
@@ -1,5 +1,5 @@
 /**
- * PrismaKeyProvider — 10 EARS (PKP-A1 to D1)
+ * PrismaKeyProvider — 11 EARS (PKP-A1 to E1)
  * Blueprint: prisma_key_provider_module.md
  *
  * | EARS ID | Test Case                                                        | Section |
@@ -14,7 +14,8 @@
  * | PKP-C2  | should store key in plaintext when no encryptionSecret           | 4.3     |
  * | PKP-C3  | should throw KEY_READ_ERROR when decryption fails               | 4.3     |
  * | PKP-D1  | should return true or false without reading key content          | 4.4     |
- * | PKP-E1  | should sign data with decrypted key and throw KEY_NOT_FOUND     | 4.5     |
+ * | PKP-E1  | should decrypt stored key, sign with Ed25519, and return signature | 4.5 |
+ * | PKP-E1  | should throw KEY_NOT_FOUND when signing with no active key      | 4.5     |
  */
 
 import { verify, createHash } from 'crypto';
@@ -245,7 +246,7 @@ describe('PrismaKeyProvider', () => {
   // ==========================================
 
   describe('4.5. Signing (PKP-E1)', () => {
-    it('[PKP-E1] should sign data with decrypted key and throw KEY_NOT_FOUND when missing', async () => {
+    it('[PKP-E1] should decrypt stored key, sign with Ed25519, and return signature', async () => {
       const { prisma } = createMockPrisma();
       const { publicKey, privateKey } = await generateKeys();
 
@@ -265,8 +266,14 @@ describe('PrismaKeyProvider', () => {
       const spki = Buffer.concat([algorithmId, Buffer.from(publicKey, 'base64')]);
       const isValid = verify(null, data, { key: spki, type: 'spki', format: 'der' }, Buffer.from(signature));
       expect(isValid).toBe(true);
+    });
 
-      // Throws KEY_NOT_FOUND for missing actor
+    it('[PKP-E1] should throw KEY_NOT_FOUND when signing with no active key', async () => {
+      const { prisma } = createMockPrisma();
+      const provider = new PrismaKeyProvider({ prisma, repoId: 'repo-1' });
+
+      const data = new Uint8Array(createHash('sha256').update('test-payload').digest());
+
       await expect(provider.sign('human:nonexistent', data))
         .rejects.toMatchObject({ code: 'KEY_NOT_FOUND' });
     });

--- a/packages/core/src/key_provider/prisma/prisma_key_provider.test.ts
+++ b/packages/core/src/key_provider/prisma/prisma_key_provider.test.ts
@@ -1,281 +1,1059 @@
 /**
- * PrismaKeyProvider — 11 EARS (PKP-A1 to E1)
- * Blueprint: prisma_key_provider_module.md
+ * PrismaKeyProvider v2 — 26 EARS (PKP-A1 to G10)
+ * Blueprint: prisma_key_provider_module.md (Cycle 2, identity_key_sync)
  *
- * | EARS ID | Test Case                                                        | Section |
- * |---------|------------------------------------------------------------------|---------|
- * | PKP-A1  | should return decrypted private key when it exists               | 4.1     |
- * | PKP-A2  | should return null when key does not exist                       | 4.1     |
- * | PKP-A3  | should encrypt and upsert key by actorId and repoId             | 4.1     |
- * | PKP-A4  | should delete key and return true or false if not exists         | 4.1     |
- * | PKP-B1  | should not return key from different repoId                     | 4.2     |
- * | PKP-B2  | should store independent keys for same actorId across repos     | 4.2     |
- * | PKP-C1  | should encrypt key before storing and decrypt on read            | 4.3     |
- * | PKP-C2  | should store key in plaintext when no encryptionSecret           | 4.3     |
- * | PKP-C3  | should throw KEY_READ_ERROR when decryption fails               | 4.3     |
- * | PKP-D1  | should return true or false without reading key content          | 4.4     |
- * | PKP-E1  | should decrypt stored key, sign with Ed25519, and return signature | 4.5 |
- * | PKP-E1  | should throw KEY_NOT_FOUND when signing with no active key      | 4.5     |
+ * | EARS ID  | Section | Test Case                                                                            |
+ * |----------|---------|--------------------------------------------------------------------------------------|
+ * | PKP-A1   | 4.1     | should return decrypted private key when active row exists                           |
+ * | PKP-A2   | 4.1     | should return null when no active key exists                                         |
+ * | PKP-A3   | 4.1     | should derive public key and delegate to storeKey                                    |
+ * | PKP-A4   | 4.1     | should archive active key and return true, false if none                             |
+ * | PKP-B1   | 4.2     | should not return key from different orgId                                           |
+ * | PKP-B2   | 4.2     | should store independent keys for same actorId across orgs                           |
+ * | PKP-C1   | 4.3     | should return true or false without reading key content                              |
+ * | PKP-D1   | 4.4     | should decrypt stored key, sign with Ed25519, and return signature                   |
+ * | PKP-D2   | 4.4     | should throw KEY_NOT_FOUND when signing with no active key                           |
+ * | PKP-E1   | 4.5     | should enforce one active key per [actorId, orgId]                                   |
+ * | PKP-E2   | 4.5     | should store iv and authTag as separate hex columns                                  |
+ * | PKP-E3   | 4.5     | should have status field with active|archived|revoked default active                |
+ * | PKP-F1   | 4.6     | should encrypt a random org key with HKDF-derived key and persist as hex             |
+ * | PKP-F1   | 4.6     | should produce non-deterministic ciphertext (random IV per call)                     |
+ * | PKP-F1   | 4.6     | should throw KeyProviderError STORE_FAILED when MASTER_KEY is missing                |
+ * | PKP-F2   | 4.6     | should lazy-load OrgEncryptionKey and cache plaintext in-instance                    |
+ * | PKP-F3   | 4.6     | should encrypt ActorKey with org key, never with MASTER_KEY directly                 |
+ * | PKP-F4   | 4.6     | should re-encrypt all active actor keys when org key is rotated                      |
+ * | PKP-G1   | 4.7     | should encrypt private key with AES-256-GCM and random IV                            |
+ * | PKP-G2   | 4.7     | should archive old active row and create new one in a transaction                    |
+ * | PKP-G3   | 4.7     | should set lastUsedAt on the new active row                                          |
+ * | PKP-G4   | 4.7     | should throw STORE_FAILED when DB or encryption fails                                |
+ * | PKP-G5   | 4.7     | should return public key without touching org key or decryption                      |
+ * | PKP-G6   | 4.7     | should return null when no active key exists                                         |
+ * | PKP-G7   | 4.7     | should set status to archived and record lastUsedAt                                  |
+ * | PKP-G8   | 4.7     | should be a no-op when no active key exists                                          |
+ * | PKP-G9   | 4.7     | should throw DECRYPTION_FAILED when AES-GCM decryption fails                         |
+ * | PKP-G10  | 4.7     | should ignore archived rows in getPrivateKey/sign/getPublicKey                       |
  */
 
-import { verify, createHash } from 'crypto';
-import { PrismaKeyProvider } from './prisma_key_provider';
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  verify as cryptoVerify,
+} from 'node:crypto';
+import {
+  PrismaKeyProvider,
+  createOrgEncryptionKey,
+  rotateOrgEncryptionKey,
+} from './prisma_key_provider';
 import { KeyProviderError } from '../key_provider';
-import type { ActorKeyRow, ActorKeyDelegate } from './prisma_key_provider.types';
-import { generateKeys } from '../../crypto/signatures';
+import type {
+  ActorKeyRow,
+  ActorKeyStatus,
+  ActorKeyDelegate,
+  OrgEncryptionKeyRow,
+  OrgEncryptionKeyDelegate,
+  PrismaClientLike,
+} from './prisma_key_provider.types';
+import { generateKeys, deriveHkdfKey } from '../../crypto/signatures';
 
-// ============================================================================
-// Mock factory
-// ============================================================================
-
-function createMockPrisma() {
-  const store = new Map<string, ActorKeyRow>();
-
-  const actorKey: ActorKeyDelegate = {
-    findUnique: jest.fn().mockImplementation(async (args) => {
-      const { actorId, repoId } = args.where.actorId_repoId;
-      return store.get(`${actorId}:${repoId}`) ?? null;
-    }),
-    upsert: jest.fn().mockImplementation(async (args) => {
-      const { actorId, repoId } = args.where.actorId_repoId;
-      const key = `${actorId}:${repoId}`;
-      const existing = store.get(key);
-      const row: ActorKeyRow = existing
-        ? { ...existing, encryptedKey: args.update.encryptedKey, updatedAt: new Date() }
-        : { id: `id-${Date.now()}`, actorId, repoId, encryptedKey: args.create.encryptedKey, createdAt: new Date(), updatedAt: new Date() };
-      store.set(key, row);
-      return row;
-    }),
-    delete: jest.fn().mockImplementation(async (args) => {
-      const { actorId, repoId } = args.where.actorId_repoId;
-      const key = `${actorId}:${repoId}`;
-      if (!store.has(key)) {
-        const err = new Error('Record not found') as Error & { code: string };
-        err.code = 'P2025';
-        throw err;
-      }
-      const row = store.get(key)!;
-      store.delete(key);
-      return row;
-    }),
-    count: jest.fn().mockImplementation(async (args) => {
-      const { actorId, repoId } = args.where;
-      return store.has(`${actorId}:${repoId}`) ? 1 : 0;
-    }),
-  };
-
-  return { prisma: { actorKey }, store };
+/**
+ * Type guard that narrows `string` to `ActorKeyStatus`. The Prisma delegate
+ * contract types status fields as `string` (because Prisma's runtime returns
+ * plain strings from a `String` schema column), but `ActorKeyRow` narrows
+ * it to the union. This guard bridges the two when the mock factory builds
+ * a row from `create.data.status`.
+ */
+function isActorKeyStatus(value: string): value is ActorKeyStatus {
+  return value === 'active' || value === 'archived' || value === 'revoked';
 }
 
-const TEST_SECRET = 'test-encryption-secret-32-bytes!';
-const TEST_KEY = 'dGVzdC1wcml2YXRlLWtleS1iYXNlNjQ='; // base64 "test-private-key-base64"
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+/**
+ * Test MASTER_KEY — 32 bytes of test data, base64. NEVER use in production.
+ * Hardcoded for hermeticity; each test that uses it restores the original
+ * env var in afterEach.
+ */
+const TEST_MASTER_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA='; // 32 '0' bytes
+
+/** HKDF info binding — must match the constant in prisma_key_provider.ts */
+const MASTER_KEY_HKDF_INFO = 'gitgov-org-key';
+
+/** AES-GCM constants — must match prisma_key_provider.ts */
+const AES_GCM_ALGORITHM = 'aes-256-gcm';
+const GCM_IV_LENGTH = 12;
+const KEY_LENGTH_BYTES = 32;
+
+/** Status literals — must match prisma_key_provider.ts */
+const STATUS_ACTIVE = 'active';
+const STATUS_ARCHIVED = 'archived';
+
+// ============================================================================
+// Mock factories (fully typed — ZERO any)
+// ============================================================================
+
+/**
+ * In-memory mock of `OrgEncryptionKeyDelegate` with enforced unique constraint
+ * on `orgId`. Used by `createOrgEncryptionKey` + `PrismaKeyProvider.getOrgKey`.
+ */
+function createMockOrgEncryptionKeyDelegate(): {
+  delegate: OrgEncryptionKeyDelegate;
+  rows: Map<string, OrgEncryptionKeyRow>;
+} {
+  const rows = new Map<string, OrgEncryptionKeyRow>();
+
+  const delegate: OrgEncryptionKeyDelegate = {
+    findUnique: jest.fn(async (args: { where: { orgId: string } }) => {
+      return rows.get(args.where.orgId) ?? null;
+    }),
+    create: jest.fn(
+      async (args: {
+        data: { orgId: string; encryptedOrgKey: string; iv: string; authTag: string };
+      }) => {
+        if (rows.has(args.data.orgId)) {
+          const err = new Error('Unique constraint failed on orgId') as Error & {
+            code: string;
+          };
+          err.code = 'P2002';
+          throw err;
+        }
+        const row: OrgEncryptionKeyRow = {
+          id: `oek-${rows.size + 1}`,
+          orgId: args.data.orgId,
+          encryptedOrgKey: args.data.encryptedOrgKey,
+          iv: args.data.iv,
+          authTag: args.data.authTag,
+          createdAt: new Date(),
+          rotatedAt: new Date(),
+        };
+        rows.set(args.data.orgId, row);
+        return row;
+      },
+    ),
+    update: jest.fn(
+      async (args: {
+        where: { orgId: string };
+        data: {
+          encryptedOrgKey?: string;
+          iv?: string;
+          authTag?: string;
+          rotatedAt?: Date;
+        };
+      }) => {
+        const existing = rows.get(args.where.orgId);
+        if (!existing) {
+          const err = new Error('Record not found') as Error & { code: string };
+          err.code = 'P2025';
+          throw err;
+        }
+        const updated: OrgEncryptionKeyRow = {
+          ...existing,
+          ...(args.data.encryptedOrgKey !== undefined && {
+            encryptedOrgKey: args.data.encryptedOrgKey,
+          }),
+          ...(args.data.iv !== undefined && { iv: args.data.iv }),
+          ...(args.data.authTag !== undefined && { authTag: args.data.authTag }),
+          ...(args.data.rotatedAt !== undefined && { rotatedAt: args.data.rotatedAt }),
+        };
+        rows.set(args.where.orgId, updated);
+        return updated;
+      },
+    ),
+  };
+
+  return { delegate, rows };
+}
+
+/**
+ * In-memory mock of `ActorKeyDelegate` v2 with unique constraint enforcement
+ * on `[actorId, orgId, status]`.
+ */
+function createMockActorKeyDelegate(): {
+  delegate: ActorKeyDelegate;
+  rows: ActorKeyRow[];
+} {
+  const rows: ActorKeyRow[] = [];
+  let idCounter = 0;
+
+  const delegate: ActorKeyDelegate = {
+    findFirst: jest.fn(
+      async (args: { where: { actorId: string; orgId: string; status: string } }) => {
+        return (
+          rows.find(
+            (r) =>
+              r.actorId === args.where.actorId &&
+              r.orgId === args.where.orgId &&
+              r.status === args.where.status,
+          ) ?? null
+        );
+      },
+    ),
+    findMany: jest.fn(
+      async (args: { where: { orgId: string; status: string } }) => {
+        return rows.filter(
+          (r) => r.orgId === args.where.orgId && r.status === args.where.status,
+        );
+      },
+    ),
+    count: jest.fn(
+      async (args: { where: { actorId: string; orgId: string; status: string } }) => {
+        return rows.filter(
+          (r) =>
+            r.actorId === args.where.actorId &&
+            r.orgId === args.where.orgId &&
+            r.status === args.where.status,
+        ).length;
+      },
+    ),
+    create: jest.fn(
+      async (args: {
+        data: {
+          actorId: string;
+          orgId: string;
+          publicKey: string;
+          encryptedPrivateKey: string;
+          iv: string;
+          authTag: string;
+          status: string;
+          lastUsedAt: Date;
+        };
+      }) => {
+        // [PKP-E1] enforce unique [actorId, orgId, status]
+        const collision = rows.find(
+          (r) =>
+            r.actorId === args.data.actorId &&
+            r.orgId === args.data.orgId &&
+            r.status === args.data.status,
+        );
+        if (collision) {
+          const err = new Error(
+            'Unique constraint failed on [actorId, orgId, status]',
+          ) as Error & { code: string };
+          err.code = 'P2002';
+          throw err;
+        }
+        idCounter += 1;
+        // Narrow status from the delegate's `string` arg to the stricter
+        // ActorKeyStatus literal union. Runtime-validated below.
+        if (!isActorKeyStatus(args.data.status)) {
+          throw new Error(
+            `Invalid ActorKey.status: "${args.data.status}" (expected 'active' | 'archived' | 'revoked')`,
+          );
+        }
+        const row: ActorKeyRow = {
+          id: `ak-${idCounter}`,
+          actorId: args.data.actorId,
+          orgId: args.data.orgId,
+          publicKey: args.data.publicKey,
+          encryptedPrivateKey: args.data.encryptedPrivateKey,
+          iv: args.data.iv,
+          authTag: args.data.authTag,
+          status: args.data.status,
+          lastUsedAt: args.data.lastUsedAt,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+        rows.push(row);
+        return row;
+      },
+    ),
+    updateMany: jest.fn(
+      async (args: {
+        where: { actorId: string; orgId: string; status: string };
+        data: { status?: string; lastUsedAt?: Date };
+      }) => {
+        const matches = rows.filter(
+          (r) =>
+            r.actorId === args.where.actorId &&
+            r.orgId === args.where.orgId &&
+            r.status === args.where.status,
+        );
+        for (const row of matches) {
+          if (args.data.status !== undefined) {
+            if (!isActorKeyStatus(args.data.status)) {
+              throw new Error(
+                `Invalid ActorKey.status: "${args.data.status}" (expected 'active' | 'archived' | 'revoked')`,
+              );
+            }
+            row.status = args.data.status;
+          }
+          if (args.data.lastUsedAt !== undefined) row.lastUsedAt = args.data.lastUsedAt;
+          row.updatedAt = new Date();
+        }
+        return { count: matches.length };
+      },
+    ),
+    update: jest.fn(
+      async (args: {
+        where: { id: string };
+        data: {
+          encryptedPrivateKey?: string;
+          iv?: string;
+          authTag?: string;
+          lastUsedAt?: Date;
+        };
+      }) => {
+        const row = rows.find((r) => r.id === args.where.id);
+        if (!row) {
+          const err = new Error('Record not found') as Error & { code: string };
+          err.code = 'P2025';
+          throw err;
+        }
+        if (args.data.encryptedPrivateKey !== undefined)
+          row.encryptedPrivateKey = args.data.encryptedPrivateKey;
+        if (args.data.iv !== undefined) row.iv = args.data.iv;
+        if (args.data.authTag !== undefined) row.authTag = args.data.authTag;
+        if (args.data.lastUsedAt !== undefined) row.lastUsedAt = args.data.lastUsedAt;
+        row.updatedAt = new Date();
+        return row;
+      },
+    ),
+  };
+
+  return { delegate, rows };
+}
+
+/**
+ * Builds a full `PrismaClientLike` mock with both delegates + a synchronous
+ * `$transaction` that passes the same delegates to the callback. Suitable for
+ * unit tests — mimics transactional semantics in-memory (all-or-nothing is
+ * not enforced because there's nothing to roll back, but the callback API
+ * matches the real Prisma contract).
+ */
+function createMockPrismaClient(): {
+  client: PrismaClientLike;
+  orgKeyRows: Map<string, OrgEncryptionKeyRow>;
+  actorKeyRows: ActorKeyRow[];
+} {
+  const { delegate: orgEncryptionKey, rows: orgKeyRows } =
+    createMockOrgEncryptionKeyDelegate();
+  const { delegate: actorKey, rows: actorKeyRows } = createMockActorKeyDelegate();
+
+  const client: PrismaClientLike = {
+    orgEncryptionKey,
+    actorKey,
+    $transaction: jest.fn(
+      async <T>(
+        fn: (tx: {
+          orgEncryptionKey: OrgEncryptionKeyDelegate;
+          actorKey: ActorKeyDelegate;
+        }) => Promise<T>,
+      ): Promise<T> => {
+        // Simplified mock: just call fn with the same delegates
+        // Real Prisma would open a DB transaction, but for unit tests the
+        // atomicity guarantees come from the in-memory mock's single-threaded
+        // execution.
+        return fn({ orgEncryptionKey, actorKey });
+      },
+    ),
+  };
+
+  return { client, orgKeyRows, actorKeyRows };
+}
+
+/**
+ * Helper: bootstraps MASTER_KEY + OrgEncryptionKey row in the mock + an
+ * optional pre-seeded ActorKey row.
+ *
+ * Returns the provider instance scoped to `orgId`, plus the mock rows for
+ * inspection.
+ */
+async function bootstrapProvider(
+  orgId: string,
+): Promise<{
+  provider: PrismaKeyProvider;
+  client: PrismaClientLike;
+  orgKeyRows: Map<string, OrgEncryptionKeyRow>;
+  actorKeyRows: ActorKeyRow[];
+}> {
+  const { client, orgKeyRows, actorKeyRows } = createMockPrismaClient();
+  process.env['MASTER_KEY'] = TEST_MASTER_KEY;
+  await createOrgEncryptionKey(client, orgId);
+  const provider = new PrismaKeyProvider(client, orgId);
+  return { provider, client, orgKeyRows, actorKeyRows };
+}
 
 // ============================================================================
 // Tests
 // ============================================================================
 
-describe('PrismaKeyProvider', () => {
-  // ==========================================
-  // 4.1. Key CRUD (PKP-A1 to A4)
-  // ==========================================
+describe('PrismaKeyProvider v2', () => {
+  const originalMasterKey = process.env['MASTER_KEY'];
 
-  describe('4.1. Key CRUD (PKP-A1 to A4)', () => {
-    it('[PKP-A1] should return decrypted private key when it exists', async () => {
-      const { prisma } = createMockPrisma();
-      const provider = new PrismaKeyProvider({ prisma, repoId: 'repo-1', encryptionSecret: TEST_SECRET });
+  afterEach(() => {
+    if (originalMasterKey === undefined) {
+      delete process.env['MASTER_KEY'];
+    } else {
+      process.env['MASTER_KEY'] = originalMasterKey;
+    }
+  });
 
-      await provider.setPrivateKey('human:alice', TEST_KEY);
-      const result = await provider.getPrivateKey('human:alice');
+  // ==========================================================================
+  // 4.1. Key CRUD by Org (PKP-A1 to A4)
+  // ==========================================================================
 
-      expect(result).toBe(TEST_KEY);
+  describe('4.1. Key CRUD by Org (PKP-A1 to A4)', () => {
+    it('[PKP-A1] should return decrypted private key when active row exists', async () => {
+      const { provider } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
+
+      await provider.storeKey('human:alice', { publicKey, privateKey });
+
+      const retrieved = await provider.getPrivateKey('human:alice');
+      expect(retrieved).toBe(privateKey);
     });
 
-    it('[PKP-A2] should return null when key does not exist', async () => {
-      const { prisma } = createMockPrisma();
-      const provider = new PrismaKeyProvider({ prisma, repoId: 'repo-1', encryptionSecret: TEST_SECRET });
+    it('[PKP-A2] should return null when no active key exists', async () => {
+      const { provider } = await bootstrapProvider('org-1');
 
-      const result = await provider.getPrivateKey('human:nobody');
+      const result = await provider.getPrivateKey('human:ghost');
 
       expect(result).toBeNull();
     });
 
-    it('[PKP-A3] should encrypt and upsert key by actorId and repoId', async () => {
-      const { prisma } = createMockPrisma();
-      const provider = new PrismaKeyProvider({ prisma, repoId: 'repo-1', encryptionSecret: TEST_SECRET });
+    it('[PKP-A3] should derive public key and delegate to storeKey', async () => {
+      const { provider, actorKeyRows } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
 
-      await provider.setPrivateKey('human:alice', TEST_KEY);
+      await provider.setPrivateKey('human:alice', privateKey);
 
-      expect(prisma.actorKey.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { actorId_repoId: { actorId: 'human:alice', repoId: 'repo-1' } },
-          create: expect.objectContaining({ actorId: 'human:alice', repoId: 'repo-1' }),
-        }),
-      );
-
-      // The stored value should NOT be the plaintext key (it's encrypted)
-      const upsertCall = (prisma.actorKey.upsert as jest.Mock).mock.calls[0][0];
-      expect(upsertCall.create.encryptedKey).not.toBe(TEST_KEY);
+      // Verify: one active row exists with the *derived* public key
+      // (same as generateKeys returned, since derivation is deterministic)
+      expect(actorKeyRows).toHaveLength(1);
+      expect(actorKeyRows[0]).toBeDefined();
+      const row = actorKeyRows[0];
+      if (!row) throw new Error('unreachable');
+      expect(row.actorId).toBe('human:alice');
+      expect(row.orgId).toBe('org-1');
+      expect(row.status).toBe(STATUS_ACTIVE);
+      expect(row.publicKey).toBe(publicKey); // derived === generated
+      // Round-trip: the private key can be recovered
+      expect(await provider.getPrivateKey('human:alice')).toBe(privateKey);
     });
 
-    it('[PKP-A4] should delete key and return true or false if not exists', async () => {
-      const { prisma } = createMockPrisma();
-      const provider = new PrismaKeyProvider({ prisma, repoId: 'repo-1', encryptionSecret: TEST_SECRET });
+    it('[PKP-A4] should archive active key and return true, false if none', async () => {
+      const { provider, actorKeyRows } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
+      await provider.storeKey('human:alice', { publicKey, privateKey });
 
-      await provider.setPrivateKey('human:alice', TEST_KEY);
+      // First delete: active row existed → true
+      const result1 = await provider.deletePrivateKey('human:alice');
+      expect(result1).toBe(true);
 
-      const deleted = await provider.deletePrivateKey('human:alice');
-      expect(deleted).toBe(true);
+      // Row is ARCHIVED, not hard-deleted
+      expect(actorKeyRows).toHaveLength(1);
+      expect(actorKeyRows[0]?.status).toBe(STATUS_ARCHIVED);
 
-      const deletedAgain = await provider.deletePrivateKey('human:alice');
-      expect(deletedAgain).toBe(false);
-    });
-  });
-
-  // ==========================================
-  // 4.2. Multi-Tenant Isolation (PKP-B1 to B2)
-  // ==========================================
-
-  describe('4.2. Multi-Tenant Isolation (PKP-B1 to B2)', () => {
-    it('[PKP-B1] should not return key from different repoId', async () => {
-      const { prisma } = createMockPrisma();
-      const providerA = new PrismaKeyProvider({ prisma, repoId: 'repo-A', encryptionSecret: TEST_SECRET });
-      const providerB = new PrismaKeyProvider({ prisma, repoId: 'repo-B', encryptionSecret: TEST_SECRET });
-
-      await providerA.setPrivateKey('human:alice', TEST_KEY);
-
-      const result = await providerB.getPrivateKey('human:alice');
-      expect(result).toBeNull();
-    });
-
-    it('[PKP-B2] should store independent keys for same actorId across repos', async () => {
-      const { prisma } = createMockPrisma();
-      const providerA = new PrismaKeyProvider({ prisma, repoId: 'repo-A', encryptionSecret: TEST_SECRET });
-      const providerB = new PrismaKeyProvider({ prisma, repoId: 'repo-B', encryptionSecret: TEST_SECRET });
-
-      const keyA = 'a2V5LWZvci1yZXBvLUE=';
-      const keyB = 'a2V5LWZvci1yZXBvLUI=';
-
-      await providerA.setPrivateKey('human:alice', keyA);
-      await providerB.setPrivateKey('human:alice', keyB);
-
-      expect(await providerA.getPrivateKey('human:alice')).toBe(keyA);
-      expect(await providerB.getPrivateKey('human:alice')).toBe(keyB);
+      // Second delete: no active row → false
+      const result2 = await provider.deletePrivateKey('human:alice');
+      expect(result2).toBe(false);
     });
   });
 
-  // ==========================================
-  // 4.3. Encryption (PKP-C1 to C3)
-  // ==========================================
+  // ==========================================================================
+  // 4.2. Org-Level Isolation (PKP-B1 to B2)
+  // ==========================================================================
 
-  describe('4.3. Encryption (PKP-C1 to C3)', () => {
-    it('[PKP-C1] should encrypt key before storing and decrypt on read', async () => {
-      const { prisma, store } = createMockPrisma();
-      const provider = new PrismaKeyProvider({ prisma, repoId: 'repo-1', encryptionSecret: TEST_SECRET });
+  describe('4.2. Org-Level Isolation (PKP-B1 to B2)', () => {
+    it('[PKP-B1] should not return key from different orgId', async () => {
+      const { client, orgKeyRows: orgKeysA } = createMockPrismaClient();
+      process.env['MASTER_KEY'] = TEST_MASTER_KEY;
+      await createOrgEncryptionKey(client, 'org-a');
+      await createOrgEncryptionKey(client, 'org-b');
 
-      await provider.setPrivateKey('human:alice', TEST_KEY);
+      const providerA = new PrismaKeyProvider(client, 'org-a');
+      const providerB = new PrismaKeyProvider(client, 'org-b');
+      const { privateKey, publicKey } = await generateKeys();
 
-      // The raw stored value should be encrypted (not plaintext)
-      const raw = store.get('human:alice:repo-1');
-      expect(raw).toBeDefined();
-      expect(raw!.encryptedKey).not.toBe(TEST_KEY);
-      expect(raw!.encryptedKey.length).toBeGreaterThan(TEST_KEY.length); // encrypted + IV + tag
+      await providerA.storeKey('human:alice', { publicKey, privateKey });
 
-      // But reading it back should return the original
-      const decrypted = await provider.getPrivateKey('human:alice');
-      expect(decrypted).toBe(TEST_KEY);
+      // Same actorId, different org → must NOT be visible
+      expect(await providerB.getPrivateKey('human:alice')).toBeNull();
+      expect(await providerB.hasPrivateKey('human:alice')).toBe(false);
+      // OrgEncryptionKey rows confirm both orgs were bootstrapped
+      expect(orgKeysA.size).toBe(2);
     });
 
-    it('[PKP-C2] should store key in plaintext when no encryptionSecret', async () => {
-      const { prisma, store } = createMockPrisma();
-      const provider = new PrismaKeyProvider({ prisma, repoId: 'repo-1' }); // no secret
+    it('[PKP-B2] should store independent keys for same actorId across orgs', async () => {
+      const { client } = createMockPrismaClient();
+      process.env['MASTER_KEY'] = TEST_MASTER_KEY;
+      await createOrgEncryptionKey(client, 'org-a');
+      await createOrgEncryptionKey(client, 'org-b');
 
-      await provider.setPrivateKey('human:alice', TEST_KEY);
+      const providerA = new PrismaKeyProvider(client, 'org-a');
+      const providerB = new PrismaKeyProvider(client, 'org-b');
+      const keysA = await generateKeys();
+      const keysB = await generateKeys();
 
-      const raw = store.get('human:alice:repo-1');
-      expect(raw!.encryptedKey).toBe(TEST_KEY); // plaintext!
+      await providerA.storeKey('human:alice', keysA);
+      await providerB.storeKey('human:alice', keysB);
 
-      const result = await provider.getPrivateKey('human:alice');
-      expect(result).toBe(TEST_KEY);
-    });
-
-    it('[PKP-C3] should throw KEY_READ_ERROR when decryption fails', async () => {
-      const { prisma } = createMockPrisma();
-
-      // Store with one secret
-      const provider1 = new PrismaKeyProvider({ prisma, repoId: 'repo-1', encryptionSecret: 'secret-1-aaaaaa' });
-      await provider1.setPrivateKey('human:alice', TEST_KEY);
-
-      // Try to read with a different secret
-      const provider2 = new PrismaKeyProvider({ prisma, repoId: 'repo-1', encryptionSecret: 'secret-2-bbbbbb' });
-
-      let caught: unknown;
-      try {
-        await provider2.getPrivateKey('human:alice');
-      } catch (error) {
-        caught = error;
-      }
-      expect(caught).toBeInstanceOf(KeyProviderError);
-      expect((caught as KeyProviderError).code).toBe('KEY_READ_ERROR');
+      expect(await providerA.getPrivateKey('human:alice')).toBe(keysA.privateKey);
+      expect(await providerB.getPrivateKey('human:alice')).toBe(keysB.privateKey);
+      expect(keysA.privateKey).not.toBe(keysB.privateKey);
     });
   });
 
-  // ==========================================
-  // 4.4. hasPrivateKey (PKP-D1)
-  // ==========================================
+  // ==========================================================================
+  // 4.3. hasPrivateKey (PKP-C1)
+  // ==========================================================================
 
-  describe('4.4. hasPrivateKey (PKP-D1)', () => {
-    it('[PKP-D1] should return true or false without reading key content', async () => {
-      const { prisma } = createMockPrisma();
-      const provider = new PrismaKeyProvider({ prisma, repoId: 'repo-1', encryptionSecret: TEST_SECRET });
+  describe('4.3. hasPrivateKey (PKP-C1)', () => {
+    it('[PKP-C1] should return true or false without reading key content', async () => {
+      const { provider, client } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
 
       expect(await provider.hasPrivateKey('human:alice')).toBe(false);
-
-      await provider.setPrivateKey('human:alice', TEST_KEY);
-
+      await provider.storeKey('human:alice', { publicKey, privateKey });
       expect(await provider.hasPrivateKey('human:alice')).toBe(true);
 
-      // Verify it used count, not findUnique (doesn't read content)
-      expect(prisma.actorKey.count).toHaveBeenCalledWith({
-        where: { actorId: 'human:alice', repoId: 'repo-1' },
+      // Verify: count() was used, not findFirst (count doesn't read content)
+      expect(client.actorKey.count).toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // 4.4. Signing (PKP-D1 to D2)
+  // ==========================================================================
+
+  describe('4.4. Signing (PKP-D1 to D2)', () => {
+    it('[PKP-D1] should decrypt stored key, sign with Ed25519, and return signature', async () => {
+      const { provider, actorKeyRows } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
+      await provider.storeKey('human:alice', { publicKey, privateKey });
+
+      const data = new Uint8Array(Buffer.from('test-payload-for-signing', 'utf-8'));
+      const signature = await provider.sign('human:alice', data);
+
+      // Ed25519 signatures are 64 bytes
+      expect(signature).toBeInstanceOf(Uint8Array);
+      expect(signature.length).toBe(64);
+
+      // Verify cryptographically: reconstruct SPKI DER from raw public key
+      const algorithmId = Buffer.from([
+        0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+      ]);
+      const spki = Buffer.concat([algorithmId, Buffer.from(publicKey, 'base64')]);
+      const isValid = cryptoVerify(
+        null,
+        data,
+        { key: spki, type: 'spki', format: 'der' },
+        Buffer.from(signature),
+      );
+      expect(isValid).toBe(true);
+
+      // Side effect: lastUsedAt was updated on the active row.
+      // (Non-blocking fire-and-forget update — flush microtasks to observe.)
+      await new Promise((resolve) => setImmediate(resolve));
+      const row = actorKeyRows.find(
+        (r) => r.actorId === 'human:alice' && r.status === STATUS_ACTIVE,
+      );
+      expect(row).toBeDefined();
+      expect(row?.lastUsedAt).toBeInstanceOf(Date);
+    });
+
+    it('[PKP-D2] should throw KEY_NOT_FOUND when signing with no active key', async () => {
+      const { provider } = await bootstrapProvider('org-1');
+
+      const data = new Uint8Array(Buffer.from('test', 'utf-8'));
+
+      await expect(provider.sign('human:nonexistent', data)).rejects.toBeInstanceOf(
+        KeyProviderError,
+      );
+      await expect(provider.sign('human:nonexistent', data)).rejects.toMatchObject({
+        code: 'KEY_NOT_FOUND',
+        context: expect.objectContaining({
+          actorId: 'human:nonexistent',
+          orgId: 'org-1',
+        }),
       });
     });
   });
 
-  // ==========================================
-  // 4.5. Signing (PKP-E1)
-  // ==========================================
+  // ==========================================================================
+  // 4.5. Schema Migration invariants (PKP-E1 to E3)
+  //
+  // PKP-E4 (migration populates orgId from Repository.organizationId) is a
+  // DDL-level concern validated by running the Prisma migration against a
+  // real DB — covered by integration tests in packages/e2e/, not here.
+  // ==========================================================================
 
-  describe('4.5. Signing (PKP-E1)', () => {
-    it('[PKP-E1] should decrypt stored key, sign with Ed25519, and return signature', async () => {
-      const { prisma } = createMockPrisma();
-      const { publicKey, privateKey } = await generateKeys();
+  describe('4.5. Schema Migration invariants (PKP-E1 to E3)', () => {
+    it('[PKP-E1] should enforce one active key per [actorId, orgId]', async () => {
+      // The mock ActorKeyDelegate enforces the unique constraint defined in
+      // the spec §3.3 schema: @@unique([actorId, orgId, status])
+      const { provider, client, actorKeyRows } = await bootstrapProvider('org-1');
+      const keys1 = await generateKeys();
+      const keys2 = await generateKeys();
 
-      // Store real Ed25519 key (plaintext mode — no encryption secret for simplicity)
-      const provider = new PrismaKeyProvider({ prisma, repoId: 'repo-1' });
-      await provider.setPrivateKey('human:alice', privateKey);
+      await provider.storeKey('human:alice', keys1);
+      // Second storeKey: must archive the first one BEFORE creating the second,
+      // otherwise the unique constraint blocks the insert.
+      await provider.storeKey('human:alice', keys2);
 
-      // Sign data
-      const data = new Uint8Array(createHash('sha256').update('test-payload').digest());
-      const signature = await provider.sign('human:alice', data);
+      const activeRows = actorKeyRows.filter(
+        (r) => r.actorId === 'human:alice' && r.status === STATUS_ACTIVE,
+      );
+      const archivedRows = actorKeyRows.filter(
+        (r) => r.actorId === 'human:alice' && r.status === STATUS_ARCHIVED,
+      );
 
-      expect(signature).toBeInstanceOf(Uint8Array);
-      expect(signature.length).toBe(64);
-
-      // Verify Ed25519 signature
-      const algorithmId = Buffer.from([0x30,0x2a,0x30,0x05,0x06,0x03,0x2b,0x65,0x70,0x03,0x21,0x00]);
-      const spki = Buffer.concat([algorithmId, Buffer.from(publicKey, 'base64')]);
-      const isValid = verify(null, data, { key: spki, type: 'spki', format: 'der' }, Buffer.from(signature));
-      expect(isValid).toBe(true);
+      // Exactly one active row at any time
+      expect(activeRows).toHaveLength(1);
+      expect(archivedRows).toHaveLength(1);
+      // Old row is still queryable for audit (not hard-deleted)
+      expect(actorKeyRows).toHaveLength(2);
+      // The transactional archive+create path was used
+      expect(client.$transaction).toHaveBeenCalled();
     });
 
-    it('[PKP-E1] should throw KEY_NOT_FOUND when signing with no active key', async () => {
-      const { prisma } = createMockPrisma();
-      const provider = new PrismaKeyProvider({ prisma, repoId: 'repo-1' });
+    it('[PKP-E2] should store iv and authTag as separate hex columns', async () => {
+      const { provider, actorKeyRows } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
 
-      const data = new Uint8Array(createHash('sha256').update('test-payload').digest());
+      await provider.storeKey('human:alice', { publicKey, privateKey });
 
-      await expect(provider.sign('human:nonexistent', data))
-        .rejects.toMatchObject({ code: 'KEY_NOT_FOUND' });
+      const row = actorKeyRows[0];
+      if (!row) throw new Error('row missing');
+
+      // iv: 12 bytes = 24 hex chars
+      expect(row.iv).toMatch(/^[0-9a-f]{24}$/);
+      // authTag: 16 bytes = 32 hex chars
+      expect(row.authTag).toMatch(/^[0-9a-f]{32}$/);
+      // encryptedPrivateKey: hex, non-empty, distinct from iv/authTag (separate columns)
+      expect(row.encryptedPrivateKey).toMatch(/^[0-9a-f]+$/);
+      expect(row.encryptedPrivateKey).not.toBe(row.iv);
+      expect(row.encryptedPrivateKey).not.toBe(row.authTag);
+    });
+
+    it('[PKP-E3] should have status field with active|archived|revoked default active', async () => {
+      const { provider, actorKeyRows } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
+
+      await provider.storeKey('human:alice', { publicKey, privateKey });
+
+      const row = actorKeyRows[0];
+      if (!row) throw new Error('row missing');
+      // Default for a freshly-created row is 'active' (spec §3.3)
+      expect(row.status).toBe(STATUS_ACTIVE);
+
+      // Archiving transitions to 'archived' — documents the allowed state
+      // transition from `active` to `archived`. The third literal `revoked`
+      // is a valid target for future revocation flows (not exercised here).
+      await provider.archiveKey('human:alice');
+      expect(row.status).toBe(STATUS_ARCHIVED);
+    });
+  });
+
+  // ==========================================================================
+  // 4.6. Org Key Hierarchy (PKP-F1 to F4)
+  // ==========================================================================
+
+  describe('4.6. Org Key Hierarchy (PKP-F1 to F4)', () => {
+    it('[PKP-F1] should encrypt a random org key with HKDF-derived key and persist as hex', async () => {
+      process.env['MASTER_KEY'] = TEST_MASTER_KEY;
+      const { client, orgKeyRows } = createMockPrismaClient();
+
+      await createOrgEncryptionKey(client, 'org-test-f1');
+
+      expect(client.orgEncryptionKey.create).toHaveBeenCalledTimes(1);
+      const row = orgKeyRows.get('org-test-f1');
+      expect(row).toBeDefined();
+      if (!row) throw new Error('row missing');
+
+      expect(row.iv).toMatch(/^[0-9a-f]{24}$/); // 12 bytes
+      expect(row.authTag).toMatch(/^[0-9a-f]{32}$/); // 16 bytes
+      // AES-GCM is a stream cipher: ciphertext length === plaintext length.
+      // Plaintext is the 32-byte random org key.
+      expect(row.encryptedOrgKey).toMatch(/^[0-9a-f]{64}$/);
+
+      // Round-trip: the caller should be able to decrypt with the same HKDF
+      // derivation and recover a 32-byte plaintext.
+      const wrappingKey = await deriveHkdfKey(
+        TEST_MASTER_KEY,
+        MASTER_KEY_HKDF_INFO,
+        KEY_LENGTH_BYTES,
+      );
+      const iv = Buffer.from(row.iv, 'hex');
+      const authTag = Buffer.from(row.authTag, 'hex');
+      const ciphertext = Buffer.from(row.encryptedOrgKey, 'hex');
+      const decipher = createDecipheriv(AES_GCM_ALGORITHM, wrappingKey, iv);
+      decipher.setAuthTag(authTag);
+      const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+      expect(decrypted.length).toBe(KEY_LENGTH_BYTES);
+    });
+
+    it('[PKP-F1] should produce non-deterministic ciphertext (random IV per call)', async () => {
+      process.env['MASTER_KEY'] = TEST_MASTER_KEY;
+      const { client: clientA, orgKeyRows: rowsA } = createMockPrismaClient();
+      const { client: clientB, orgKeyRows: rowsB } = createMockPrismaClient();
+
+      await createOrgEncryptionKey(clientA, 'org-a');
+      await createOrgEncryptionKey(clientB, 'org-b');
+
+      const rowA = rowsA.get('org-a');
+      const rowB = rowsB.get('org-b');
+      if (!rowA || !rowB) throw new Error('rows missing');
+
+      expect(rowA.iv).not.toBe(rowB.iv);
+      expect(rowA.encryptedOrgKey).not.toBe(rowB.encryptedOrgKey);
+      expect(rowA.authTag).not.toBe(rowB.authTag);
+    });
+
+    it('[PKP-F1] should throw KeyProviderError STORE_FAILED when MASTER_KEY is missing', async () => {
+      delete process.env['MASTER_KEY'];
+      const { client } = createMockPrismaClient();
+
+      await expect(createOrgEncryptionKey(client, 'org-f1-missing')).rejects.toBeInstanceOf(
+        KeyProviderError,
+      );
+      await expect(createOrgEncryptionKey(client, 'org-f1-missing')).rejects.toMatchObject({
+        code: 'STORE_FAILED',
+        context: expect.objectContaining({
+          orgId: 'org-f1-missing',
+          hint: expect.stringContaining('MASTER_KEY'),
+        }),
+      });
+
+      expect(client.orgEncryptionKey.create).not.toHaveBeenCalled();
+    });
+
+    it('[PKP-F2] should lazy-load OrgEncryptionKey and cache plaintext in-instance', async () => {
+      const { provider, client } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
+
+      // First call: triggers lazy-load of org key
+      await provider.storeKey('human:alice', { publicKey, privateKey });
+      const firstCallCount = (client.orgEncryptionKey.findUnique as jest.Mock).mock.calls
+        .length;
+      expect(firstCallCount).toBeGreaterThanOrEqual(1);
+
+      // Second and third calls: should NOT re-fetch OrgEncryptionKey (cache hit)
+      await provider.getPrivateKey('human:alice');
+      await provider.storeKey('human:bob', {
+        publicKey: (await generateKeys()).publicKey,
+        privateKey: (await generateKeys()).privateKey,
+      });
+
+      const finalCallCount = (client.orgEncryptionKey.findUnique as jest.Mock).mock.calls
+        .length;
+      // Cache hit: count didn't increase on subsequent operations
+      expect(finalCallCount).toBe(firstCallCount);
+    });
+
+    it('[PKP-F3] should encrypt ActorKey with org key, never with MASTER_KEY directly', async () => {
+      // Structural invariant: if we bypass the org_key (by storing ActorKey
+      // with a MASTER_KEY-derived ciphertext), decryption via PrismaKeyProvider
+      // must FAIL because the provider expects the org_key wrapping.
+      //
+      // This test validates PKP-F3 by the contrapositive: using MASTER_KEY
+      // directly to encrypt an actor key produces ciphertext that the
+      // provider cannot decrypt — proving the provider uses org_key, not
+      // MASTER_KEY.
+      const { provider, client, orgKeyRows, actorKeyRows } = await bootstrapProvider(
+        'org-1',
+      );
+      const { privateKey, publicKey } = await generateKeys();
+
+      // Manually insert a row encrypted with MASTER_KEY-derived key (WRONG)
+      const masterDerived = await deriveHkdfKey(
+        TEST_MASTER_KEY,
+        MASTER_KEY_HKDF_INFO,
+        KEY_LENGTH_BYTES,
+      );
+      const iv = randomBytes(GCM_IV_LENGTH);
+      const cipher = createCipheriv(AES_GCM_ALGORITHM, masterDerived, iv);
+      const ct = Buffer.concat([
+        cipher.update(Buffer.from(privateKey, 'utf-8')),
+        cipher.final(),
+      ]);
+      const authTag = cipher.getAuthTag();
+
+      await client.actorKey.create({
+        data: {
+          actorId: 'human:wrong',
+          orgId: 'org-1',
+          publicKey,
+          encryptedPrivateKey: ct.toString('hex'),
+          iv: iv.toString('hex'),
+          authTag: authTag.toString('hex'),
+          status: STATUS_ACTIVE,
+          lastUsedAt: new Date(),
+        },
+      });
+
+      // Attempt to decrypt via provider (which uses org_key, not MASTER_KEY-derived)
+      await expect(provider.getPrivateKey('human:wrong')).rejects.toBeInstanceOf(
+        KeyProviderError,
+      );
+      await expect(provider.getPrivateKey('human:wrong')).rejects.toMatchObject({
+        code: 'DECRYPTION_FAILED',
+      });
+
+      // Sanity: the org_key and the master-derived key are DIFFERENT buffers
+      const orgRow = orgKeyRows.get('org-1');
+      if (!orgRow) throw new Error('org row missing');
+      const orgIv = Buffer.from(orgRow.iv, 'hex');
+      const orgAuthTag = Buffer.from(orgRow.authTag, 'hex');
+      const orgCipher = Buffer.from(orgRow.encryptedOrgKey, 'hex');
+      const dec = createDecipheriv(AES_GCM_ALGORITHM, masterDerived, orgIv);
+      dec.setAuthTag(orgAuthTag);
+      const actualOrgKey = Buffer.concat([dec.update(orgCipher), dec.final()]);
+      expect(actualOrgKey.equals(masterDerived)).toBe(false);
+
+      // Clean up the wrong row
+      expect(actorKeyRows).toHaveLength(1);
+    });
+
+    it('[PKP-F4] should re-encrypt all active actor keys when org key is rotated', async () => {
+      const { provider, client, orgKeyRows, actorKeyRows } = await bootstrapProvider(
+        'org-1',
+      );
+
+      // Seed multiple actor keys
+      const alice = await generateKeys();
+      const bob = await generateKeys();
+      await provider.storeKey('human:alice', alice);
+      await provider.storeKey('human:bob', bob);
+
+      // Capture old ciphertexts
+      const aliceRowBefore = actorKeyRows.find(
+        (r) => r.actorId === 'human:alice' && r.status === STATUS_ACTIVE,
+      );
+      const bobRowBefore = actorKeyRows.find(
+        (r) => r.actorId === 'human:bob' && r.status === STATUS_ACTIVE,
+      );
+      if (!aliceRowBefore || !bobRowBefore) throw new Error('rows missing');
+      const aliceOldCt = aliceRowBefore.encryptedPrivateKey;
+      const bobOldCt = bobRowBefore.encryptedPrivateKey;
+      const orgKeyBefore = orgKeyRows.get('org-1')?.encryptedOrgKey;
+
+      // Rotate
+      await rotateOrgEncryptionKey(client, 'org-1');
+
+      // Org key row was updated
+      const orgKeyAfter = orgKeyRows.get('org-1')?.encryptedOrgKey;
+      expect(orgKeyAfter).not.toBe(orgKeyBefore);
+
+      // Actor key ciphertexts changed (re-encrypted)
+      const aliceRowAfter = actorKeyRows.find(
+        (r) => r.actorId === 'human:alice' && r.status === STATUS_ACTIVE,
+      );
+      const bobRowAfter = actorKeyRows.find(
+        (r) => r.actorId === 'human:bob' && r.status === STATUS_ACTIVE,
+      );
+      expect(aliceRowAfter?.encryptedPrivateKey).not.toBe(aliceOldCt);
+      expect(bobRowAfter?.encryptedPrivateKey).not.toBe(bobOldCt);
+
+      // After rotation, force the provider to reload the org key cache
+      // and verify plaintext round-trip still works.
+      const providerAfter = new PrismaKeyProvider(client, 'org-1');
+      expect(await providerAfter.getPrivateKey('human:alice')).toBe(alice.privateKey);
+      expect(await providerAfter.getPrivateKey('human:bob')).toBe(bob.privateKey);
+    });
+  });
+
+  // ==========================================================================
+  // 4.7. Key Lifecycle v2 — storeKey / archive / getPublicKey (PKP-G1 to G10)
+  // ==========================================================================
+
+  describe('4.7. Key Lifecycle v2 (PKP-G1 to G10)', () => {
+    it('[PKP-G1] should encrypt private key with AES-256-GCM and random IV', async () => {
+      const { provider, actorKeyRows } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
+
+      await provider.storeKey('human:alice', { publicKey, privateKey });
+
+      const row = actorKeyRows[0];
+      if (!row) throw new Error('row missing');
+
+      // IV: 12 bytes hex → 24 chars
+      expect(row.iv).toMatch(/^[0-9a-f]{24}$/);
+      // Store another actor — IV MUST be different (random per op)
+      const bob = await generateKeys();
+      await provider.storeKey('human:bob', bob);
+      const bobRow = actorKeyRows.find(
+        (r) => r.actorId === 'human:bob' && r.status === STATUS_ACTIVE,
+      );
+      if (!bobRow) throw new Error('bob row missing');
+      expect(bobRow.iv).not.toBe(row.iv);
+      // Ciphertexts differ (trivially from IV difference, even if plaintext collided)
+      expect(bobRow.encryptedPrivateKey).not.toBe(row.encryptedPrivateKey);
+    });
+
+    it('[PKP-G2] should archive old active row and create new one in a transaction', async () => {
+      const { provider, client, actorKeyRows } = await bootstrapProvider('org-1');
+      const keys1 = await generateKeys();
+      const keys2 = await generateKeys();
+
+      await provider.storeKey('human:alice', keys1);
+      await provider.storeKey('human:alice', keys2);
+
+      // transaction was invoked for each storeKey call (2 total)
+      expect(client.$transaction).toHaveBeenCalledTimes(2);
+
+      // One active + one archived row for human:alice
+      const aliceRows = actorKeyRows.filter((r) => r.actorId === 'human:alice');
+      expect(aliceRows).toHaveLength(2);
+      const activeCount = aliceRows.filter((r) => r.status === STATUS_ACTIVE).length;
+      const archivedCount = aliceRows.filter((r) => r.status === STATUS_ARCHIVED).length;
+      expect(activeCount).toBe(1);
+      expect(archivedCount).toBe(1);
+
+      // Active row has the newest keys
+      expect(await provider.getPrivateKey('human:alice')).toBe(keys2.privateKey);
+    });
+
+    it('[PKP-G3] should set lastUsedAt on the new active row', async () => {
+      const { provider, actorKeyRows } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
+      const before = Date.now();
+
+      await provider.storeKey('human:alice', { publicKey, privateKey });
+
+      const row = actorKeyRows.find(
+        (r) => r.actorId === 'human:alice' && r.status === STATUS_ACTIVE,
+      );
+      expect(row?.lastUsedAt).toBeInstanceOf(Date);
+      expect(row!.lastUsedAt!.getTime()).toBeGreaterThanOrEqual(before);
+    });
+
+    it('[PKP-G4] should throw STORE_FAILED when DB or encryption fails', async () => {
+      const { provider, client } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
+
+      // Force the underlying transaction to throw persistently (not just once,
+      // because the test asserts twice on the same rejection shape).
+      (client.$transaction as jest.Mock).mockImplementation(async () => {
+        throw new Error('DB connection lost');
+      });
+
+      // Capture the thrown error once, then assert its shape.
+      let caught: unknown;
+      try {
+        await provider.storeKey('human:alice', { publicKey, privateKey });
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(KeyProviderError);
+      expect(caught).toMatchObject({
+        code: 'STORE_FAILED',
+        context: expect.objectContaining({
+          actorId: 'human:alice',
+          orgId: 'org-1',
+        }),
+      });
+    });
+
+    it('[PKP-G5] should return public key without touching org key or decryption', async () => {
+      const { provider, client } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
+      await provider.storeKey('human:alice', { publicKey, privateKey });
+
+      // Clear the cache to force a fresh lazy-load on next org_key access
+      (provider as unknown as { _clearOrgKeyCacheForTesting(): void })._clearOrgKeyCacheForTesting();
+
+      const orgKeyFetchesBefore = (client.orgEncryptionKey.findUnique as jest.Mock).mock
+        .calls.length;
+
+      const result = await provider.getPublicKey('human:alice');
+
+      expect(result).toBe(publicKey);
+      // getPublicKey MUST NOT fetch the OrgEncryptionKey row (no decryption)
+      const orgKeyFetchesAfter = (client.orgEncryptionKey.findUnique as jest.Mock).mock
+        .calls.length;
+      expect(orgKeyFetchesAfter).toBe(orgKeyFetchesBefore);
+    });
+
+    it('[PKP-G6] should return null when no active key exists', async () => {
+      const { provider } = await bootstrapProvider('org-1');
+
+      const result = await provider.getPublicKey('human:ghost');
+
+      expect(result).toBeNull();
+    });
+
+    it('[PKP-G7] should set status to archived and record lastUsedAt', async () => {
+      const { provider, actorKeyRows } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
+      await provider.storeKey('human:alice', { publicKey, privateKey });
+
+      const beforeArchive = Date.now();
+      await provider.archiveKey('human:alice');
+
+      const row = actorKeyRows.find((r) => r.actorId === 'human:alice');
+      expect(row?.status).toBe(STATUS_ARCHIVED);
+      expect(row?.lastUsedAt).toBeInstanceOf(Date);
+      expect(row!.lastUsedAt!.getTime()).toBeGreaterThanOrEqual(beforeArchive);
+    });
+
+    it('[PKP-G8] should be a no-op when no active key exists', async () => {
+      const { provider, actorKeyRows } = await bootstrapProvider('org-1');
+
+      // No throw, no side effect
+      await expect(provider.archiveKey('human:ghost')).resolves.toBeUndefined();
+      expect(actorKeyRows).toHaveLength(0);
+
+      // Calling archiveKey twice is also a no-op the second time
+      const { privateKey, publicKey } = await generateKeys();
+      await provider.storeKey('human:alice', { publicKey, privateKey });
+      await provider.archiveKey('human:alice');
+      await expect(provider.archiveKey('human:alice')).resolves.toBeUndefined();
+
+      // Still exactly 1 row (archived), no duplicates from the double archive
+      expect(actorKeyRows).toHaveLength(1);
+      expect(actorKeyRows[0]?.status).toBe(STATUS_ARCHIVED);
+    });
+
+    it('[PKP-G9] should throw DECRYPTION_FAILED when AES-GCM decryption fails', async () => {
+      const { provider, actorKeyRows } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
+      await provider.storeKey('human:alice', { publicKey, privateKey });
+
+      // Tamper the ciphertext directly in the mock
+      const row = actorKeyRows[0];
+      if (!row || !row.encryptedPrivateKey) throw new Error('row missing');
+      // Flip last hex char to guarantee ciphertext is invalid
+      const tampered = row.encryptedPrivateKey.slice(0, -2) + '00';
+      row.encryptedPrivateKey = tampered;
+
+      await expect(provider.getPrivateKey('human:alice')).rejects.toBeInstanceOf(
+        KeyProviderError,
+      );
+      await expect(provider.getPrivateKey('human:alice')).rejects.toMatchObject({
+        code: 'DECRYPTION_FAILED',
+        context: expect.objectContaining({
+          actorId: 'human:alice',
+          orgId: 'org-1',
+        }),
+      });
+    });
+
+    it('[PKP-G10] should ignore archived rows in getPrivateKey/sign/getPublicKey', async () => {
+      const { provider, actorKeyRows } = await bootstrapProvider('org-1');
+      const { privateKey, publicKey } = await generateKeys();
+      await provider.storeKey('human:alice', { publicKey, privateKey });
+
+      // Archive the active row
+      await provider.archiveKey('human:alice');
+
+      // Archived row still exists in the table
+      expect(actorKeyRows).toHaveLength(1);
+      expect(actorKeyRows[0]?.status).toBe(STATUS_ARCHIVED);
+
+      // But getPrivateKey/getPublicKey/hasPrivateKey all ignore it
+      expect(await provider.getPrivateKey('human:alice')).toBeNull();
+      expect(await provider.getPublicKey('human:alice')).toBeNull();
+      expect(await provider.hasPrivateKey('human:alice')).toBe(false);
+
+      // And sign throws KEY_NOT_FOUND
+      const data = new Uint8Array(Buffer.from('test', 'utf-8'));
+      await expect(provider.sign('human:alice', data)).rejects.toMatchObject({
+        code: 'KEY_NOT_FOUND',
+      });
     });
   });
 });

--- a/packages/core/src/key_provider/prisma/prisma_key_provider.test.ts
+++ b/packages/core/src/key_provider/prisma/prisma_key_provider.test.ts
@@ -14,11 +14,14 @@
  * | PKP-C2  | should store key in plaintext when no encryptionSecret           | 4.3     |
  * | PKP-C3  | should throw KEY_READ_ERROR when decryption fails               | 4.3     |
  * | PKP-D1  | should return true or false without reading key content          | 4.4     |
+ * | PKP-E1  | should sign data with decrypted key and throw KEY_NOT_FOUND     | 4.5     |
  */
 
+import { verify, createHash } from 'crypto';
 import { PrismaKeyProvider } from './prisma_key_provider';
 import { KeyProviderError } from '../key_provider';
 import type { ActorKeyRow, ActorKeyDelegate } from './prisma_key_provider.types';
+import { generateKeys } from '../../crypto/signatures';
 
 // ============================================================================
 // Mock factory
@@ -234,6 +237,38 @@ describe('PrismaKeyProvider', () => {
       expect(prisma.actorKey.count).toHaveBeenCalledWith({
         where: { actorId: 'human:alice', repoId: 'repo-1' },
       });
+    });
+  });
+
+  // ==========================================
+  // 4.5. Signing (PKP-E1)
+  // ==========================================
+
+  describe('4.5. Signing (PKP-E1)', () => {
+    it('[PKP-E1] should sign data with decrypted key and throw KEY_NOT_FOUND when missing', async () => {
+      const { prisma } = createMockPrisma();
+      const { publicKey, privateKey } = await generateKeys();
+
+      // Store real Ed25519 key (plaintext mode — no encryption secret for simplicity)
+      const provider = new PrismaKeyProvider({ prisma, repoId: 'repo-1' });
+      await provider.setPrivateKey('human:alice', privateKey);
+
+      // Sign data
+      const data = new Uint8Array(createHash('sha256').update('test-payload').digest());
+      const signature = await provider.sign('human:alice', data);
+
+      expect(signature).toBeInstanceOf(Uint8Array);
+      expect(signature.length).toBe(64);
+
+      // Verify Ed25519 signature
+      const algorithmId = Buffer.from([0x30,0x2a,0x30,0x05,0x06,0x03,0x2b,0x65,0x70,0x03,0x21,0x00]);
+      const spki = Buffer.concat([algorithmId, Buffer.from(publicKey, 'base64')]);
+      const isValid = verify(null, data, { key: spki, type: 'spki', format: 'der' }, Buffer.from(signature));
+      expect(isValid).toBe(true);
+
+      // Throws KEY_NOT_FOUND for missing actor
+      await expect(provider.sign('human:nonexistent', data))
+        .rejects.toMatchObject({ code: 'KEY_NOT_FOUND' });
     });
   });
 });

--- a/packages/core/src/key_provider/prisma/prisma_key_provider.ts
+++ b/packages/core/src/key_provider/prisma/prisma_key_provider.ts
@@ -17,6 +17,7 @@
  * | PKP-C2  | plaintext mode  | 4.3     |
  * | PKP-C3  | decrypt error   | 4.3     |
  * | PKP-D1  | hasPrivateKey   | 4.4     |
+ * | PKP-E1  | sign            | 4.5     |
  */
 
 import { createCipheriv, createDecipheriv, randomBytes, createHash, sign } from 'node:crypto';

--- a/packages/core/src/key_provider/prisma/prisma_key_provider.ts
+++ b/packages/core/src/key_provider/prisma/prisma_key_provider.ts
@@ -23,6 +23,7 @@
 import { createCipheriv, createDecipheriv, randomBytes, createHash, sign } from 'node:crypto';
 import type { KeyProvider } from '../key_provider';
 import { KeyProviderError } from '../key_provider';
+import { derivePublicKey } from '../../crypto/signatures';
 import type { PrismaKeyProviderOptions } from './prisma_key_provider.types';
 
 const ALGORITHM = 'aes-256-gcm';
@@ -38,6 +39,29 @@ export class PrismaKeyProvider implements KeyProvider {
     this.prisma = options.prisma;
     this.repoId = options.repoId;
     this.encryptionSecret = options.encryptionSecret;
+  }
+
+  /**
+   * [EARS-KP07] Derives the raw Ed25519 public key from the stored private key.
+   * [EARS-KP08] Returns null if no key exists for the actor.
+   *
+   * Note: v1 derives on-demand. In Cycle 2 v2 this will be replaced with a direct
+   * read of the `publicKey` column on ActorKey (no decryption, no org_key access).
+   */
+  async getPublicKey(actorId: string): Promise<string | null> {
+    const privateKey = await this.getPrivateKey(actorId);
+    if (!privateKey) {
+      return null;
+    }
+    try {
+      return derivePublicKey(privateKey);
+    } catch (error) {
+      throw new KeyProviderError(
+        `Failed to derive public key for ${actorId}: ${(error as Error).message}`,
+        'KEY_READ_ERROR',
+        { actorId }
+      );
+    }
   }
 
   /**

--- a/packages/core/src/key_provider/prisma/prisma_key_provider.ts
+++ b/packages/core/src/key_provider/prisma/prisma_key_provider.ts
@@ -19,7 +19,7 @@
  * | PKP-D1  | hasPrivateKey   | 4.4     |
  */
 
-import { createCipheriv, createDecipheriv, randomBytes, createHash } from 'node:crypto';
+import { createCipheriv, createDecipheriv, randomBytes, createHash, sign } from 'node:crypto';
 import type { KeyProvider } from '../key_provider';
 import { KeyProviderError } from '../key_provider';
 import type { PrismaKeyProviderOptions } from './prisma_key_provider.types';
@@ -37,6 +37,29 @@ export class PrismaKeyProvider implements KeyProvider {
     this.prisma = options.prisma;
     this.repoId = options.repoId;
     this.encryptionSecret = options.encryptionSecret;
+  }
+
+  /**
+   * [PKP-E1] Signs data with actor's Ed25519 private key (decrypted from DB).
+   * Throws KeyProviderError('KEY_NOT_FOUND') if no key stored.
+   * Full implementation in Cycle 2 with org key hierarchy.
+   */
+  async sign(actorId: string, data: Uint8Array): Promise<Uint8Array> {
+    const privateKey = await this.getPrivateKey(actorId);
+    if (!privateKey) {
+      throw new KeyProviderError(
+        `Private key not found for ${actorId}`,
+        'KEY_NOT_FOUND',
+        { actorId, hint: 'Run gitgov login to sync your signing key' }
+      );
+    }
+
+    const signature = sign(null, data, {
+      key: Buffer.from(privateKey, 'base64'),
+      type: 'pkcs8',
+      format: 'pem',
+    });
+    return new Uint8Array(signature);
   }
 
   /**
@@ -61,7 +84,7 @@ export class PrismaKeyProvider implements KeyProvider {
       throw new KeyProviderError(
         `Failed to decrypt private key for ${actorId}: ${(error as Error).message}`,
         'KEY_READ_ERROR',
-        actorId,
+        { actorId },
       );
     }
   }
@@ -82,7 +105,7 @@ export class PrismaKeyProvider implements KeyProvider {
       throw new KeyProviderError(
         `Failed to store private key for ${actorId}: ${(error as Error).message}`,
         'KEY_WRITE_ERROR',
-        actorId,
+        { actorId },
       );
     }
   }

--- a/packages/core/src/key_provider/prisma/prisma_key_provider.ts
+++ b/packages/core/src/key_provider/prisma/prisma_key_provider.ts
@@ -1,215 +1,736 @@
 /**
- * PrismaKeyProvider — Database-backed KeyProvider implementation.
- * Blueprint: prisma_key_provider_module.md
+ * PrismaKeyProvider v2 — Database-backed KeyProvider implementation.
+ * Blueprint: prisma_key_provider_module.md (v2 target, Cycle 2 of identity_key_sync)
  *
- * Stores private keys in an ActorKey table, encrypted with AES-256-GCM.
- * Used by SaaS environments for multi-tenant key management.
+ * Stores Ed25519 private keys in an `ActorKey` table, encrypted at rest with
+ * AES-256-GCM via a 3-level key hierarchy:
  *
- * | EARS ID | Method          | Section |
- * |---------|-----------------|---------|
- * | PKP-A1  | getPrivateKey   | 4.1     |
- * | PKP-A2  | getPrivateKey   | 4.1     |
- * | PKP-A3  | setPrivateKey   | 4.1     |
- * | PKP-A4  | deletePrivateKey| 4.1     |
- * | PKP-B1  | (isolation)     | 4.2     |
- * | PKP-B2  | (isolation)     | 4.2     |
- * | PKP-C1  | encrypt/decrypt | 4.3     |
- * | PKP-C2  | plaintext mode  | 4.3     |
- * | PKP-C3  | decrypt error   | 4.3     |
- * | PKP-D1  | hasPrivateKey   | 4.4     |
- * | PKP-E1  | sign            | 4.5     |
+ *   MASTER_KEY (env var)
+ *       ↓  HKDF-SHA256, info='gitgov-org-key'
+ *   wrapping key (in-memory only)
+ *       ↓  decrypts OrgEncryptionKey.encryptedOrgKey
+ *   org_key (cached per-instance)
+ *       ↓  encrypts/decrypts ActorKey.encryptedPrivateKey
+ *   actor private key
+ *
+ * Org-scoped: one `PrismaKeyProvider` instance is scoped to a single `orgId`
+ * at construction time. Actor keys are isolated per-org.
+ *
+ * Append-only lifecycle: `storeKey()` archives the previous active row and
+ * creates a new one transactionally. `deletePrivateKey()` delegates to
+ * `archiveKey()` — no hard deletes.
+ *
+ * | EARS ID  | Method / Behavior                          | Section |
+ * |----------|--------------------------------------------|---------|
+ * | PKP-A1   | getPrivateKey (decrypt + return)           | 4.1     |
+ * | PKP-A2   | getPrivateKey returns null when no active  | 4.1     |
+ * | PKP-A3   | setPrivateKey derives pub + delegates      | 4.1     |
+ * | PKP-A4   | deletePrivateKey → archiveKey              | 4.1     |
+ * | PKP-B1   | org-level isolation                        | 4.2     |
+ * | PKP-B2   | same actorId across orgs independent       | 4.2     |
+ * | PKP-C1   | hasPrivateKey via count                    | 4.3     |
+ * | PKP-D1   | sign (decrypt + Ed25519 + lastUsedAt)      | 4.4     |
+ * | PKP-D2   | sign throws KEY_NOT_FOUND                  | 4.4     |
+ * | PKP-E1-3 | schema invariants (DDL) — enforced by      | 4.5     |
+ * |          | Prisma schema + migration SQL (not runtime |         |
+ * |          | code). See saas.prisma ActorKey model and  |         |
+ * |          | prisma_key_provider.test.ts §4.5 block.    |         |
+ * | PKP-E4   | DDL migration runtime — deferred to e2e    | 4.5 🟡  |
+ * |          | (actorkey_migration_flow, Task 2.2)        |         |
+ * | PKP-F1   | createOrgEncryptionKey bootstrap           | 4.6     |
+ * | PKP-F2   | lazy-load + cache org key                  | 4.6     |
+ * | PKP-F3   | MASTER_KEY never encrypts actor keys       | 4.6     |
+ * | PKP-F4   | rotate org key re-encrypts actor keys      | 4.6     |
+ * | PKP-G1   | storeKey random IV per op                  | 4.7     |
+ * | PKP-G2   | storeKey archives old active row (tx)      | 4.7     |
+ * | PKP-G3   | storeKey updates lastUsedAt                | 4.7     |
+ * | PKP-G4   | storeKey throws STORE_FAILED               | 4.7     |
+ * | PKP-G5   | getPublicKey without decryption            | 4.7     |
+ * | PKP-G6   | getPublicKey null when no active           | 4.7     |
+ * | PKP-G7   | archiveKey sets status + lastUsedAt        | 4.7     |
+ * | PKP-G8   | archiveKey idempotent                      | 4.7     |
+ * | PKP-G9   | decryption failure → DECRYPTION_FAILED     | 4.7     |
+ * | PKP-G10  | archived rows ignored by active-only ops   | 4.7     |
  */
 
-import { createCipheriv, createDecipheriv, randomBytes, createHash, sign } from 'node:crypto';
-import type { KeyProvider } from '../key_provider';
+import { createCipheriv, createDecipheriv, randomBytes, sign as cryptoSign } from 'node:crypto';
+import type { KeyProvider, KeyPair } from '../key_provider';
 import { KeyProviderError } from '../key_provider';
-import { derivePublicKey } from '../../crypto/signatures';
-import type { PrismaKeyProviderOptions } from './prisma_key_provider.types';
+import { derivePublicKey, deriveHkdfKey } from '../../crypto/signatures';
+import type {
+  ActorKeyRow,
+  OrgEncryptionKeyClient,
+  PrismaClientLike,
+} from './prisma_key_provider.types';
 
-const ALGORITHM = 'aes-256-gcm';
-const IV_LENGTH = 12;
-const AUTH_TAG_LENGTH = 16;
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/** AES-256-GCM algorithm identifier for Node's crypto module */
+const AES_GCM_ALGORITHM = 'aes-256-gcm';
+
+/** AES-GCM IV length: 12 bytes (96 bits, NIST-recommended for GCM) */
+const GCM_IV_LENGTH = 12;
+
+/** Raw org key / AES-256 key length in bytes */
+const KEY_LENGTH_BYTES = 32;
+
+/**
+ * HKDF `info` parameter for deriving the MASTER_KEY wrapping key. Binds the
+ * derived key to this specific purpose — MASTER_KEY can be safely reused
+ * with different `info` strings for other derivation domains.
+ */
+const MASTER_KEY_HKDF_INFO = 'gitgov-org-key';
+
+/** Active status literal for ActorKey rows */
+const STATUS_ACTIVE = 'active';
+
+/** Archived status literal for ActorKey rows */
+const STATUS_ARCHIVED = 'archived';
+
+// ─── Class: PrismaKeyProvider v2 ────────────────────────────────────────────
 
 export class PrismaKeyProvider implements KeyProvider {
-  private readonly prisma: PrismaKeyProviderOptions['prisma'];
-  private readonly repoId: string;
-  private readonly encryptionSecret: string | undefined;
-
-  constructor(options: PrismaKeyProviderOptions) {
-    this.prisma = options.prisma;
-    this.repoId = options.repoId;
-    this.encryptionSecret = options.encryptionSecret;
-  }
+  private readonly prisma: PrismaClientLike;
+  private readonly orgId: string;
 
   /**
-   * [EARS-KP07] Derives the raw Ed25519 public key from the stored private key.
-   * [EARS-KP08] Returns null if no key exists for the actor.
+   * Lazy-loaded + cached org key (plaintext, 32 bytes). Populated on first
+   * call to any method that needs to encrypt/decrypt actor keys. NEVER
+   * logged, NEVER exposed via getters. Scoped to this instance only.
    *
-   * Note: v1 derives on-demand. In Cycle 2 v2 this will be replaced with a direct
-   * read of the `publicKey` column on ActorKey (no decryption, no org_key access).
+   * [PKP-F2] lazy-load + cache org key per instance
    */
-  async getPublicKey(actorId: string): Promise<string | null> {
-    const privateKey = await this.getPrivateKey(actorId);
-    if (!privateKey) {
-      return null;
-    }
-    try {
-      return derivePublicKey(privateKey);
-    } catch (error) {
-      throw new KeyProviderError(
-        `Failed to derive public key for ${actorId}: ${(error as Error).message}`,
-        'KEY_READ_ERROR',
-        { actorId }
-      );
-    }
-  }
+  private orgKeyCache: Buffer | null = null;
 
   /**
-   * [PKP-E1] Signs data with actor's Ed25519 private key (decrypted from DB).
-   * Throws KeyProviderError('KEY_NOT_FOUND') if no key stored.
-   * Full implementation in Cycle 2 with org key hierarchy.
+   * Constructs a key provider scoped to a single organization.
+   *
+   * @param prisma - Prisma-compatible client (real PrismaClient satisfies this).
+   * @param orgId - Organization ID. All keys managed by this instance belong
+   *                to this org. The `OrgEncryptionKey` row for this orgId
+   *                must exist (created via `createOrgEncryptionKey`).
+   */
+  constructor(prisma: PrismaClientLike, orgId: string) {
+    this.prisma = prisma;
+    this.orgId = orgId;
+  }
+
+  // ─── IKeyProvider base (6 methods) ─────────────────────────────────────────
+
+  /**
+   * [PKP-D1] Signs data with the actor's Ed25519 private key.
+   * [PKP-D2] Throws KeyProviderError('KEY_NOT_FOUND') if no active key exists.
+   *
+   * Flow: obtain org key (lazy) → fetch active ActorKey row → AES-GCM decrypt
+   * the private key → Ed25519 sign the data → update lastUsedAt → return
+   * signature bytes.
    */
   async sign(actorId: string, data: Uint8Array): Promise<Uint8Array> {
-    const privateKey = await this.getPrivateKey(actorId);
-    if (!privateKey) {
+    const row = await this.prisma.actorKey.findFirst({
+      where: { actorId, orgId: this.orgId, status: STATUS_ACTIVE },
+    });
+    if (!row) {
+      // [PKP-D2]
       throw new KeyProviderError(
-        `Private key not found for ${actorId}`,
+        `No active key for actor ${actorId} in org ${this.orgId}`,
         'KEY_NOT_FOUND',
-        { actorId, hint: 'Run gitgov login to sync your signing key' }
+        {
+          actorId,
+          orgId: this.orgId,
+          hint: 'Call storeKey() or createActor() first, then retry signing',
+        },
       );
     }
 
-    const signature = sign(null, data, {
-      key: Buffer.from(privateKey, 'base64'),
+    // [PKP-D1] Decrypt stored private key using cached org key
+    const privateKeyBase64 = await this.decryptActorKeyRow(row, actorId);
+
+    const signature = cryptoSign(null, data, {
+      key: Buffer.from(privateKeyBase64, 'base64'),
       type: 'pkcs8',
       format: 'pem',
     });
+
+    // [PKP-D1] Side effect: update lastUsedAt (fire-and-forget, non-blocking)
+    void this.prisma.actorKey
+      .update({ where: { id: row.id }, data: { lastUsedAt: new Date() } })
+      .catch(() => {
+        /* non-blocking; signing already succeeded */
+      });
+
     return new Uint8Array(signature);
   }
 
   /**
-   * [PKP-A1] Get existing key → decrypt + return
-   * [PKP-A2] Get non-existing key → null
+   * [PKP-A1] Returns the base64-encoded private key for the actor, decrypted
+   * from the stored ciphertext using the cached org key.
+   * [PKP-A2] Returns `null` if no active ActorKey row exists (fail-safe).
+   * [PKP-G10] Archived rows are ignored — only `status='active'` rows are served.
    */
   async getPrivateKey(actorId: string): Promise<string | null> {
-    const row = await this.prisma.actorKey.findUnique({
-      where: { actorId_repoId: { actorId, repoId: this.repoId } },
+    const row = await this.prisma.actorKey.findFirst({
+      where: { actorId, orgId: this.orgId, status: STATUS_ACTIVE },
     });
-
     if (!row) {
-      // [PKP-A2] Not found → null (fail-safe)
+      // [PKP-A2]
       return null;
     }
-
-    // [PKP-A1] Decrypt and return
-    try {
-      return this.decrypt(row.encryptedKey);
-    } catch (error) {
-      // [PKP-C3] Decryption failure → throw
-      throw new KeyProviderError(
-        `Failed to decrypt private key for ${actorId}: ${(error as Error).message}`,
-        'KEY_READ_ERROR',
-        { actorId },
-      );
-    }
+    return this.decryptActorKeyRow(row, actorId);
   }
 
   /**
-   * [PKP-A3] Set key → encrypt + upsert
+   * [PKP-G5] Returns the public key for the actor from the stored row's
+   * `publicKey` column — NO decryption, NO org key access.
+   * [PKP-G6] Returns `null` when no active row exists.
+   * [PKP-G10] Ignores archived rows.
+   */
+  async getPublicKey(actorId: string): Promise<string | null> {
+    const row = await this.prisma.actorKey.findFirst({
+      where: { actorId, orgId: this.orgId, status: STATUS_ACTIVE },
+    });
+    // [PKP-G5] No decryption — direct field read
+    // [PKP-G6] Null when no active row
+    return row?.publicKey ?? null;
+  }
+
+  /**
+   * [PKP-A3] Stores a private key for an actor by deriving the public key
+   * via the `derivePublicKey()` helper from `@gitgov/core/crypto/signatures`
+   * (wrapper over `createPublicKey()` + SPKI DER `subarray(-32)`) and
+   * delegating to `storeKey()`.
+   *
+   * This method exists for `IKeyProvider` interface compatibility. Callers
+   * that already have a `KeyPair` should prefer `storeKey()` directly — it
+   * avoids the public-key derivation round trip.
    */
   async setPrivateKey(actorId: string, privateKey: string): Promise<void> {
-    const encryptedKey = this.encrypt(privateKey);
-
+    // [PKP-A3] Derive public key and delegate to storeKey
+    let publicKey: string;
     try {
-      await this.prisma.actorKey.upsert({
-        where: { actorId_repoId: { actorId, repoId: this.repoId } },
-        create: { actorId, repoId: this.repoId, encryptedKey },
-        update: { encryptedKey },
-      });
-    } catch (error) {
+      publicKey = derivePublicKey(privateKey);
+    } catch (cause) {
       throw new KeyProviderError(
-        `Failed to store private key for ${actorId}: ${(error as Error).message}`,
-        'KEY_WRITE_ERROR',
-        { actorId },
+        `Cannot derive public key for ${actorId}: invalid private key format`,
+        'INVALID_KEY_FORMAT',
+        {
+          actorId,
+          orgId: this.orgId,
+          hint: 'privateKey must be PKCS8 PEM base64-encoded (see crypto/signatures.generateKeys())',
+          cause: cause instanceof Error ? cause : new Error(String(cause)),
+        },
       );
     }
+    await this.storeKey(actorId, { publicKey, privateKey });
   }
 
   /**
-   * [PKP-D1] Check existence without reading key content
+   * [PKP-C1] Returns `true` if an active ActorKey row exists for
+   * `[actorId, orgId]`, `false` otherwise, via `count()` — without reading
+   * or decrypting key content.
+   * [PKP-G10] Archived rows are ignored by count.
    */
   async hasPrivateKey(actorId: string): Promise<boolean> {
     const count = await this.prisma.actorKey.count({
-      where: { actorId, repoId: this.repoId },
+      where: { actorId, orgId: this.orgId, status: STATUS_ACTIVE },
     });
     return count > 0;
   }
 
   /**
-   * [PKP-A4] Delete key → true/false
+   * [PKP-A4] v2 is append-only — delegates to `archiveKey()`. Returns `true`
+   * if an active row existed (and was archived), `false` otherwise.
+   *
+   * The row is NOT hard-deleted; it remains queryable for audit/history
+   * with `status='archived'`.
    */
   async deletePrivateKey(actorId: string): Promise<boolean> {
-    try {
-      await this.prisma.actorKey.delete({
-        where: { actorId_repoId: { actorId, repoId: this.repoId } },
-      });
-      return true;
-    } catch (error) {
-      // P2025 = record not found → return false
-      // All other errors (DB connection, etc.) → propagate per §5.3
-      if (error instanceof Error && 'code' in error && (error as { code: string }).code === 'P2025') {
-        return false;
-      }
-      throw error;
+    const hadActive = await this.hasPrivateKey(actorId);
+    if (hadActive) {
+      await this.archiveKey(actorId);
     }
+    return hadActive;
   }
 
+  // ─── Extensions beyond IKeyProvider ────────────────────────────────────────
+
   /**
-   * [PKP-C1] Encrypt with AES-256-GCM
-   * [PKP-C2] No secret → plaintext
+   * [PKP-G1] Stores a complete keypair atomically. Encrypts the private key
+   * with AES-256-GCM using the org key and a random 12-byte IV.
+   * [PKP-G2] If an active row already exists for `[actorId, orgId]`, archives
+   * it (`status='archived'`, `lastUsedAt=now()`) and creates a new active
+   * row — both updates committed together in a single `$transaction`.
+   * [PKP-G3] Sets `lastUsedAt=now()` on the newly created active row.
+   * [PKP-G4] Throws `KeyProviderError('STORE_FAILED', {...})` on failure.
+   *
+   * Prefer this over `setPrivateKey()` when the caller already has both
+   * keys in hand (e.g., right after `generateKeys()`) — avoids public-key
+   * re-derivation.
    */
-  private encrypt(plaintext: string): string {
-    if (!this.encryptionSecret) {
-      // [PKP-C2] Dev mode — store plaintext
-      return plaintext;
-    }
+  async storeKey(actorId: string, keypair: KeyPair): Promise<void> {
+    const orgKey = await this.getOrgKey();
 
-    const key = this.deriveKey(this.encryptionSecret);
-    const iv = randomBytes(IV_LENGTH);
-    const cipher = createCipheriv(ALGORITHM, key, iv);
-
-    const encrypted = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()]);
+    // [PKP-G1] Encrypt private key with random IV
+    const iv = randomBytes(GCM_IV_LENGTH);
+    const cipher = createCipheriv(AES_GCM_ALGORITHM, orgKey, iv);
+    const privateKeyBytes = Buffer.from(keypair.privateKey, 'utf-8');
+    const encryptedBytes = Buffer.concat([cipher.update(privateKeyBytes), cipher.final()]);
     const authTag = cipher.getAuthTag();
 
-    // Format: base64(iv + authTag + ciphertext)
-    return Buffer.concat([iv, authTag, encrypted]).toString('base64');
+    const now = new Date();
+
+    // [PKP-G2] Transactional: archive old active + create new active
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        // [PKP-G2] Archive any existing active row for this actor+org
+        await tx.actorKey.updateMany({
+          where: { actorId, orgId: this.orgId, status: STATUS_ACTIVE },
+          data: { status: STATUS_ARCHIVED, lastUsedAt: now },
+        });
+
+        // [PKP-G1][PKP-G3] Create new active row
+        await tx.actorKey.create({
+          data: {
+            actorId,
+            orgId: this.orgId,
+            publicKey: keypair.publicKey,
+            encryptedPrivateKey: encryptedBytes.toString('hex'),
+            iv: iv.toString('hex'),
+            authTag: authTag.toString('hex'),
+            status: STATUS_ACTIVE,
+            lastUsedAt: now,
+          },
+        });
+      });
+    } catch (cause) {
+      // [PKP-G4]
+      throw new KeyProviderError(
+        `Failed to store key for ${actorId} in org ${this.orgId}`,
+        'STORE_FAILED',
+        {
+          actorId,
+          orgId: this.orgId,
+          hint: 'Check DB connectivity and that the orgId references an existing Organization',
+          cause: cause instanceof Error ? cause : new Error(String(cause)),
+        },
+      );
+    }
   }
 
   /**
-   * [PKP-C1] Decrypt with AES-256-GCM
-   * [PKP-C3] Throws on failure
+   * [PKP-G7] Marks the active key as archived. Idempotent.
+   * [PKP-G8] No-op when no active row exists — no throw.
    */
-  private decrypt(ciphertext: string): string {
-    if (!this.encryptionSecret) {
-      // [PKP-C2] Dev mode — stored as plaintext
-      return ciphertext;
-    }
-
-    const key = this.deriveKey(this.encryptionSecret);
-    const data = Buffer.from(ciphertext, 'base64');
-
-    const iv = data.subarray(0, IV_LENGTH);
-    const authTag = data.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
-    const encrypted = data.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
-
-    const decipher = createDecipheriv(ALGORITHM, key, iv);
-    decipher.setAuthTag(authTag);
-
-    return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf-8');
+  async archiveKey(actorId: string): Promise<void> {
+    // [PKP-G7] Set status to archived + record lastUsedAt
+    // [PKP-G8] updateMany is idempotent — matches 0 or 1 row
+    await this.prisma.actorKey.updateMany({
+      where: { actorId, orgId: this.orgId, status: STATUS_ACTIVE },
+      data: { status: STATUS_ARCHIVED, lastUsedAt: new Date() },
+    });
   }
 
-  /** Derive 32-byte key from secret using SHA-256 */
-  private deriveKey(secret: string): Buffer {
-    return createHash('sha256').update(secret).digest();
+  // ─── Private helpers ───────────────────────────────────────────────────────
+
+  /**
+   * [PKP-F2] Lazy-loads the org key on first call and caches it in-instance.
+   * Subsequent calls return the cached buffer without touching the DB.
+   *
+   * Flow: fetch OrgEncryptionKey row by orgId → HKDF-derive wrapping key
+   * from MASTER_KEY → AES-GCM decrypt encryptedOrgKey → cache result.
+   *
+   * Throws `STORE_FAILED` if no OrgEncryptionKey row exists for this org
+   * (hint: call `createOrgEncryptionKey(prisma, orgId)` first).
+   */
+  private async getOrgKey(): Promise<Buffer> {
+    if (this.orgKeyCache !== null) {
+      return this.orgKeyCache;
+    }
+
+    const row = await this.prisma.orgEncryptionKey.findUnique({
+      where: { orgId: this.orgId },
+    });
+    if (!row) {
+      throw new KeyProviderError(
+        `No OrgEncryptionKey for org ${this.orgId}`,
+        'STORE_FAILED',
+        {
+          orgId: this.orgId,
+          hint: 'Call createOrgEncryptionKey(prisma, orgId) when the Organization is created',
+        },
+      );
+    }
+
+    const masterKeyBase64 = process.env['MASTER_KEY'];
+    if (!masterKeyBase64 || masterKeyBase64.trim() === '') {
+      throw new KeyProviderError(
+        'MASTER_KEY env var is missing or empty',
+        'STORE_FAILED',
+        {
+          orgId: this.orgId,
+          hint: 'Set MASTER_KEY to a base64-encoded 32+ byte value (openssl rand -base64 32)',
+        },
+      );
+    }
+
+    let wrappingKey: Buffer;
+    try {
+      wrappingKey = await deriveHkdfKey(masterKeyBase64, MASTER_KEY_HKDF_INFO, KEY_LENGTH_BYTES);
+    } catch (cause) {
+      throw new KeyProviderError(
+        'HKDF derivation from MASTER_KEY failed',
+        'STORE_FAILED',
+        {
+          orgId: this.orgId,
+          hint: 'MASTER_KEY must be valid base64 of 32+ bytes',
+          cause: cause instanceof Error ? cause : new Error(String(cause)),
+        },
+      );
+    }
+
+    try {
+      const iv = Buffer.from(row.iv, 'hex');
+      const authTag = Buffer.from(row.authTag, 'hex');
+      const ciphertext = Buffer.from(row.encryptedOrgKey, 'hex');
+
+      const decipher = createDecipheriv(AES_GCM_ALGORITHM, wrappingKey, iv);
+      decipher.setAuthTag(authTag);
+      const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+
+      // [PKP-F2] cache and return
+      this.orgKeyCache = plaintext;
+      return plaintext;
+    } catch (cause) {
+      throw new KeyProviderError(
+        `Failed to decrypt OrgEncryptionKey for ${this.orgId}`,
+        'DECRYPTION_FAILED',
+        {
+          orgId: this.orgId,
+          hint: 'OrgEncryptionKey may be tampered or MASTER_KEY changed since it was created',
+          cause: cause instanceof Error ? cause : new Error(String(cause)),
+        },
+      );
+    }
+  }
+
+  /**
+   * [PKP-A1] Decrypts an ActorKey row's encrypted private key using the
+   * cached org key.
+   * [PKP-F3] Uses the org key (level 2) — NEVER the MASTER_KEY-derived key
+   * (level 1) directly. The org key was itself decrypted from the
+   * OrgEncryptionKey table using MASTER_KEY-derived key in `getOrgKey()`.
+   * [PKP-G9] Throws `DECRYPTION_FAILED` on AES-GCM failure.
+   */
+  private async decryptActorKeyRow(row: ActorKeyRow, actorId: string): Promise<string> {
+    if (row.encryptedPrivateKey === null || row.iv === null || row.authTag === null) {
+      throw new KeyProviderError(
+        `ActorKey row for ${actorId} is verify-only (no encryptedPrivateKey)`,
+        'KEY_NOT_FOUND',
+        {
+          actorId,
+          orgId: this.orgId,
+          hint: 'This actor has only a public key synced — no private key available for signing/export',
+        },
+      );
+    }
+
+    const orgKey = await this.getOrgKey();
+
+    try {
+      const iv = Buffer.from(row.iv, 'hex');
+      const authTag = Buffer.from(row.authTag, 'hex');
+      const ciphertext = Buffer.from(row.encryptedPrivateKey, 'hex');
+
+      const decipher = createDecipheriv(AES_GCM_ALGORITHM, orgKey, iv);
+      decipher.setAuthTag(authTag);
+      const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+      return plaintext.toString('utf-8');
+    } catch (cause) {
+      // [PKP-G9]
+      throw new KeyProviderError(
+        `AES-GCM decryption failed for actor ${actorId}`,
+        'DECRYPTION_FAILED',
+        {
+          actorId,
+          orgId: this.orgId,
+          hint: 'Key may be tampered or org key was rotated without re-encryption',
+          cause: cause instanceof Error ? cause : new Error(String(cause)),
+        },
+      );
+    }
+  }
+
+  // ─── Test helper (internal — not part of public API) ───────────────────────
+
+  /**
+   * For tests only: clears the cached org key to force a fresh lazy-load.
+   * Not exposed in the public API; called by tests via a type assertion.
+   *
+   * @internal
+   */
+  _clearOrgKeyCacheForTesting(): void {
+    this.orgKeyCache = null;
+  }
+}
+
+// ─── Org Key Hierarchy — bootstrap helper (PKP-F1, Cycle 2) ─────────────────
+
+/**
+ * [PKP-F1] Bootstraps the per-org encryption key for a freshly-created
+ * Organization.
+ *
+ * Called ONCE per Organization at creation time (e.g., from the GitHub App
+ * install webhook handler). Generates a random AES-256 org key, encrypts it
+ * with an HKDF(MASTER_KEY, 'gitgov-org-key')-derived wrapping key, and
+ * persists the ciphertext in the `OrgEncryptionKey` table with IV and auth
+ * tag as separate hex columns.
+ *
+ * This is the entry point to the 3-level key hierarchy:
+ *
+ *     MASTER_KEY (env var)
+ *         ↓  HKDF-SHA256, info='gitgov-org-key'
+ *     wrapping key (32 bytes, in-memory only)
+ *         ↓  AES-256-GCM encrypt
+ *     OrgEncryptionKey.encryptedOrgKey (hex, persisted)
+ *         ↓  (later) used by PrismaKeyProvider to encrypt ActorKey rows
+ *
+ * Spec: prisma_key_provider_module.md §3.5 (encryption strategy),
+ *       §4.6 PKP-F1 (requirement).
+ *
+ * @param prisma - Prisma-compatible client with `orgEncryptionKey` delegate.
+ * @param orgId - The `Organization.id` this key belongs to.
+ * @throws {KeyProviderError} with code `STORE_FAILED` if MASTER_KEY missing,
+ *                 invalid, or the DB write fails.
+ */
+export async function createOrgEncryptionKey(
+  prisma: OrgEncryptionKeyClient,
+  orgId: string,
+): Promise<void> {
+  // [PKP-F1] Read MASTER_KEY from environment — fail fast if missing.
+  const masterKeyBase64 = process.env['MASTER_KEY'];
+  if (!masterKeyBase64 || masterKeyBase64.trim() === '') {
+    throw new KeyProviderError(
+      'Cannot create OrgEncryptionKey: MASTER_KEY env var is missing or empty',
+      'STORE_FAILED',
+      {
+        orgId,
+        hint: 'Set MASTER_KEY to a base64-encoded 32+ byte value. Generate with: openssl rand -base64 32',
+      },
+    );
+  }
+
+  // [PKP-F1][PKP-F3] Derive the 32-byte wrapping key via HKDF-SHA256. This is
+  // the LEVEL-1 key that wraps the org key — it NEVER encrypts actor keys
+  // directly (that would be PKP-F3 violation).
+  let wrappingKey: Buffer;
+  try {
+    wrappingKey = await deriveHkdfKey(masterKeyBase64, MASTER_KEY_HKDF_INFO, KEY_LENGTH_BYTES);
+  } catch (cause) {
+    throw new KeyProviderError(
+      'Cannot create OrgEncryptionKey: HKDF derivation from MASTER_KEY failed',
+      'STORE_FAILED',
+      {
+        orgId,
+        hint: 'MASTER_KEY must be valid base64 of 32+ bytes. Generate with: openssl rand -base64 32',
+        cause: cause instanceof Error ? cause : new Error(String(cause)),
+      },
+    );
+  }
+
+  // [PKP-F1] Generate a fresh 32-byte random org key. Each org gets its own
+  // AES-256 key — blast radius of a compromise is contained to that org only.
+  const orgKeyPlaintext = randomBytes(KEY_LENGTH_BYTES);
+
+  // [PKP-F1] Encrypt the org key with AES-256-GCM, random IV per operation.
+  const iv = randomBytes(GCM_IV_LENGTH);
+  const cipher = createCipheriv(AES_GCM_ALGORITHM, wrappingKey, iv);
+  const encryptedOrgKey = Buffer.concat([
+    cipher.update(orgKeyPlaintext),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  // [PKP-F1] Persist with iv, authTag, encryptedOrgKey as SEPARATE hex columns
+  // (not a concatenated base64 blob) — facilitates debugging and forensics.
+  try {
+    await prisma.orgEncryptionKey.create({
+      data: {
+        orgId,
+        encryptedOrgKey: encryptedOrgKey.toString('hex'),
+        iv: iv.toString('hex'),
+        authTag: authTag.toString('hex'),
+      },
+    });
+  } catch (cause) {
+    throw new KeyProviderError(
+      `Failed to persist OrgEncryptionKey for ${orgId}`,
+      'STORE_FAILED',
+      {
+        orgId,
+        hint: 'Check DB connectivity and that the Organization row exists for this orgId',
+        cause: cause instanceof Error ? cause : new Error(String(cause)),
+      },
+    );
+  }
+}
+
+// ─── Org Key Hierarchy — rotation helper (PKP-F4, Cycle 2) ──────────────────
+
+/**
+ * [PKP-F4] Rotates the `OrgEncryptionKey` for a given org. Generates a new
+ * random AES-256 org key, re-encrypts all active `ActorKey` rows of that
+ * org with the new org key, and updates the `OrgEncryptionKey` row. The
+ * entire operation runs in a single transaction — either all rows are
+ * re-encrypted and the new org key is stored, or nothing changes.
+ *
+ * This is a migration-script-grade operation — NOT called from the hot path.
+ * Typical trigger: suspected key compromise or scheduled rotation policy.
+ *
+ * Runtime: proportional to the number of active actor keys in the org
+ * (each requires decrypt-with-old + encrypt-with-new).
+ *
+ * @param prisma - Full Prisma client with `orgEncryptionKey` + `actorKey`
+ *                 delegates + `$transaction` support.
+ * @param orgId - Organization to rotate.
+ * @throws {KeyProviderError} on MASTER_KEY issues, DB errors, or decryption
+ *                 failures of existing rows.
+ */
+export async function rotateOrgEncryptionKey(
+  prisma: PrismaClientLike,
+  orgId: string,
+): Promise<void> {
+  // Read MASTER_KEY
+  const masterKeyBase64 = process.env['MASTER_KEY'];
+  if (!masterKeyBase64 || masterKeyBase64.trim() === '') {
+    throw new KeyProviderError(
+      `Cannot rotate OrgEncryptionKey for ${orgId}: MASTER_KEY env var is missing`,
+      'STORE_FAILED',
+      { orgId, hint: 'Set MASTER_KEY before running key rotation' },
+    );
+  }
+
+  // Derive wrapping key (same for old and new org key — only the org key itself changes)
+  let wrappingKey: Buffer;
+  try {
+    wrappingKey = await deriveHkdfKey(masterKeyBase64, MASTER_KEY_HKDF_INFO, KEY_LENGTH_BYTES);
+  } catch (cause) {
+    throw new KeyProviderError(
+      `HKDF derivation failed during rotation for ${orgId}`,
+      'STORE_FAILED',
+      {
+        orgId,
+        cause: cause instanceof Error ? cause : new Error(String(cause)),
+      },
+    );
+  }
+
+  // Fetch current org key row
+  const oldRow = await prisma.orgEncryptionKey.findUnique({ where: { orgId } });
+  if (!oldRow) {
+    throw new KeyProviderError(
+      `No OrgEncryptionKey to rotate for ${orgId}`,
+      'STORE_FAILED',
+      {
+        orgId,
+        hint: 'Call createOrgEncryptionKey() first to bootstrap the org key before rotating',
+      },
+    );
+  }
+
+  // Decrypt old org key
+  let oldOrgKey: Buffer;
+  try {
+    const oldIv = Buffer.from(oldRow.iv, 'hex');
+    const oldAuthTag = Buffer.from(oldRow.authTag, 'hex');
+    const oldCiphertext = Buffer.from(oldRow.encryptedOrgKey, 'hex');
+    const decipher = createDecipheriv(AES_GCM_ALGORITHM, wrappingKey, oldIv);
+    decipher.setAuthTag(oldAuthTag);
+    oldOrgKey = Buffer.concat([decipher.update(oldCiphertext), decipher.final()]);
+  } catch (cause) {
+    throw new KeyProviderError(
+      `Failed to decrypt old OrgEncryptionKey for ${orgId} during rotation`,
+      'DECRYPTION_FAILED',
+      {
+        orgId,
+        cause: cause instanceof Error ? cause : new Error(String(cause)),
+      },
+    );
+  }
+
+  // Generate new org key + encrypt with the same wrapping key (but fresh IV)
+  const newOrgKey = randomBytes(KEY_LENGTH_BYTES);
+  const newIv = randomBytes(GCM_IV_LENGTH);
+  const newCipher = createCipheriv(AES_GCM_ALGORITHM, wrappingKey, newIv);
+  const newEncryptedOrgKey = Buffer.concat([
+    newCipher.update(newOrgKey),
+    newCipher.final(),
+  ]);
+  const newAuthTag = newCipher.getAuthTag();
+
+  // [PKP-F4] Transactional rotation: re-encrypt all active actor keys + update org key row
+  try {
+    await prisma.$transaction(async (tx) => {
+      // Fetch all active actor keys of this org
+      const activeKeys = await tx.actorKey.findMany({
+        where: { orgId, status: STATUS_ACTIVE },
+      });
+
+      // Re-encrypt each one with the new org key
+      for (const row of activeKeys) {
+        if (row.encryptedPrivateKey === null || row.iv === null || row.authTag === null) {
+          // Verify-only row — no private key to re-encrypt, skip
+          continue;
+        }
+
+        // Decrypt with OLD org key
+        const oldActorIv = Buffer.from(row.iv, 'hex');
+        const oldActorAuthTag = Buffer.from(row.authTag, 'hex');
+        const oldActorCiphertext = Buffer.from(row.encryptedPrivateKey, 'hex');
+        const decipher = createDecipheriv(AES_GCM_ALGORITHM, oldOrgKey, oldActorIv);
+        decipher.setAuthTag(oldActorAuthTag);
+        const plaintext = Buffer.concat([
+          decipher.update(oldActorCiphertext),
+          decipher.final(),
+        ]);
+
+        // Re-encrypt with NEW org key (fresh IV per row)
+        const newActorIv = randomBytes(GCM_IV_LENGTH);
+        const newActorCipher = createCipheriv(AES_GCM_ALGORITHM, newOrgKey, newActorIv);
+        const newActorCiphertext = Buffer.concat([
+          newActorCipher.update(plaintext),
+          newActorCipher.final(),
+        ]);
+        const newActorAuthTag = newActorCipher.getAuthTag();
+
+        await tx.actorKey.update({
+          where: { id: row.id },
+          data: {
+            encryptedPrivateKey: newActorCiphertext.toString('hex'),
+            iv: newActorIv.toString('hex'),
+            authTag: newActorAuthTag.toString('hex'),
+          },
+        });
+      }
+
+      // Update the OrgEncryptionKey row with the new ciphertext + bump rotatedAt
+      await tx.orgEncryptionKey.update({
+        where: { orgId },
+        data: {
+          encryptedOrgKey: newEncryptedOrgKey.toString('hex'),
+          iv: newIv.toString('hex'),
+          authTag: newAuthTag.toString('hex'),
+          rotatedAt: new Date(),
+        },
+      });
+    });
+  } catch (cause) {
+    throw new KeyProviderError(
+      `Failed to rotate OrgEncryptionKey for ${orgId}`,
+      'STORE_FAILED',
+      {
+        orgId,
+        hint: 'Rotation rolled back — all actor keys remain encrypted with the previous org key',
+        cause: cause instanceof Error ? cause : new Error(String(cause)),
+      },
+    );
   }
 }

--- a/packages/core/src/key_provider/prisma/prisma_key_provider.types.ts
+++ b/packages/core/src/key_provider/prisma/prisma_key_provider.types.ts
@@ -1,44 +1,175 @@
 /**
- * Types for PrismaKeyProvider — database-backed KeyProvider implementation.
+ * Types for PrismaKeyProvider v2 — database-backed KeyProvider implementation.
  *
  * Follows the same pattern as PrismaRecordProjection: defines query interfaces
  * instead of depending on @prisma/client directly. The consumer provides a
- * Prisma client that satisfies these interfaces.
+ * Prisma client that satisfies these interfaces (duck-typing).
+ *
+ * Cycle 2 v2 target (identity_key_sync epic):
+ *   - ActorKey scoped by `orgId` (not `repoId`), with separate encryption
+ *     columns (encryptedPrivateKey, iv, authTag) and append-only lifecycle
+ *     (status + lastUsedAt).
+ *   - OrgEncryptionKey table provides per-org AES-256 wrapping keys.
+ *   - MASTER_KEY (env) → HKDF-derived wrapping key → org key → actor key.
+ *
+ * Spec: prisma_key_provider_module.md §3.2, §3.3
  */
 
-/** Row shape for the ActorKey table */
+// ─── ActorKey v2 (Cycle 2, identity_key_sync) ────────────────────────────────
+
+/**
+ * Lifecycle status of an `ActorKey` row. Default on create is `'active'`.
+ * Only `'active'` rows are served by `sign`/`getPrivateKey`/`getPublicKey`.
+ *
+ * Spec: prisma_key_provider_module.md §3.2
+ */
+export type ActorKeyStatus = 'active' | 'archived' | 'revoked';
+
+/** Row shape for the ActorKey table (v2). */
 export type ActorKeyRow = {
   id: string;
   actorId: string;
-  repoId: string;
-  encryptedKey: string;
+  orgId: string;
+  publicKey: string;
+  /** Hex-encoded AES-256-GCM ciphertext of the private key. Null for verify-only records. */
+  encryptedPrivateKey: string | null;
+  /** Hex-encoded 12-byte AES-GCM IV. Null when verify-only. */
+  iv: string | null;
+  /** Hex-encoded 16-byte AES-GCM auth tag. Null when verify-only. */
+  authTag: string | null;
+  status: ActorKeyStatus;
+  lastUsedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 };
 
-/** Where clause for unique lookup */
-export type ActorKeyWhereUnique = {
-  actorId_repoId: { actorId: string; repoId: string };
-};
-
-/** Prisma-like delegate for ActorKey queries */
+/**
+ * Prisma-like delegate for ActorKey v2 queries (duck-typed — no @prisma/client
+ * dependency in core).
+ *
+ * Only the methods consumed by PrismaKeyProvider v2 are declared. Adding
+ * methods is non-breaking — the real Prisma client delegate has many more.
+ */
 export type ActorKeyDelegate = {
-  findUnique(args: { where: ActorKeyWhereUnique }): Promise<ActorKeyRow | null>;
-  upsert(args: {
-    where: ActorKeyWhereUnique;
-    create: { actorId: string; repoId: string; encryptedKey: string };
-    update: { encryptedKey: string };
+  findFirst(args: {
+    where: { actorId: string; orgId: string; status: string };
+  }): Promise<ActorKeyRow | null>;
+  findMany(args: {
+    where: { orgId: string; status: string };
+  }): Promise<ActorKeyRow[]>;
+  count(args: {
+    where: { actorId: string; orgId: string; status: string };
+  }): Promise<number>;
+  create(args: {
+    data: {
+      actorId: string;
+      orgId: string;
+      publicKey: string;
+      encryptedPrivateKey: string;
+      iv: string;
+      authTag: string;
+      status: string;
+      lastUsedAt: Date;
+    };
   }): Promise<ActorKeyRow>;
-  delete(args: { where: ActorKeyWhereUnique }): Promise<ActorKeyRow>;
-  count(args: { where: { actorId: string; repoId: string } }): Promise<number>;
+  updateMany(args: {
+    where: { actorId: string; orgId: string; status: string };
+    data: { status?: string; lastUsedAt?: Date };
+  }): Promise<{ count: number }>;
+  update(args: {
+    where: { id: string };
+    data: {
+      encryptedPrivateKey?: string;
+      iv?: string;
+      authTag?: string;
+      lastUsedAt?: Date;
+    };
+  }): Promise<ActorKeyRow>;
 };
 
-/** Options for PrismaKeyProvider */
-export type PrismaKeyProviderOptions = {
-  /** Prisma-compatible client with actorKey delegate */
-  prisma: { actorKey: ActorKeyDelegate };
-  /** Repository ID for scoping keys (multi-tenant isolation) */
-  repoId: string;
-  /** Encryption secret for keys at rest. If not provided, keys stored in plaintext (dev only). */
-  encryptionSecret?: string;
+// ─── OrgEncryptionKey (Cycle 2, identity_key_sync) ──────────────────────────
+
+/**
+ * Row shape for the OrgEncryptionKey table.
+ *
+ * Stores the per-org AES-256 encryption key that wraps ActorKey private keys.
+ * The raw 32-byte org key is encrypted at rest with an HKDF(MASTER_KEY,
+ * 'gitgov-org-key')-derived key using AES-256-GCM.
+ *
+ * See: prisma_key_provider_module.md §3.3 (schema), §3.5 (3-level hierarchy),
+ * §4.6 (PKP-F1..F4).
+ */
+export type OrgEncryptionKeyRow = {
+  id: string;
+  orgId: string;
+  /** Hex-encoded AES-256-GCM ciphertext of the raw 32-byte org key */
+  encryptedOrgKey: string;
+  /** Hex-encoded 12-byte AES-GCM IV */
+  iv: string;
+  /** Hex-encoded 16-byte AES-GCM auth tag */
+  authTag: string;
+  createdAt: Date;
+  rotatedAt: Date;
+};
+
+/**
+ * Prisma-like delegate for OrgEncryptionKey queries (duck-typed).
+ */
+export type OrgEncryptionKeyDelegate = {
+  findUnique(args: { where: { orgId: string } }): Promise<OrgEncryptionKeyRow | null>;
+  create(args: {
+    data: {
+      orgId: string;
+      encryptedOrgKey: string;
+      iv: string;
+      authTag: string;
+    };
+  }): Promise<OrgEncryptionKeyRow>;
+  update(args: {
+    where: { orgId: string };
+    data: {
+      encryptedOrgKey?: string;
+      iv?: string;
+      authTag?: string;
+      rotatedAt?: Date;
+    };
+  }): Promise<OrgEncryptionKeyRow>;
+};
+
+// ─── Client shapes (compose delegates) ───────────────────────────────────────
+
+/**
+ * Minimal Prisma client surface required by `createOrgEncryptionKey()`.
+ * Just the `orgEncryptionKey` delegate is needed for bootstrap.
+ */
+export type OrgEncryptionKeyClient = {
+  orgEncryptionKey: OrgEncryptionKeyDelegate;
+};
+
+/**
+ * Full Prisma client surface required by `PrismaKeyProvider` v2 instance
+ * methods and `rotateOrgEncryptionKey()`.
+ *
+ * Includes `orgEncryptionKey` + `actorKey` delegates + `$transaction` for
+ * atomic multi-table operations (e.g., storeKey archives old + creates new
+ * in a single transaction; rotateOrgEncryptionKey re-encrypts all actor keys
+ * of an org atomically).
+ *
+ * The real `PrismaClient` from `@prisma/client` structurally satisfies this
+ * type — consumers pass their Prisma instance directly without any cast.
+ */
+export type PrismaClientLike = {
+  orgEncryptionKey: OrgEncryptionKeyDelegate;
+  actorKey: ActorKeyDelegate;
+  /**
+   * Prisma's interactive transaction API. The callback receives a transaction
+   * client with the same delegate shape and all operations inside it either
+   * all commit or all rollback.
+   */
+  $transaction<T>(
+    fn: (tx: {
+      orgEncryptionKey: OrgEncryptionKeyDelegate;
+      actorKey: ActorKeyDelegate;
+    }) => Promise<T>,
+  ): Promise<T>;
 };

--- a/packages/core/src/prisma.ts
+++ b/packages/core/src/prisma.ts
@@ -3,7 +3,8 @@
  *
  * This module exports implementations that persist data via a Prisma-compatible
  * database client. Core does NOT depend on @prisma/client — it defines structural
- * types (ProjectionClient) that any generated PrismaClient satisfies via duck typing.
+ * types (ProjectionClient, PrismaClientLike) that any generated PrismaClient
+ * satisfies via duck typing.
  */
 
 // RecordProjection (database-backed via Prisma-compatible client)
@@ -14,10 +15,20 @@ export type {
   JsonValue,
 } from './record_projection/prisma';
 
-// KeyProvider (database-backed via Prisma-compatible client)
-export { PrismaKeyProvider } from './key_provider/prisma';
+// KeyProvider v2 (Cycle 2, identity_key_sync)
+// Org-scoped, 3-level key hierarchy (MASTER_KEY → org_key → actor_key),
+// append-only lifecycle.
+export {
+  PrismaKeyProvider,
+  createOrgEncryptionKey,
+  rotateOrgEncryptionKey,
+} from './key_provider/prisma';
 export type {
-  PrismaKeyProviderOptions,
-  ActorKeyDelegate,
+  ActorKeyStatus,
   ActorKeyRow,
+  ActorKeyDelegate,
+  OrgEncryptionKeyRow,
+  OrgEncryptionKeyDelegate,
+  OrgEncryptionKeyClient,
+  PrismaClientLike,
 } from './key_provider/prisma';

--- a/packages/core/src/record_projection/prisma/prisma_record_projection.test.ts
+++ b/packages/core/src/record_projection/prisma/prisma_record_projection.test.ts
@@ -1,6 +1,6 @@
 import { PrismaRecordProjection } from './prisma_record_projection';
 import type { IndexData, ProjectionContext, EnrichedTaskRecord } from '../record_projection.types';
-import type { ProjectionClient } from './prisma_record_projection.types';
+import type { ProjectionClient, GitgovExecutionRow, GitgovAgentRow } from './prisma_record_projection.types';
 
 function createMockDelegate() {
   return {


### PR DESCRIPTION
## Why

`signRecord()` had a fallback that produced structurally valid but meaningless signatures when a key was not loaded. The condition was difficult to detect and produced confusing test failures. This PR removes the fallback and refactors signing to go through the `KeyProvider` interface.

## What's in it

- `KeyProvider.sign(actorId, data)` is added as the primary signing method. `signRecord()` delegates to it instead of calling `getPrivateKey()` followed by an external sign step.
- The mock signature fallback is removed. Missing keys now throw `KeyProviderError('KEY_NOT_FOUND')` with a hint.
- `IKeyProvider.getPublicKey(actorId)` is added to the interface, plus a `derivePublicKey` helper in `crypto/signatures` for providers that do not cache.
- `PrismaKeyProvider` is rewritten with a new key lifecycle and storage model.
- `KeyProviderError` now carries a structured context object instead of a single optional actor id. New error codes for storage and decryption failures.
- Cross-module test mocks are updated to match the new interface.

## Test plan

- [x] \`tsc --noEmit\` core: 0 errors
- [x] Core suite: 2787 / 2790 passing (3 skipped pre-existing, no regressions vs main)
- [x] \`PrismaKeyProvider\` unit tests: 28 / 28
- [x] Internal audit pass: clean
- [ ] Integration coverage will be added in a follow-up PR

Consumer-side updates will be submitted as a separate PR.