### PR TITLE
feat(core,cli): identity_key_sync Cycles 3-4 — ECDH + login v2 + GitRemoteRef

### DIFF
--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -3,10 +3,8 @@ export { registerLoginCommands } from './login';
 export type {
   LoginCommandOptions,
   LoginDeps,
-  SyncKeyRequest,
   SyncKeyResponse,
-  GetKeyRequest,
   GetKeyResponse,
-  KeyStatusRequest,
   KeyStatusResponse,
+  TrpcResponse,
 } from './login-command.types';

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -17,6 +17,7 @@ const mockLoadSession = jest.fn();
 const mockGetPrivateKey = jest.fn();
 const mockSetPrivateKey = jest.fn();
 const mockHasPrivateKey = jest.fn();
+const mockGetPublicKey = jest.fn();
 const mockGetConfig = jest.fn();
 
 jest.mock('../../services/dependency-injection', () => ({
@@ -30,6 +31,7 @@ jest.mock('../../services/dependency-injection', () => ({
         getPrivateKey: mockGetPrivateKey,
         setPrivateKey: mockSetPrivateKey,
         hasPrivateKey: mockHasPrivateKey,
+        getPublicKey: mockGetPublicKey,
       } as unknown as IKeyProvider),
       getConfigManager: jest.fn().mockResolvedValue({
         loadConfig: mockGetConfig,
@@ -295,18 +297,15 @@ describe('LoginCommand', () => {
   // ==================== §4.4 Key Conflict Resolution (LOGIN-D1 to D2) ====================
 
   describe('4.4. Key Conflict Resolution (LOGIN-D1 to D2)', () => {
-    it('[LOGIN-D1] should display already synced when keys are identical', async () => {
-      const sharedKey = 'same-key-on-both-sides';
+    it('[LOGIN-D1] should display already synced when public keys are identical', async () => {
+      const sharedPublicKey = 'same-public-key-base64';
       mockHasPrivateKey.mockResolvedValue(true);
-      mockGetPrivateKey.mockResolvedValue(sharedKey);
+      mockGetPublicKey.mockResolvedValue(sharedPublicKey);
 
       const deps = createMockDeps({
         fetchSaas: jest.fn().mockImplementation(async (url: string) => {
           if (url.includes('/api/identity/status')) {
-            return { ok: true, json: async () => ({ hasKey: true, actorExists: true }) };
-          }
-          if (url.includes('/api/identity/key')) {
-            return { ok: true, json: async () => ({ privateKey: sharedKey }) };
+            return { ok: true, json: async () => ({ hasKey: true, actorExists: true, publicKey: sharedPublicKey }) };
           }
           return { ok: false, json: async () => ({}) };
         }),
@@ -319,17 +318,14 @@ describe('LoginCommand', () => {
       expect(output).toContain('Already synced');
     });
 
-    it('[LOGIN-D2] should display error with resolution instructions when keys differ', async () => {
+    it('[LOGIN-D2] should display error with resolution instructions when public keys differ', async () => {
       mockHasPrivateKey.mockResolvedValue(true);
-      mockGetPrivateKey.mockResolvedValue('cli-private-key');
+      mockGetPublicKey.mockResolvedValue('cli-public-key');
 
       const deps = createMockDeps({
         fetchSaas: jest.fn().mockImplementation(async (url: string) => {
           if (url.includes('/api/identity/status')) {
-            return { ok: true, json: async () => ({ hasKey: true, actorExists: true }) };
-          }
-          if (url.includes('/api/identity/key')) {
-            return { ok: true, json: async () => ({ privateKey: 'different-saas-key' }) };
+            return { ok: true, json: async () => ({ hasKey: true, actorExists: true, publicKey: 'different-saas-public-key' }) };
           }
           return { ok: false, json: async () => ({}) };
         }),
@@ -340,7 +336,8 @@ describe('LoginCommand', () => {
 
       const errorOutput = mockConsoleError.mock.calls.map(c => c[0]).join('\n');
       expect(errorOutput).toContain('Keys differ');
-      expect(errorOutput).toContain('gitgov actor rotate-key');
+      expect(errorOutput).toContain('--force-local');
+      expect(errorOutput).toContain('--force-cloud');
     });
   });
 });

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -43,9 +43,9 @@ jest.mock('@gitgov/core', () => ({
   parseRemoteUrl: (url: string) => {
     // Parse the mock URL: https://github.com/testorg/testrepo.git
     const httpsMatch = url.match(/^https?:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
-    if (httpsMatch?.[1] && httpsMatch[2]) return { host: httpsMatch[1], path: httpsMatch[2] };
+    if (httpsMatch?.[1] && httpsMatch[2]) return { providerHost: httpsMatch[1], repoPath: httpsMatch[2] };
     const sshMatch = url.match(/^[^@]+@([^:]+):(.+?)(?:\.git)?$/);
-    if (sshMatch?.[1] && sshMatch[2]) return { host: sshMatch[1], path: sshMatch[2] };
+    if (sshMatch?.[1] && sshMatch[2]) return { providerHost: sshMatch[1], repoPath: sshMatch[2] };
     return null;
   },
 }));

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -43,7 +43,9 @@ jest.mock('@gitgov/core', () => ({
 }));
 
 // Mock DependencyInjectionService
-const mockSaveSession = jest.fn();
+const mockSetCloudToken = jest.fn();
+const mockSetLastSession = jest.fn();
+const mockClearCloudToken = jest.fn();
 const mockLoadSession = jest.fn();
 const mockGetPrivateKey = jest.fn();
 const mockSetPrivateKey = jest.fn();
@@ -56,7 +58,9 @@ jest.mock('../../services/dependency-injection', () => ({
     getInstance: jest.fn().mockReturnValue({
       getSessionManager: jest.fn().mockResolvedValue({
         loadSession: mockLoadSession,
-        sessionStore: { saveSession: mockSaveSession },
+        setCloudToken: mockSetCloudToken,
+        setLastSession: mockSetLastSession,
+        clearCloudToken: mockClearCloudToken,
       }),
       getKeyProvider: jest.fn().mockReturnValue({
         getPrivateKey: mockGetPrivateKey,
@@ -66,6 +70,10 @@ jest.mock('../../services/dependency-injection', () => ({
       } as unknown as IKeyProvider),
       getConfigManager: jest.fn().mockResolvedValue({
         loadConfig: mockGetConfig,
+        getSaasUrl: jest.fn().mockImplementation(async () => {
+          const config = await mockGetConfig();
+          return config?.saasUrl ?? null;
+        }),
       }),
     }),
   },
@@ -150,10 +158,8 @@ describe('LoginCommand v2', () => {
 
       expect(deps.startCallbackServer).toHaveBeenCalledTimes(1);
 
-      expect(mockSaveSession).toHaveBeenCalled();
-      const savedSession = mockSaveSession.mock.calls[0][0];
-      expect(savedSession.cloud.sessionToken).toBe('test-session-token');
-      expect(savedSession.lastSession.actorId).toBe('human:camilo');
+      expect(mockSetCloudToken).toHaveBeenCalledWith('test-session-token');
+      expect(mockSetLastSession).toHaveBeenCalledWith('human:camilo', expect.any(String));
     });
 
     it('[LOGIN-A2] should display login status with user info', async () => {
@@ -184,22 +190,11 @@ describe('LoginCommand v2', () => {
       const cmd = new LoginCommand(createMockDeps());
       await cmd.executeLogout(defaultOptions);
 
-      expect(mockSaveSession).toHaveBeenCalled();
-      const savedSession = mockSaveSession.mock.calls[0][0];
-      expect(savedSession.cloud).toBeUndefined();
-      expect(savedSession.actorState).toEqual({ 'human:camilo': { activeTaskId: 'task-1' } });
+      expect(mockClearCloudToken).toHaveBeenCalled();
       expect(mockSetPrivateKey).not.toHaveBeenCalled();
     });
 
-    it('[LOGIN-A4] should fail when saasUrl is not configured', async () => {
-      mockGetConfig.mockResolvedValue({ projectId: 'test-repo' }); // no saasUrl
-
-      const cmd = new LoginCommand(createMockDeps());
-      await cmd.executeLogin(defaultOptions);
-
-      const errorOutput = mockConsoleError.mock.calls.map(c => c[0]).join('\n');
-      expect(errorOutput).toContain('No saasUrl configured');
-    });
+    // LOGIN-A4 (no saasUrl) was deduplicated → covered by LOGIN-H1 in §4.8
   });
 
   // ==================== §4.2 Key Sync CLI → SaaS (LOGIN-B1 to B3) ====================
@@ -232,12 +227,37 @@ describe('LoginCommand v2', () => {
       expect(output).toContain('Key synced to SaaS');
     });
 
+    it('[LOGIN-B2] should display confirmation after successful sync (keySynced derived, not persisted)', async () => {
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPrivateKey.mockResolvedValue('base64-private-key');
+      mockGetPublicKey.mockResolvedValue('base64-public-key');
+
+      const syncResponse: SyncKeyResponse = { success: true, actorId: 'human:camilo', mode: 'full' };
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) return { ok: true, json: async () => trpcWrap(noKeyStatus) };
+          if (url.includes('identity.syncKey')) return { ok: true, json: async () => trpcWrap(syncResponse) };
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // Confirmation displayed
+      const output = mockConsoleLog.mock.calls.map(c => c[0]).join('\n');
+      expect(output).toContain('Key synced to SaaS');
+      // keySynced is NOT persisted in session — derived at runtime (§3.4)
+      // setCloudToken was called (for login), but no keySynced field
+      expect(mockSetCloudToken).toHaveBeenCalled();
+    });
+
     it('[LOGIN-B3] should skip key sync when no-key-sync flag is passed', async () => {
       const deps = createMockDeps();
       const cmd = new LoginCommand(deps);
       await cmd.executeLogin({ ...defaultOptions, noKeySync: true });
 
-      expect(mockSaveSession).toHaveBeenCalled();
+      expect(mockSetCloudToken).toHaveBeenCalled();
       expect(deps.fetchSaas).not.toHaveBeenCalled();
     });
   });
@@ -279,6 +299,32 @@ describe('LoginCommand v2', () => {
           headers: expect.objectContaining({ Authorization: 'Bearer test-session-token' }),
         })
       );
+    });
+
+    it('[LOGIN-C2] should store downloaded key via FsKeyProvider (handles 0600 permissions)', async () => {
+      mockHasPrivateKey.mockResolvedValue(false);
+
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) {
+            return { ok: true, json: async () => trpcWrap(keyStatusWith('saas-pub')) };
+          }
+          if (url.includes('identity.getKey')) {
+            return { ok: true, json: async () => trpcWrap({
+              publicKey: 'saas-pub',
+              privateKeyEnvelope: { ephemeralPublicKey: 'e', ciphertext: 'c', iv: 'i', authTag: 'a' },
+            }) };
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // mockEcdhDecrypt returns Buffer.from('decrypted-private-key')
+      // setPrivateKey should be called — FsKeyProvider handles 0600 internally
+      expect(mockSetPrivateKey).toHaveBeenCalledWith('human:camilo', expect.any(String));
     });
   });
 
@@ -350,7 +396,34 @@ describe('LoginCommand v2', () => {
       );
     });
 
-    it('[LOGIN-F3] should show fingerprints and exit 1 when no --force flag', async () => {
+    it('[LOGIN-F2] should download SaaS key with --force-cloud when keys differ', async () => {
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPublicKey.mockResolvedValue('local-pub-key');
+
+      const mockEnvelope = { ephemeralPublicKey: 'ep', ciphertext: 'ct', iv: 'iv', authTag: 'at' };
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) {
+            return { ok: true, json: async () => trpcWrap(keyStatusWith('different-saas-pub')) };
+          }
+          if (url.includes('identity.getKey')) {
+            return { ok: true, json: async () => trpcWrap({ publicKey: 'different-saas-pub', privateKeyEnvelope: mockEnvelope }) };
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin({ ...defaultOptions, forceCloud: true });
+
+      expect(mockSetPrivateKey).toHaveBeenCalled();
+      expect(deps.fetchSaas).toHaveBeenCalledWith(
+        expect.stringContaining('/trpc/identity.getKey'),
+        expect.any(Object)
+      );
+    });
+
+    it('[LOGIN-F3] should show SHA-256 fingerprints and exit 1 when no --force flag', async () => {
       mockHasPrivateKey.mockResolvedValue(true);
       mockGetPublicKey.mockResolvedValue('cli-pub-key-abcdef');
 
@@ -362,10 +435,111 @@ describe('LoginCommand v2', () => {
       await cmd.executeLogin(defaultOptions);
 
       const errorOutput = mockConsoleError.mock.calls.map(c => c[0]).join('\n');
-      // .slice(0, 16) → first 16 chars of each public key
-      expect(errorOutput).toContain('cli-pub-key-abcd');
-      expect(errorOutput).toContain('saas-pub-key-xyz');
+      // SHA-256 hex fingerprints (first 16 chars of hash)
+      expect(errorOutput).toContain('Keys differ');
+      expect(errorOutput).toMatch(/Local:\s+[0-9a-f]{16}/);
+      expect(errorOutput).toMatch(/Cloud:\s+[0-9a-f]{16}/);
       expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it('[LOGIN-F4] should verify keyStatus matches after --force-local resolve', async () => {
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPrivateKey.mockResolvedValue('local-priv');
+      mockGetPublicKey.mockResolvedValue('local-pub-key');
+
+      let callCount = 0;
+      const syncResponse: SyncKeyResponse = { success: true, actorId: 'human:camilo', mode: 'full' };
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) {
+            callCount++;
+            // First call: different key. Second call (post-verify): local key uploaded
+            const pub = callCount === 1 ? 'different-saas-key' : 'local-pub-key';
+            return { ok: true, json: async () => trpcWrap(keyStatusWith(pub)) };
+          }
+          if (url.includes('identity.syncKey')) return { ok: true, json: async () => trpcWrap(syncResponse) };
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin({ ...defaultOptions, forceLocal: true });
+
+      // keyStatus called twice: initial check + post-sync verification
+      const keyStatusCalls = (deps.fetchSaas as jest.Mock).mock.calls.filter(
+        (c: [string]) => c[0].includes('identity.keyStatus')
+      );
+      expect(keyStatusCalls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // ==================== §4.7 ECDH Transport (LOGIN-G1 to G3) ====================
+
+  describe('4.7. ECDH Transport (LOGIN-G1 to G3)', () => {
+    it('[LOGIN-G1] should encrypt key with ECDH before uploading to SaaS', async () => {
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPrivateKey.mockResolvedValue('base64-priv-key');
+      mockGetPublicKey.mockResolvedValue('base64-pub-key');
+
+      const syncResponse = { success: true, actorId: 'human:camilo', mode: 'full' as const };
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) return { ok: true, json: async () => trpcWrap(noKeyStatus) };
+          if (url.includes('identity.syncKey')) return { ok: true, json: async () => trpcWrap(syncResponse) };
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // Verify Crypto.ecdhEncrypt was called
+      expect(mockEcdhEncrypt).toHaveBeenCalled();
+      expect(mockGenerateEphemeralKeypair).toHaveBeenCalled();
+    });
+
+    it('[LOGIN-G2] should decrypt ECDH envelope when downloading key from SaaS', async () => {
+      mockHasPrivateKey.mockResolvedValue(false);
+
+      const mockEnvelope = { ephemeralPublicKey: 'ep', ciphertext: 'ct', iv: 'iv', authTag: 'at' };
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) return { ok: true, json: async () => trpcWrap(keyStatusWith('saas-pub')) };
+          if (url.includes('identity.getKey')) return { ok: true, json: async () => trpcWrap({ publicKey: 'saas-pub', privateKeyEnvelope: mockEnvelope }) };
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      expect(mockEcdhDecrypt).toHaveBeenCalled();
+      // ecdhDecrypt returns Buffer, code does .toString('base64') before storing
+      const expectedKey = Buffer.from('decrypted-private-key').toString('base64');
+      expect(mockSetPrivateKey).toHaveBeenCalledWith('human:camilo', expectedKey);
+    });
+
+    it('[LOGIN-G3] should exit with error and not store key when ECDH decryption fails', async () => {
+      mockHasPrivateKey.mockResolvedValue(false);
+      mockEcdhDecrypt.mockRejectedValueOnce(new Error('Unsupported state or unable to authenticate data'));
+
+      const mockEnvelope = { ephemeralPublicKey: 'ep', ciphertext: 'tampered', iv: 'iv', authTag: 'at' };
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) return { ok: true, json: async () => trpcWrap(keyStatusWith('saas-pub')) };
+          if (url.includes('identity.getKey')) return { ok: true, json: async () => trpcWrap({ publicKey: 'saas-pub', privateKeyEnvelope: mockEnvelope }) };
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // Key should NOT have been stored
+      expect(mockSetPrivateKey).not.toHaveBeenCalled();
+      // Error should mention ECDH
+      const errorOutput = mockConsoleError.mock.calls.map(c => c[0]).join('\n');
+      expect(errorOutput).toContain('ECDH decryption error');
     });
   });
 
@@ -382,15 +556,15 @@ describe('LoginCommand v2', () => {
       expect(errorOutput).toContain('No saasUrl configured');
     });
 
-    it('[LOGIN-H3] should resolve orgId from git remote origin', async () => {
+    it('[LOGIN-H3] should resolve repoFullName from git remote origin', async () => {
       // The mock for child_process.execSync returns 'https://github.com/testorg/testrepo.git'
-      // resolveOrgId should parse this to 'testorg/testrepo'
+      // resolveRepoFullName should parse this to 'testorg/testrepo'
       mockHasPrivateKey.mockResolvedValue(false);
 
       const deps = createMockDeps({
         fetchSaas: jest.fn().mockImplementation(async (url: string) => {
           if (url.includes('identity.keyStatus')) {
-            // Verify the orgId is passed correctly in the tRPC input
+            // Verify the repoFullName is passed correctly in the tRPC input
             expect(url).toContain('testorg');
             return { ok: true, json: async () => trpcWrap(noKeyStatus) };
           }
@@ -401,11 +575,13 @@ describe('LoginCommand v2', () => {
       const cmd = new LoginCommand(deps);
       await cmd.executeLogin(defaultOptions);
 
-      // keyStatus should have been called with orgId from git remote
+      // keyStatus should have been called with repoFullName from git remote
       expect(deps.fetchSaas).toHaveBeenCalledWith(
         expect.stringContaining('testorg'),
         expect.any(Object)
       );
     });
+
+    it.todo('[LOGIN-H2] should timeout after 5 minutes with error message (requires timer mock — deferred to E2E)');
   });
 });

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -40,6 +40,14 @@ jest.mock('@gitgov/core', () => ({
     ecdhDecrypt: (...args: unknown[]) => mockEcdhDecrypt(...args),
     generateEphemeralKeypair: () => mockGenerateEphemeralKeypair(),
   },
+  parseRemoteUrl: (url: string) => {
+    // Parse the mock URL: https://github.com/testorg/testrepo.git
+    const httpsMatch = url.match(/^https?:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
+    if (httpsMatch?.[1] && httpsMatch[2]) return { host: httpsMatch[1], path: httpsMatch[2] };
+    const sshMatch = url.match(/^[^@]+@([^:]+):(.+?)(?:\.git)?$/);
+    if (sshMatch?.[1] && sshMatch[2]) return { host: sshMatch[1], path: sshMatch[2] };
+    return null;
+  },
 }));
 
 // Mock DependencyInjectionService

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -1,15 +1,46 @@
 /**
- * LoginCommand Unit Tests
+ * LoginCommand Unit Tests v2 — Cycle 4, identity_key_sync
  *
- * Spec: cli/specs/login_command.md
+ * Spec: cli/specs/login_command.md (v2)
  * EARS Coverage:
- * - A: OAuth Login Flow (LOGIN-A1 to A3)
+ * - A: OAuth Login Flow (LOGIN-A1 to A4)
  * - B: Key Sync CLI → SaaS (LOGIN-B1 to B3)
  * - C: Key Sync SaaS → CLI (LOGIN-C1 to C2)
  * - D: Key Conflict Resolution (LOGIN-D1 to D2)
+ * - F: Conflict Resolution flags (LOGIN-F1 to F4)
+ * - G: ECDH Transport (LOGIN-G1 to G3)
+ * - H: Config Requirements (LOGIN-H1 to H3)
+ * - I: getSaasUrl (EARS-I1 to I2) — tested in config_manager.test.ts
  */
 
 import type { IKeyProvider } from '@gitgov/core';
+
+// Mock child_process for resolveOrgId
+jest.mock('child_process', () => ({
+  exec: jest.fn(),
+  execSync: jest.fn().mockReturnValue('https://github.com/testorg/testrepo.git\n'),
+}));
+
+// Mock @gitgov/core Crypto for ECDH (avoids real X25519 operations with mock keys)
+const mockEcdhEncrypt = jest.fn().mockResolvedValue({
+  ephemeralPublicKey: 'mock-eph-pub',
+  ciphertext: 'mock-ciphertext',
+  iv: 'mock-iv',
+  authTag: 'mock-tag',
+});
+const mockEcdhDecrypt = jest.fn().mockResolvedValue(Buffer.from('decrypted-private-key'));
+const mockGenerateEphemeralKeypair = jest.fn().mockReturnValue({
+  publicKey: 'mock-client-pub',
+  privateKey: 'mock-client-priv',
+});
+
+jest.mock('@gitgov/core', () => ({
+  Crypto: {
+    ecdhEncrypt: (...args: unknown[]) => mockEcdhEncrypt(...args),
+    ecdhDecrypt: (...args: unknown[]) => mockEcdhDecrypt(...args),
+    generateEphemeralKeypair: () => mockGenerateEphemeralKeypair(),
+  },
+}));
 
 // Mock DependencyInjectionService
 const mockSaveSession = jest.fn();
@@ -41,12 +72,29 @@ jest.mock('../../services/dependency-injection', () => ({
 }));
 
 import { LoginCommand } from './login-command';
-import type { LoginCommandOptions, LoginDeps } from './login-command.types';
+import type { LoginCommandOptions, LoginDeps, TrpcResponse, KeyStatusResponse, SyncKeyResponse } from './login-command.types';
 
 // Mock console and process.exit
 const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
 const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
 const mockProcessExit = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+// ─── tRPC mock helpers ────────────────────────────────────────────────────
+
+/** Wrap a response in tRPC envelope */
+function trpcWrap<T>(data: T): TrpcResponse<T> {
+  return { result: { data: { json: data } } };
+}
+
+/** Default keyStatus response (no key) */
+const noKeyStatus: KeyStatusResponse = {
+  exists: false, hasPrivateKey: false, publicKey: null, ecdhPublicKey: 'server-ecdh-pub-key',
+};
+
+/** keyStatus with key */
+function keyStatusWith(publicKey: string): KeyStatusResponse {
+  return { exists: true, hasPrivateKey: true, publicKey, ecdhPublicKey: 'server-ecdh-pub-key' };
+}
 
 function createMockDeps(overrides?: Partial<LoginDeps>): LoginDeps {
   return {
@@ -57,17 +105,18 @@ function createMockDeps(overrides?: Partial<LoginDeps>): LoginDeps {
     }),
     fetchSaas: jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ hasKey: false, actorExists: false }),
+      json: async () => trpcWrap(noKeyStatus),
     }),
     ...overrides,
   };
 }
 
-function createMockFetch(responses: Record<string, unknown>): LoginDeps['fetchSaas'] {
+/** Create fetchSaas mock that routes by URL pattern */
+function createTrpcFetch(routes: Record<string, unknown>): LoginDeps['fetchSaas'] {
   return jest.fn().mockImplementation(async (url: string) => {
-    for (const [pattern, response] of Object.entries(responses)) {
+    for (const [pattern, response] of Object.entries(routes)) {
       if (url.includes(pattern)) {
-        return { ok: true, json: async () => response };
+        return { ok: true, json: async () => trpcWrap(response) };
       }
     }
     return { ok: false, json: async () => ({}) };
@@ -76,44 +125,38 @@ function createMockFetch(responses: Record<string, unknown>): LoginDeps['fetchSa
 
 const defaultOptions: LoginCommandOptions = {};
 
-describe('LoginCommand', () => {
+describe('LoginCommand v2', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetConfig.mockResolvedValue({ projectId: 'test-repo', saasUrl: 'https://test.gitgov.dev' });
     mockLoadSession.mockResolvedValue(null);
   });
 
-  // ==================== §4.1 OAuth Login Flow (LOGIN-A1 to A3) ====================
+  // ==================== §4.1 OAuth Login Flow (LOGIN-A1 to A4) ====================
 
-  describe('4.1. OAuth Login Flow (LOGIN-A1 to A3)', () => {
+  describe('4.1. OAuth Login Flow (LOGIN-A1 to A4)', () => {
     it('[LOGIN-A1] should open browser and store session token after OAuth callback', async () => {
-      const deps = createMockDeps();
-      // SaaS has no key, CLI has no key — "no actor" path
-      (deps.fetchSaas as jest.Mock).mockResolvedValue({
-        ok: true,
-        json: async () => ({ hasKey: false, actorExists: false }),
-      });
       mockHasPrivateKey.mockResolvedValue(false);
+      const deps = createMockDeps({
+        fetchSaas: createTrpcFetch({ 'identity.keyStatus': noKeyStatus }),
+      });
 
       const cmd = new LoginCommand(deps);
       await cmd.executeLogin(defaultOptions);
 
-      // Browser should have been opened with OAuth URL
       expect(deps.openBrowser).toHaveBeenCalledTimes(1);
       const openUrl = (deps.openBrowser as jest.Mock).mock.calls[0][0] as string;
       expect(openUrl).toContain('/api/auth/cli?callback=');
 
-      // Callback server should have started
       expect(deps.startCallbackServer).toHaveBeenCalledTimes(1);
 
-      // Session should be saved with token
       expect(mockSaveSession).toHaveBeenCalled();
       const savedSession = mockSaveSession.mock.calls[0][0];
       expect(savedSession.cloud.sessionToken).toBe('test-session-token');
       expect(savedSession.lastSession.actorId).toBe('human:camilo');
     });
 
-    it('[LOGIN-A2] should display login status with user info and key sync status', async () => {
+    it('[LOGIN-A2] should display login status with user info', async () => {
       mockLoadSession.mockResolvedValue({
         cloud: { sessionToken: 'existing-token' },
         lastSession: { actorId: 'human:camilo', timestamp: '2026-03-22T10:00:00Z' },
@@ -121,18 +164,14 @@ describe('LoginCommand', () => {
       mockHasPrivateKey.mockResolvedValue(true);
 
       const deps = createMockDeps({
-        fetchSaas: createMockFetch({
-          '/api/identity/status': { hasKey: true, actorExists: true },
-        }),
+        fetchSaas: createTrpcFetch({ 'identity.keyStatus': keyStatusWith('pub-key-1') }),
       });
 
       const cmd = new LoginCommand(deps);
       await cmd.executeStatus(defaultOptions);
 
-      // Should output status info
       const output = mockConsoleLog.mock.calls.map(c => c[0]).join('\n');
       expect(output).toContain('human:camilo');
-      expect(output).toContain('yes');
     });
 
     it('[LOGIN-A3] should remove session token without deleting keys', async () => {
@@ -142,70 +181,40 @@ describe('LoginCommand', () => {
         actorState: { 'human:camilo': { activeTaskId: 'task-1' } },
       });
 
-      const deps = createMockDeps();
-      const cmd = new LoginCommand(deps);
+      const cmd = new LoginCommand(createMockDeps());
       await cmd.executeLogout(defaultOptions);
 
-      // Session should be saved WITHOUT cloud token
       expect(mockSaveSession).toHaveBeenCalled();
       const savedSession = mockSaveSession.mock.calls[0][0];
       expect(savedSession.cloud).toBeUndefined();
-
-      // actorState should be preserved
       expect(savedSession.actorState).toEqual({ 'human:camilo': { activeTaskId: 'task-1' } });
-
-      // Keys should NOT be touched
       expect(mockSetPrivateKey).not.toHaveBeenCalled();
-      expect(mockGetPrivateKey).not.toHaveBeenCalled();
+    });
+
+    it('[LOGIN-A4] should fail when saasUrl is not configured', async () => {
+      mockGetConfig.mockResolvedValue({ projectId: 'test-repo' }); // no saasUrl
+
+      const cmd = new LoginCommand(createMockDeps());
+      await cmd.executeLogin(defaultOptions);
+
+      const errorOutput = mockConsoleError.mock.calls.map(c => c[0]).join('\n');
+      expect(errorOutput).toContain('No saasUrl configured');
     });
   });
 
   // ==================== §4.2 Key Sync CLI → SaaS (LOGIN-B1 to B3) ====================
 
   describe('4.2. Key Sync CLI → SaaS (LOGIN-B1 to B3)', () => {
-    it('[LOGIN-B1] should prompt and sync local key to SaaS when SaaS has no key', async () => {
-      // CLI has key, SaaS does not
+    it('[LOGIN-B1] should sync local key to SaaS via tRPC when SaaS has no key', async () => {
       mockHasPrivateKey.mockResolvedValue(true);
-      mockGetPrivateKey.mockResolvedValue('base64-private-key-data');
+      mockGetPrivateKey.mockResolvedValue('base64-private-key');
+      mockGetPublicKey.mockResolvedValue('base64-public-key');
 
-      const syncKeyMock = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ synced: true }) });
-      const deps = createMockDeps({
-        fetchSaas: jest.fn().mockImplementation(async (url: string, init?: RequestInit) => {
-          if (url.includes('/api/identity/status')) {
-            return { ok: true, json: async () => ({ hasKey: false, actorExists: true }) };
-          }
-          if (url.includes('/api/identity/sync-key')) {
-            return syncKeyMock();
-          }
-          return { ok: false, json: async () => ({}) };
-        }),
-      });
-
-      const cmd = new LoginCommand(deps);
-      await cmd.executeLogin(defaultOptions);
-
-      // Should have called sync-key endpoint
-      expect(deps.fetchSaas).toHaveBeenCalledWith(
-        expect.stringContaining('/api/identity/sync-key'),
-        expect.objectContaining({
-          method: 'POST',
-          body: expect.stringContaining('base64-private-key-data'),
-        })
-      );
-    });
-
-    it('[LOGIN-B2] should update session with keySynced true after successful sync', async () => {
-      mockHasPrivateKey.mockResolvedValue(true);
-      mockGetPrivateKey.mockResolvedValue('base64-private-key-data');
-
+      const syncResponse: SyncKeyResponse = { success: true, actorId: 'human:camilo', mode: 'full' };
       const deps = createMockDeps({
         fetchSaas: jest.fn().mockImplementation(async (url: string) => {
-          if (url.includes('/api/identity/status')) {
-            return { ok: true, json: async () => ({ hasKey: false, actorExists: true }) };
-          }
-          if (url.includes('/api/identity/sync-key')) {
-            return { ok: true, json: async () => ({ synced: true }) };
-          }
+          if (url.includes('identity.keyStatus')) return { ok: true, json: async () => trpcWrap(noKeyStatus) };
+          if (url.includes('identity.syncKey')) return { ok: true, json: async () => trpcWrap(syncResponse) };
           return { ok: false, json: async () => ({}) };
         }),
       });
@@ -213,7 +222,12 @@ describe('LoginCommand', () => {
       const cmd = new LoginCommand(deps);
       await cmd.executeLogin(defaultOptions);
 
-      // Output should confirm sync
+      // Should have called tRPC syncKey endpoint
+      expect(deps.fetchSaas).toHaveBeenCalledWith(
+        expect.stringContaining('/trpc/identity.syncKey'),
+        expect.objectContaining({ method: 'POST' })
+      );
+
       const output = mockConsoleLog.mock.calls.map(c => c[0]).join('\n');
       expect(output).toContain('Key synced to SaaS');
     });
@@ -221,13 +235,9 @@ describe('LoginCommand', () => {
     it('[LOGIN-B3] should skip key sync when no-key-sync flag is passed', async () => {
       const deps = createMockDeps();
       const cmd = new LoginCommand(deps);
-
       await cmd.executeLogin({ ...defaultOptions, noKeySync: true });
 
-      // Session should be stored (login happened)
       expect(mockSaveSession).toHaveBeenCalled();
-
-      // But NO fetch to key status or sync-key should have been made
       expect(deps.fetchSaas).not.toHaveBeenCalled();
     });
   });
@@ -235,62 +245,40 @@ describe('LoginCommand', () => {
   // ==================== §4.3 Key Sync SaaS → CLI (LOGIN-C1 to C2) ====================
 
   describe('4.3. Key Sync SaaS → CLI (LOGIN-C1 to C2)', () => {
-    it('[LOGIN-C1] should prompt and download key from SaaS when CLI has no key', async () => {
-      // CLI has no key, SaaS has key
+    it('[LOGIN-C1] should download key from SaaS via ECDH when CLI has no key', async () => {
       mockHasPrivateKey.mockResolvedValue(false);
+
+      // Mock getKey response with ECDH envelope
+      const mockEnvelope = {
+        ephemeralPublicKey: 'server-eph-pub',
+        ciphertext: 'encrypted-data',
+        iv: 'mock-iv-base64',
+        authTag: 'mock-tag-base64',
+      };
 
       const deps = createMockDeps({
         fetchSaas: jest.fn().mockImplementation(async (url: string) => {
-          if (url.includes('/api/identity/status')) {
-            return { ok: true, json: async () => ({ hasKey: true, actorExists: true }) };
+          if (url.includes('identity.keyStatus')) {
+            return { ok: true, json: async () => trpcWrap(keyStatusWith('saas-pub-key')) };
           }
-          if (url.includes('/api/identity/key')) {
-            return { ok: true, json: async () => ({ privateKey: 'saas-private-key-base64' }) };
+          if (url.includes('identity.getKey')) {
+            return { ok: true, json: async () => trpcWrap({ publicKey: 'saas-pub-key', privateKeyEnvelope: mockEnvelope }) };
           }
           return { ok: false, json: async () => ({}) };
         }),
       });
 
       const cmd = new LoginCommand(deps);
+      // This will fail at ecdhDecrypt (mock envelope is not real ECDH)
+      // but we can verify the fetch was made correctly
       await cmd.executeLogin(defaultOptions);
 
-      // Should have fetched the key from SaaS
       expect(deps.fetchSaas).toHaveBeenCalledWith(
-        expect.stringContaining('/api/identity/key'),
+        expect.stringContaining('/trpc/identity.getKey'),
         expect.objectContaining({
           headers: expect.objectContaining({ Authorization: 'Bearer test-session-token' }),
         })
       );
-
-      // Should store via FsKeyProvider
-      expect(mockSetPrivateKey).toHaveBeenCalledWith('human:camilo', 'saas-private-key-base64');
-    });
-
-    it('[LOGIN-C2] should store downloaded key in FsKeyProvider with 0600 permissions', async () => {
-      // FsKeyProvider handles 0600 internally — verify setPrivateKey is called correctly
-      mockHasPrivateKey.mockResolvedValue(false);
-
-      const deps = createMockDeps({
-        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
-          if (url.includes('/api/identity/status')) {
-            return { ok: true, json: async () => ({ hasKey: true, actorExists: true }) };
-          }
-          if (url.includes('/api/identity/key')) {
-            return { ok: true, json: async () => ({ privateKey: 'downloaded-key-data' }) };
-          }
-          return { ok: false, json: async () => ({}) };
-        }),
-      });
-
-      const cmd = new LoginCommand(deps);
-      await cmd.executeLogin(defaultOptions);
-
-      // setPrivateKey delegates to FsKeyProvider which handles file permissions
-      expect(mockSetPrivateKey).toHaveBeenCalledWith('human:camilo', 'downloaded-key-data');
-
-      // Output should confirm download
-      const output = mockConsoleLog.mock.calls.map(c => c[0]).join('\n');
-      expect(output).toContain('Key downloaded from SaaS');
     });
   });
 
@@ -298,17 +286,12 @@ describe('LoginCommand', () => {
 
   describe('4.4. Key Conflict Resolution (LOGIN-D1 to D2)', () => {
     it('[LOGIN-D1] should display already synced when public keys are identical', async () => {
-      const sharedPublicKey = 'same-public-key-base64';
+      const sharedPub = 'same-public-key-base64';
       mockHasPrivateKey.mockResolvedValue(true);
-      mockGetPublicKey.mockResolvedValue(sharedPublicKey);
+      mockGetPublicKey.mockResolvedValue(sharedPub);
 
       const deps = createMockDeps({
-        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
-          if (url.includes('/api/identity/status')) {
-            return { ok: true, json: async () => ({ hasKey: true, actorExists: true, publicKey: sharedPublicKey }) };
-          }
-          return { ok: false, json: async () => ({}) };
-        }),
+        fetchSaas: createTrpcFetch({ 'identity.keyStatus': keyStatusWith(sharedPub) }),
       });
 
       const cmd = new LoginCommand(deps);
@@ -318,17 +301,12 @@ describe('LoginCommand', () => {
       expect(output).toContain('Already synced');
     });
 
-    it('[LOGIN-D2] should display error with resolution instructions when public keys differ', async () => {
+    it('[LOGIN-D2] should display error with --force instructions when public keys differ', async () => {
       mockHasPrivateKey.mockResolvedValue(true);
-      mockGetPublicKey.mockResolvedValue('cli-public-key');
+      mockGetPublicKey.mockResolvedValue('cli-public-key-1234567890');
 
       const deps = createMockDeps({
-        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
-          if (url.includes('/api/identity/status')) {
-            return { ok: true, json: async () => ({ hasKey: true, actorExists: true, publicKey: 'different-saas-public-key' }) };
-          }
-          return { ok: false, json: async () => ({}) };
-        }),
+        fetchSaas: createTrpcFetch({ 'identity.keyStatus': keyStatusWith('saas-public-key-9876543210') }),
       });
 
       const cmd = new LoginCommand(deps);
@@ -338,6 +316,96 @@ describe('LoginCommand', () => {
       expect(errorOutput).toContain('Keys differ');
       expect(errorOutput).toContain('--force-local');
       expect(errorOutput).toContain('--force-cloud');
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  // ==================== §4.6 Conflict Resolution (LOGIN-F1 to F4) ====================
+
+  describe('4.6. Conflict Resolution (LOGIN-F1 to F4)', () => {
+    it('[LOGIN-F1] should upload local key with --force-local when keys differ', async () => {
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPrivateKey.mockResolvedValue('local-private-key');
+      mockGetPublicKey.mockResolvedValue('local-public-key');
+
+      const syncResponse: SyncKeyResponse = { success: true, actorId: 'human:camilo', mode: 'full' };
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) {
+            return { ok: true, json: async () => trpcWrap(keyStatusWith('different-saas-key')) };
+          }
+          if (url.includes('identity.syncKey')) {
+            return { ok: true, json: async () => trpcWrap(syncResponse) };
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin({ ...defaultOptions, forceLocal: true });
+
+      expect(deps.fetchSaas).toHaveBeenCalledWith(
+        expect.stringContaining('/trpc/identity.syncKey'),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('[LOGIN-F3] should show fingerprints and exit 1 when no --force flag', async () => {
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPublicKey.mockResolvedValue('cli-pub-key-abcdef');
+
+      const deps = createMockDeps({
+        fetchSaas: createTrpcFetch({ 'identity.keyStatus': keyStatusWith('saas-pub-key-xyz123') }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      const errorOutput = mockConsoleError.mock.calls.map(c => c[0]).join('\n');
+      // .slice(0, 16) → first 16 chars of each public key
+      expect(errorOutput).toContain('cli-pub-key-abcd');
+      expect(errorOutput).toContain('saas-pub-key-xyz');
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  // ==================== §4.8 Config Requirements (LOGIN-H1 to H3) ====================
+
+  describe('4.8. Config Requirements (LOGIN-H1 to H3)', () => {
+    it('[LOGIN-H1] should exit with error when saasUrl is not configured', async () => {
+      mockGetConfig.mockResolvedValue({ projectId: 'test' }); // no saasUrl
+
+      const cmd = new LoginCommand(createMockDeps());
+      await cmd.executeLogin(defaultOptions);
+
+      const errorOutput = mockConsoleError.mock.calls.map(c => c[0]).join('\n');
+      expect(errorOutput).toContain('No saasUrl configured');
+    });
+
+    it('[LOGIN-H3] should resolve orgId from git remote origin', async () => {
+      // The mock for child_process.execSync returns 'https://github.com/testorg/testrepo.git'
+      // resolveOrgId should parse this to 'testorg/testrepo'
+      mockHasPrivateKey.mockResolvedValue(false);
+
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) {
+            // Verify the orgId is passed correctly in the tRPC input
+            expect(url).toContain('testorg');
+            return { ok: true, json: async () => trpcWrap(noKeyStatus) };
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // keyStatus should have been called with orgId from git remote
+      expect(deps.fetchSaas).toHaveBeenCalledWith(
+        expect.stringContaining('testorg'),
+        expect.any(Object)
+      );
     });
   });
 });

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -377,7 +377,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
 
   /** Call identity.keyStatus via tRPC (IKS-A27 wire format) */
   private async getKeyStatus(saasUrl: string, token: string, repo: GitRemoteRef): Promise<KeyStatusResponse> {
-    const input = encodeURIComponent(JSON.stringify({ json: { providerHost: repo.host, repoPath: repo.path } }));
+    const input = encodeURIComponent(JSON.stringify({ json: repo }));
     const url = `${saasUrl}/trpc/identity.keyStatus?input=${input}`;
     const res = await this.deps.fetchSaas(url, {
       headers: { Authorization: `Bearer ${token}` },
@@ -418,7 +418,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ json: { providerHost: repo.host, repoPath: repo.path, publicKey, privateKeyEnvelope: envelope } }),
+      body: JSON.stringify({ json: { ...repo, publicKey, privateKeyEnvelope: envelope } }),
     });
     if (!res.ok) throw new Error(`Failed to sync key to SaaS: ${res.status}`);
     const body = await res.json() as TrpcResponse<SyncKeyResponse>;
@@ -439,7 +439,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     const clientKp = Crypto.generateEphemeralKeypair();
 
     const input = encodeURIComponent(JSON.stringify({
-      json: { providerHost: repo.host, repoPath: repo.path, clientEcdhPublicKey: clientKp.publicKey },
+      json: { ...repo, clientEcdhPublicKey: clientKp.publicKey },
     }));
     const url = `${saasUrl}/trpc/identity.getKey?input=${input}`;
     const res = await this.deps.fetchSaas(url, {

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -8,7 +8,7 @@
  * v2 changes (Cycle 4, identity_key_sync):
  *   - REST → tRPC wire format (IKS-A27)
  *   - plaintext → ECDH encrypted key exchange (IKS-A24/A25)
- *   - repoId → orgId via owner/repo from git remote (IKS-A29)
+ *   - repoId → repoFullName via owner/repo from git remote (IKS-A29, IKS-A32)
  *   - +--force-local / --force-cloud conflict resolution (LOGIN-F1..F4)
  *   - saasUrl required, no default (IKS-A28, LOGIN-H1)
  *   - 5 minute callback timeout (LOGIN-H2)
@@ -102,12 +102,10 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       // Wait for callback with token
       const { token, user } = await callbackPromise;
 
-      // Store session token via SessionManager
+      // Store session token via SessionManager public API
       const sessionManager = await this.dependencyService.getSessionManager();
-      const session = await sessionManager.loadSession() ?? {};
-      session.cloud = { sessionToken: token };
-      session.lastSession = { actorId: `human:${user.login}`, timestamp: new Date().toISOString() };
-      await (sessionManager as any).sessionStore.saveSession(session);
+      await sessionManager.setCloudToken(token);
+      await sessionManager.setLastSession(`human:${user.login}`, new Date().toISOString());
 
       console.log(`Logged in as ${user.login} (human:${user.login})`);
 
@@ -156,10 +154,10 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       // Check key sync status via tRPC
       let keyStatus: KeyStatusResponse | null = null;
       try {
-        const orgId = await this.resolveOrgId();
-        keyStatus = await this.getKeyStatus(saasUrl, token, orgId);
+        const repoFullName = await this.resolveRepoFullName();
+        keyStatus = await this.getKeyStatus(saasUrl, token, repoFullName);
       } catch {
-        // Non-fatal — can't reach SaaS or resolve orgId
+        // Non-fatal — can't reach SaaS or resolve repoFullName
       }
 
       const hasLocalKey = await this.hasLocalKey(actorId);
@@ -197,12 +195,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
   async executeLogout(options: LoginCommandOptions): Promise<void> {
     try {
       const sessionManager = await this.dependencyService.getSessionManager();
-      const session = await sessionManager.loadSession() ?? {};
-
-      // Remove cloud token but preserve everything else
-      delete session.cloud;
-
-      await (sessionManager as any).sessionStore.saveSession(session);
+      await sessionManager.clearCloudToken();
 
       this.handleSuccess(
         { loggedOut: true },
@@ -232,15 +225,15 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     token: string,
     options: LoginCommandOptions,
   ): Promise<void> {
-    // [LOGIN-H3] Resolve orgId from git remote
-    const orgId = await this.resolveOrgId();
+    // [LOGIN-H3] Resolve repoFullName from git remote (IKS-A29, IKS-A32)
+    const repoFullName = await this.resolveRepoFullName();
 
     const hasLocal = await this.hasLocalKey(actorId);
-    const keyStatus = await this.getKeyStatus(saasUrl, token, orgId);
+    const keyStatus = await this.getKeyStatus(saasUrl, token, repoFullName);
 
     // [LOGIN-B1] CLI has key, SaaS does not → upload with ECDH
     if (hasLocal && !keyStatus.exists) {
-      await this.uploadKeyToSaas(actorId, saasUrl, token, orgId, keyStatus.ecdhPublicKey);
+      await this.uploadKeyToSaas(actorId, saasUrl, token, repoFullName, keyStatus.ecdhPublicKey);
       this.handleSuccess(
         { loggedIn: true, user: actorId, keySynced: true },
         options,
@@ -251,7 +244,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
 
     // [LOGIN-C1] SaaS has key, CLI does not → download with ECDH
     if (!hasLocal && keyStatus.exists && keyStatus.hasPrivateKey) {
-      await this.downloadKeyFromSaas(actorId, saasUrl, token, orgId);
+      await this.downloadKeyFromSaas(actorId, saasUrl, token, repoFullName);
       this.handleSuccess(
         { loggedIn: true, user: actorId, keySynced: true },
         options,
@@ -279,10 +272,10 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       if (localPublicKey && saasPublicKey && localPublicKey !== saasPublicKey) {
         // [LOGIN-F1] --force-local: upload local key, archive SaaS key
         if (options.forceLocal) {
-          await this.uploadKeyToSaas(actorId, saasUrl, token, orgId, keyStatus.ecdhPublicKey);
+          await this.uploadKeyToSaas(actorId, saasUrl, token, repoFullName, keyStatus.ecdhPublicKey);
           console.log('Previous cloud key archived. Local key is now canonical.');
           // [LOGIN-F4] Post-sync verification
-          const postStatus = await this.getKeyStatus(saasUrl, token, orgId);
+          const postStatus = await this.getKeyStatus(saasUrl, token, repoFullName);
           const newLocalPub = await keyProvider.getPublicKey(actorId);
           if (postStatus.publicKey === newLocalPub) {
             this.handleSuccess(
@@ -296,19 +289,25 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
 
         // [LOGIN-F2] --force-cloud: download SaaS key, replace local
         if (options.forceCloud) {
-          await this.downloadKeyFromSaas(actorId, saasUrl, token, orgId);
+          await this.downloadKeyFromSaas(actorId, saasUrl, token, repoFullName);
           console.log('Previous local key archived. Cloud key is now canonical.');
-          this.handleSuccess(
-            { loggedIn: true, user: actorId, keySynced: true },
-            options,
-            `Logged in as ${actorId}\nKey conflict resolved (cloud key downloaded)`
-          );
+          // [LOGIN-F4] Post-sync verification
+          const postStatus = await this.getKeyStatus(saasUrl, token, repoFullName);
+          const newLocalPub = await keyProvider.getPublicKey(actorId);
+          if (postStatus.publicKey === newLocalPub) {
+            this.handleSuccess(
+              { loggedIn: true, user: actorId, keySynced: true },
+              options,
+              `Logged in as ${actorId}\nKey conflict resolved (cloud key downloaded)`
+            );
+          }
           return;
         }
 
-        // [LOGIN-F3] No flags → show fingerprints and exit
-        const localFp = localPublicKey.slice(0, 16);
-        const saasFp = saasPublicKey.slice(0, 16);
+        // [LOGIN-F3] No flags → show fingerprints (SHA-256 hex, first 16 chars) and exit
+        const { createHash } = await import('crypto');
+        const localFp = createHash('sha256').update(Buffer.from(localPublicKey, 'base64')).digest('hex').slice(0, 16);
+        const saasFp = createHash('sha256').update(Buffer.from(saasPublicKey, 'base64')).digest('hex').slice(0, 16);
         if (options.json) {
           console.log(JSON.stringify({
             success: false,
@@ -328,18 +327,15 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       }
     }
 
-    // Neither has key (case e)
+    // Neither has key (case e) — exit 1 per spec
     if (!hasLocal && !keyStatus.exists) {
-      this.handleSuccess(
-        { loggedIn: true, user: actorId, keySynced: false },
-        options,
-        `Logged in as ${actorId}\nNo actor key found. Run gitgov init first.`
-      );
+      console.error('No actor key found. Run gitgov init first to generate your identity key.');
+      process.exit(1);
     }
   }
 
   // ============================================================================
-  // tRPC HELPERS (v2 — ECDH encrypted, orgId-scoped)
+  // tRPC HELPERS (v2 — ECDH encrypted, repoFullName-scoped)
   // ============================================================================
 
   // [LOGIN-H1] saasUrl must be explicitly configured — no default (IKS-A28)
@@ -347,16 +343,16 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     if (options.url) return options.url;
     try {
       const configManager = await this.dependencyService.getConfigManager();
-      const config = await configManager.loadConfig();
-      if (config?.saasUrl) return config.saasUrl;
+      const saasUrl = await configManager.getSaasUrl();
+      if (saasUrl) return saasUrl;
     } catch {
       // No config available
     }
     throw new Error('No saasUrl configured. Run gitgov init or set saasUrl in .gitgov/config.json');
   }
 
-  // [LOGIN-H3] Resolve orgId from git remote origin → owner/repo (IKS-A29)
-  private async resolveOrgId(): Promise<string> {
+  // [LOGIN-H3] Resolve repoFullName from git remote origin (IKS-A29, IKS-A32)
+  private async resolveRepoFullName(): Promise<string> {
     try {
       const { execSync } = await import('child_process');
       const remoteUrl = execSync('git remote get-url origin', { encoding: 'utf-8' }).trim();
@@ -379,8 +375,8 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
   }
 
   /** Call identity.keyStatus via tRPC (IKS-A27 wire format) */
-  private async getKeyStatus(saasUrl: string, token: string, orgId: string): Promise<KeyStatusResponse> {
-    const input = encodeURIComponent(JSON.stringify({ json: { orgId } }));
+  private async getKeyStatus(saasUrl: string, token: string, repoFullName: string): Promise<KeyStatusResponse> {
+    const input = encodeURIComponent(JSON.stringify({ json: { repoFullName } }));
     const url = `${saasUrl}/trpc/identity.keyStatus?input=${input}`;
     const res = await this.deps.fetchSaas(url, {
       headers: { Authorization: `Bearer ${token}` },
@@ -398,7 +394,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     actorId: string,
     saasUrl: string,
     token: string,
-    orgId: string,
+    repoFullName: string,
     serverEcdhPublicKey: string,
   ): Promise<SyncKeyResponse> {
     const keyProvider = this.dependencyService.getKeyProvider();
@@ -421,7 +417,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ json: { orgId, publicKey, privateKeyEnvelope: envelope } }),
+      body: JSON.stringify({ json: { repoFullName, publicKey, privateKeyEnvelope: envelope } }),
     });
     if (!res.ok) throw new Error(`Failed to sync key to SaaS: ${res.status}`);
     const body = await res.json() as TrpcResponse<SyncKeyResponse>;
@@ -436,13 +432,13 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     actorId: string,
     saasUrl: string,
     token: string,
-    orgId: string,
+    repoFullName: string,
   ): Promise<void> {
     // [LOGIN-G2] Generate ephemeral keypair for ECDH
     const clientKp = Crypto.generateEphemeralKeypair();
 
     const input = encodeURIComponent(JSON.stringify({
-      json: { orgId, clientEcdhPublicKey: clientKp.publicKey },
+      json: { repoFullName, clientEcdhPublicKey: clientKp.publicKey },
     }));
     const url = `${saasUrl}/trpc/identity.getKey?input=${input}`;
     const res = await this.deps.fetchSaas(url, {

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -1,14 +1,30 @@
 /**
- * Login Command — connects CLI with SaaS, exchanges private keys
+ * Login Command v2 — connects CLI with SaaS, exchanges private keys via ECDH
  *
- * Spec: cli/specs/login_command.md
- * EARS: LOGIN-A1..A3, LOGIN-B1..B3, LOGIN-C1..C2, LOGIN-D1..D2 (unit tests)
- *       LOGIN-E1..E4 (E2E tests in cli/e2e/login_command_e2e.test.ts)
+ * Spec: cli/specs/login_command.md (v2)
+ * EARS: LOGIN-A1..A4, LOGIN-B1..B3, LOGIN-C1..C2, LOGIN-D1..D2,
+ *       LOGIN-E1..E4 (E2E), LOGIN-F1..F4, LOGIN-G1..G3, LOGIN-H1..H3
+ *
+ * v2 changes (Cycle 4, identity_key_sync):
+ *   - REST → tRPC wire format (IKS-A27)
+ *   - plaintext → ECDH encrypted key exchange (IKS-A24/A25)
+ *   - repoId → orgId via owner/repo from git remote (IKS-A29)
+ *   - +--force-local / --force-cloud conflict resolution (LOGIN-F1..F4)
+ *   - saasUrl required, no default (IKS-A28, LOGIN-H1)
+ *   - 5 minute callback timeout (LOGIN-H2)
  */
 
 import { Command } from 'commander';
 import { BaseCommand } from '../../base/base-command';
-import type { LoginCommandOptions, LoginDeps, KeyStatusResponse, SyncKeyResponse, GetKeyResponse } from './login-command.types';
+import { Crypto } from '@gitgov/core';
+import type {
+  LoginCommandOptions,
+  LoginDeps,
+  KeyStatusResponse,
+  SyncKeyResponse,
+  GetKeyResponse,
+  TrpcResponse,
+} from './login-command.types';
 
 const CALLBACK_PORT = 9876;
 const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes (IKS-A28, LOGIN-H2)
@@ -137,15 +153,13 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       const saasUrl = await this.resolveSaasUrl(options);
       const actorId = lastSession.actorId;
 
-      // Check key sync status
-      let keyStatus: KeyStatusResponse = { hasKey: false, actorExists: false };
+      // Check key sync status via tRPC
+      let keyStatus: KeyStatusResponse | null = null;
       try {
-        const configManager = await this.dependencyService.getConfigManager();
-        const config = await configManager.loadConfig();
-        const repoId = config?.projectId ?? '';
-        keyStatus = await this.getKeyStatus(saasUrl, token, actorId, repoId);
+        const orgId = await this.resolveOrgId();
+        keyStatus = await this.getKeyStatus(saasUrl, token, orgId);
       } catch {
-        // Non-fatal — can't reach SaaS
+        // Non-fatal — can't reach SaaS or resolve orgId
       }
 
       const hasLocalKey = await this.hasLocalKey(actorId);
@@ -155,9 +169,9 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
           loggedIn: true,
           user: actorId,
           saasUrl,
-          keySynced: hasLocalKey && keyStatus.hasKey,
+          keySynced: hasLocalKey && (keyStatus?.hasPrivateKey ?? false),
           localKey: hasLocalKey,
-          saasKey: keyStatus.hasKey,
+          saasKey: keyStatus?.hasPrivateKey ?? false,
           lastLogin: lastSession.timestamp,
         },
         options,
@@ -165,8 +179,8 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
           `Logged in as ${actorId}`,
           `  SaaS: ${saasUrl}`,
           `  Local key: ${hasLocalKey ? 'yes' : 'no'}`,
-          `  SaaS key: ${keyStatus.hasKey ? 'yes' : 'no'}`,
-          `  Synced: ${hasLocalKey && keyStatus.hasKey ? 'yes' : 'no'}`,
+          `  SaaS key: ${keyStatus?.hasPrivateKey ? 'yes' : 'no'}`,
+          `  Synced: ${hasLocalKey && keyStatus?.hasPrivateKey ? 'yes' : 'no'}`,
           `  Last login: ${lastSession.timestamp}`,
         ].join('\n')
       );
@@ -205,13 +219,12 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
   }
 
   /**
-   * Key sync detection and execution
-   * [LOGIN-B1] CLI → SaaS when SaaS has no key
-   * [LOGIN-B2] Update session after sync
-   * [LOGIN-C1] SaaS → CLI when CLI has no key
-   * [LOGIN-C2] Store downloaded key with secure permissions
-   * [LOGIN-D1] Keys match → already synced
-   * [LOGIN-D2] Keys differ → error
+   * Key sync detection and execution (5 cases + --force conflict resolution)
+   * [LOGIN-B1] CLI → SaaS when SaaS has no key (ECDH upload)
+   * [LOGIN-C1] SaaS → CLI when CLI has no key (ECDH download)
+   * [LOGIN-D1] Public keys match → already synced
+   * [LOGIN-D2] Public keys differ → conflict
+   * [LOGIN-F1..F4] --force-local / --force-cloud
    */
   private async syncKeys(
     actorId: string,
@@ -219,53 +232,39 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     token: string,
     options: LoginCommandOptions,
   ): Promise<void> {
-    const configManager = await this.dependencyService.getConfigManager();
-    const config = await configManager.loadConfig();
-    const repoId = config?.projectId ?? '';
+    // [LOGIN-H3] Resolve orgId from git remote
+    const orgId = await this.resolveOrgId();
 
     const hasLocal = await this.hasLocalKey(actorId);
-    const keyStatus = await this.getKeyStatus(saasUrl, token, actorId, repoId);
+    const keyStatus = await this.getKeyStatus(saasUrl, token, orgId);
 
-    // [LOGIN-B1] CLI has key, SaaS does not → sync to SaaS
-    if (hasLocal && !keyStatus.hasKey) {
-      const keyProvider = this.dependencyService.getKeyProvider();
-      const privateKey = await keyProvider.getPrivateKey(actorId);
-      if (privateKey) {
-        await this.syncKeyToSaas(saasUrl, token, actorId, repoId, privateKey);
-        // [LOGIN-B2] Update session
-        console.log(`Key synced to SaaS for repo ${repoId}`);
-        this.handleSuccess(
-          { loggedIn: true, user: actorId, keySynced: true },
-          options,
-          `Logged in as ${actorId}\nKey synced to SaaS`
-        );
-        return;
-      }
+    // [LOGIN-B1] CLI has key, SaaS does not → upload with ECDH
+    if (hasLocal && !keyStatus.exists) {
+      await this.uploadKeyToSaas(actorId, saasUrl, token, orgId, keyStatus.ecdhPublicKey);
+      this.handleSuccess(
+        { loggedIn: true, user: actorId, keySynced: true },
+        options,
+        `Logged in as ${actorId}\nKey synced to SaaS`
+      );
+      return;
     }
 
-    // [LOGIN-C1] SaaS has key, CLI does not → download to CLI
-    if (!hasLocal && keyStatus.hasKey) {
-      const keyResponse = await this.getKeyFromSaas(saasUrl, token, actorId, repoId);
-      if (keyResponse.privateKey) {
-        // [LOGIN-C2] Store with FsKeyProvider (handles 0600 permissions)
-        const keyProvider = this.dependencyService.getKeyProvider();
-        await keyProvider.setPrivateKey(actorId, keyResponse.privateKey);
-        console.log(`Key downloaded from SaaS`);
-        this.handleSuccess(
-          { loggedIn: true, user: actorId, keySynced: true },
-          options,
-          `Logged in as ${actorId}\nKey downloaded from SaaS`
-        );
-        return;
-      }
+    // [LOGIN-C1] SaaS has key, CLI does not → download with ECDH
+    if (!hasLocal && keyStatus.exists && keyStatus.hasPrivateKey) {
+      await this.downloadKeyFromSaas(actorId, saasUrl, token, orgId);
+      this.handleSuccess(
+        { loggedIn: true, user: actorId, keySynced: true },
+        options,
+        `Logged in as ${actorId}\nKey downloaded from SaaS`
+      );
+      return;
     }
 
-    // [LOGIN-D1] Both have key — compare PUBLIC keys (not private — cheaper + more secure)
-    if (hasLocal && keyStatus.hasKey) {
+    // [LOGIN-D1] Both have key — compare PUBLIC keys
+    if (hasLocal && keyStatus.exists) {
       const keyProvider = this.dependencyService.getKeyProvider();
       const localPublicKey = await keyProvider.getPublicKey(actorId);
-      // keyStatus.publicKey comes from the SaaS without downloading private key material
-      const saasPublicKey = keyStatus.publicKey ?? null;
+      const saasPublicKey = keyStatus.publicKey;
 
       if (localPublicKey && saasPublicKey && localPublicKey === saasPublicKey) {
         this.handleSuccess(
@@ -276,16 +275,51 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
         return;
       }
 
-      // [LOGIN-D2] Keys differ → error with instructions, exit 1
+      // [LOGIN-D2 / LOGIN-F1..F4] Keys differ → conflict resolution
       if (localPublicKey && saasPublicKey && localPublicKey !== saasPublicKey) {
+        // [LOGIN-F1] --force-local: upload local key, archive SaaS key
+        if (options.forceLocal) {
+          await this.uploadKeyToSaas(actorId, saasUrl, token, orgId, keyStatus.ecdhPublicKey);
+          console.log('Previous cloud key archived. Local key is now canonical.');
+          // [LOGIN-F4] Post-sync verification
+          const postStatus = await this.getKeyStatus(saasUrl, token, orgId);
+          const newLocalPub = await keyProvider.getPublicKey(actorId);
+          if (postStatus.publicKey === newLocalPub) {
+            this.handleSuccess(
+              { loggedIn: true, user: actorId, keySynced: true },
+              options,
+              `Logged in as ${actorId}\nKey conflict resolved (local key uploaded)`
+            );
+          }
+          return;
+        }
+
+        // [LOGIN-F2] --force-cloud: download SaaS key, replace local
+        if (options.forceCloud) {
+          await this.downloadKeyFromSaas(actorId, saasUrl, token, orgId);
+          console.log('Previous local key archived. Cloud key is now canonical.');
+          this.handleSuccess(
+            { loggedIn: true, user: actorId, keySynced: true },
+            options,
+            `Logged in as ${actorId}\nKey conflict resolved (cloud key downloaded)`
+          );
+          return;
+        }
+
+        // [LOGIN-F3] No flags → show fingerprints and exit
+        const localFp = localPublicKey.slice(0, 16);
+        const saasFp = saasPublicKey.slice(0, 16);
         if (options.json) {
           console.log(JSON.stringify({
             success: false,
             error: 'Key conflict',
-            data: { loggedIn: true, user: actorId, keySynced: false, keyConflict: true },
+            data: { loggedIn: true, user: actorId, keySynced: false, keyConflict: true,
+              localFingerprint: localFp, saasFingerprint: saasFp },
           }, null, 2));
         } else {
           console.error('Keys differ between CLI and SaaS.');
+          console.error(`  Local:  ${localFp}...`);
+          console.error(`  Cloud:  ${saasFp}...`);
           console.error('Use --force-local to keep local key (uploads to cloud)');
           console.error('Use --force-cloud to keep cloud key (downloads to local)');
         }
@@ -294,8 +328,8 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       }
     }
 
-    // Neither has key
-    if (!hasLocal && !keyStatus.hasKey) {
+    // Neither has key (case e)
+    if (!hasLocal && !keyStatus.exists) {
       this.handleSuccess(
         { loggedIn: true, user: actorId, keySynced: false },
         options,
@@ -305,7 +339,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
   }
 
   // ============================================================================
-  // HELPERS
+  // tRPC HELPERS (v2 — ECDH encrypted, orgId-scoped)
   // ============================================================================
 
   // [LOGIN-H1] saasUrl must be explicitly configured — no default (IKS-A28)
@@ -321,6 +355,20 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     throw new Error('No saasUrl configured. Run gitgov init or set saasUrl in .gitgov/config.json');
   }
 
+  // [LOGIN-H3] Resolve orgId from git remote origin → owner/repo (IKS-A29)
+  private async resolveOrgId(): Promise<string> {
+    try {
+      const { execSync } = await import('child_process');
+      const remoteUrl = execSync('git remote get-url origin', { encoding: 'utf-8' }).trim();
+      // Parse owner/repo from https://github.com/owner/repo.git or git@github.com:owner/repo.git
+      const match = remoteUrl.match(/[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
+      if (match) return `${match[1]}/${match[2]}`;
+    } catch {
+      // Git not available or no remote
+    }
+    throw new Error('Could not determine repository. Ensure you are in a git repository with a remote origin.');
+  }
+
   private async hasLocalKey(actorId: string): Promise<boolean> {
     try {
       const keyProvider = this.dependencyService.getKeyProvider();
@@ -330,35 +378,93 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     }
   }
 
-  private async getKeyStatus(saasUrl: string, token: string, actorId: string, repoId: string): Promise<KeyStatusResponse> {
-    const url = `${saasUrl}/api/identity/status?actorId=${encodeURIComponent(actorId)}&repoId=${encodeURIComponent(repoId)}`;
+  /** Call identity.keyStatus via tRPC (IKS-A27 wire format) */
+  private async getKeyStatus(saasUrl: string, token: string, orgId: string): Promise<KeyStatusResponse> {
+    const input = encodeURIComponent(JSON.stringify({ json: { orgId } }));
+    const url = `${saasUrl}/trpc/identity.keyStatus?input=${input}`;
     const res = await this.deps.fetchSaas(url, {
       headers: { Authorization: `Bearer ${token}` },
     });
-    if (!res.ok) return { hasKey: false, actorExists: false };
-    return await res.json() as KeyStatusResponse;
+    if (!res.ok) return { exists: false, hasPrivateKey: false, publicKey: null, ecdhPublicKey: '' };
+    const body = await res.json() as TrpcResponse<KeyStatusResponse>;
+    return body.result.data.json;
   }
 
-  private async syncKeyToSaas(saasUrl: string, token: string, actorId: string, repoId: string, privateKey: string): Promise<SyncKeyResponse> {
-    const url = `${saasUrl}/api/identity/sync-key`;
+  /**
+   * [LOGIN-G1] Upload key to SaaS with ECDH (ECIES pattern).
+   * Fetches server's ecdhPublicKey from keyStatus, encrypts with ecdhEncrypt.
+   */
+  private async uploadKeyToSaas(
+    actorId: string,
+    saasUrl: string,
+    token: string,
+    orgId: string,
+    serverEcdhPublicKey: string,
+  ): Promise<SyncKeyResponse> {
+    const keyProvider = this.dependencyService.getKeyProvider();
+    const privateKey = await keyProvider.getPrivateKey(actorId);
+    const publicKey = await keyProvider.getPublicKey(actorId);
+    if (!privateKey || !publicKey) throw new Error('Local key not found');
+
+    // [LOGIN-G1] ECDH encrypt: client generates ephemeral keypair, encrypts for server
+    const clientKp = Crypto.generateEphemeralKeypair();
+    const envelope = await Crypto.ecdhEncrypt(
+      Buffer.from(privateKey, 'base64'),
+      clientKp,
+      serverEcdhPublicKey,
+    );
+
+    const url = `${saasUrl}/trpc/identity.syncKey`;
     const res = await this.deps.fetchSaas(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ actorId, repoId, privateKey }),
+      body: JSON.stringify({ json: { orgId, publicKey, privateKeyEnvelope: envelope } }),
     });
     if (!res.ok) throw new Error(`Failed to sync key to SaaS: ${res.status}`);
-    return await res.json() as SyncKeyResponse;
+    const body = await res.json() as TrpcResponse<SyncKeyResponse>;
+    return body.result.data.json;
   }
 
-  private async getKeyFromSaas(saasUrl: string, token: string, actorId: string, repoId: string): Promise<GetKeyResponse> {
-    const url = `${saasUrl}/api/identity/key?actorId=${encodeURIComponent(actorId)}&repoId=${encodeURIComponent(repoId)}`;
+  /**
+   * [LOGIN-G2] Download key from SaaS with ECDH (ephemeral pattern).
+   * Generates client ephemeral keypair, sends pubkey, decrypts response.
+   */
+  private async downloadKeyFromSaas(
+    actorId: string,
+    saasUrl: string,
+    token: string,
+    orgId: string,
+  ): Promise<void> {
+    // [LOGIN-G2] Generate ephemeral keypair for ECDH
+    const clientKp = Crypto.generateEphemeralKeypair();
+
+    const input = encodeURIComponent(JSON.stringify({
+      json: { orgId, clientEcdhPublicKey: clientKp.publicKey },
+    }));
+    const url = `${saasUrl}/trpc/identity.getKey?input=${input}`;
     const res = await this.deps.fetchSaas(url, {
       headers: { Authorization: `Bearer ${token}` },
     });
-    if (!res.ok) return { privateKey: null };
-    return await res.json() as GetKeyResponse;
+    if (!res.ok) throw new Error(`Failed to download key from SaaS: ${res.status}`);
+
+    const body = await res.json() as TrpcResponse<GetKeyResponse>;
+    const { privateKeyEnvelope } = body.result.data.json;
+
+    // [LOGIN-G2] Decrypt ECDH envelope
+    let decryptedKey: Buffer;
+    try {
+      decryptedKey = await Crypto.ecdhDecrypt(privateKeyEnvelope, clientKp.privateKey);
+    } catch {
+      // [LOGIN-G3] ECDH decryption failure
+      throw new Error('Key transfer failed: ECDH decryption error. Try again or contact support.');
+    }
+
+    // [LOGIN-C2] Store with FsKeyProvider (handles 0600 permissions)
+    const keyProvider = this.dependencyService.getKeyProvider();
+    await keyProvider.setPrivateKey(actorId, decryptedKey.toString('base64'));
+    console.log('Key downloaded from SaaS');
   }
 }

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -10,8 +10,8 @@ import { Command } from 'commander';
 import { BaseCommand } from '../../base/base-command';
 import type { LoginCommandOptions, LoginDeps, KeyStatusResponse, SyncKeyResponse, GetKeyResponse } from './login-command.types';
 
-const DEFAULT_SAAS_URL = 'https://cloud.gitgov.dev';
 const CALLBACK_PORT = 9876;
+const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes (IKS-A28, LOGIN-H2)
 
 /**
  * Default deps use real implementations (overridable for tests).
@@ -45,11 +45,11 @@ function createDefaultDeps(): LoginDeps {
           });
           server.listen(port, () => {});
           server.on('error', reject);
-          // Timeout after 60s
+          // [LOGIN-H2] Timeout after 5 minutes
           setTimeout(() => {
             server.close();
-            reject(new Error('Login timeout — no callback received within 60 seconds'));
-          }, 60_000);
+            reject(new Error('Login timeout — no callback received within 5 minutes'));
+          }, CALLBACK_TIMEOUT_MS);
         });
       });
     },
@@ -260,13 +260,14 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       }
     }
 
-    // [LOGIN-D1] Both have key and they match → already synced
+    // [LOGIN-D1] Both have key — compare PUBLIC keys (not private — cheaper + more secure)
     if (hasLocal && keyStatus.hasKey) {
       const keyProvider = this.dependencyService.getKeyProvider();
-      const localKey = await keyProvider.getPrivateKey(actorId);
-      const saasKeyResponse = await this.getKeyFromSaas(saasUrl, token, actorId, repoId);
+      const localPublicKey = await keyProvider.getPublicKey(actorId);
+      // keyStatus.publicKey comes from the SaaS without downloading private key material
+      const saasPublicKey = keyStatus.publicKey ?? null;
 
-      if (localKey && saasKeyResponse.privateKey && localKey === saasKeyResponse.privateKey) {
+      if (localPublicKey && saasPublicKey && localPublicKey === saasPublicKey) {
         this.handleSuccess(
           { loggedIn: true, user: actorId, keySynced: true },
           options,
@@ -275,9 +276,8 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
         return;
       }
 
-      // [LOGIN-D2] Keys differ → error (logged in but key conflict is an error state)
-      if (localKey && saasKeyResponse.privateKey && localKey !== saasKeyResponse.privateKey) {
-        // Login succeeded but key sync failed — report as error
+      // [LOGIN-D2] Keys differ → error with instructions, exit 1
+      if (localPublicKey && saasPublicKey && localPublicKey !== saasPublicKey) {
         if (options.json) {
           console.log(JSON.stringify({
             success: false,
@@ -285,8 +285,11 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
             data: { loggedIn: true, user: actorId, keySynced: false, keyConflict: true },
           }, null, 2));
         } else {
-          console.error('Keys differ between CLI and SaaS. Resolve manually: use `gitgov actor rotate-key` to generate a new key, or choose which to keep.');
+          console.error('Keys differ between CLI and SaaS.');
+          console.error('Use --force-local to keep local key (uploads to cloud)');
+          console.error('Use --force-cloud to keep cloud key (downloads to local)');
         }
+        process.exit(1);
         return;
       }
     }
@@ -305,6 +308,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
   // HELPERS
   // ============================================================================
 
+  // [LOGIN-H1] saasUrl must be explicitly configured — no default (IKS-A28)
   private async resolveSaasUrl(options: LoginCommandOptions): Promise<string> {
     if (options.url) return options.url;
     try {
@@ -312,9 +316,9 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       const config = await configManager.loadConfig();
       if (config?.saasUrl) return config.saasUrl;
     } catch {
-      // No config available — use default
+      // No config available
     }
-    return DEFAULT_SAAS_URL;
+    throw new Error('No saasUrl configured. Run gitgov init or set saasUrl in .gitgov/config.json');
   }
 
   private async hasLocalKey(actorId: string): Promise<boolean> {

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -8,7 +8,7 @@
  * v2 changes (Cycle 4, identity_key_sync):
  *   - REST → tRPC wire format (IKS-A27)
  *   - plaintext → ECDH encrypted key exchange (IKS-A24/A25)
- *   - repoId → repoFullName via owner/repo from git remote (IKS-A29, IKS-A32)
+ *   - repoId → { providerHost, repoPath } from git remote (IKS-A29, IKS-A33)
  *   - +--force-local / --force-cloud conflict resolution (LOGIN-F1..F4)
  *   - saasUrl required, no default (IKS-A28, LOGIN-H1)
  *   - 5 minute callback timeout (LOGIN-H2)
@@ -16,7 +16,8 @@
 
 import { Command } from 'commander';
 import { BaseCommand } from '../../base/base-command';
-import { Crypto } from '@gitgov/core';
+import { Crypto, parseRemoteUrl } from '@gitgov/core';
+import type { GitRemoteRef } from '@gitgov/core';
 import type {
   LoginCommandOptions,
   LoginDeps,
@@ -154,10 +155,10 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       // Check key sync status via tRPC
       let keyStatus: KeyStatusResponse | null = null;
       try {
-        const repoFullName = await this.resolveRepoFullName();
-        keyStatus = await this.getKeyStatus(saasUrl, token, repoFullName);
+        const repo = await this.resolveRepoIdentity();
+        keyStatus = await this.getKeyStatus(saasUrl, token, repo);
       } catch {
-        // Non-fatal — can't reach SaaS or resolve repoFullName
+        // Non-fatal — can't reach SaaS or resolve repo identity
       }
 
       const hasLocalKey = await this.hasLocalKey(actorId);
@@ -225,15 +226,15 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     token: string,
     options: LoginCommandOptions,
   ): Promise<void> {
-    // [LOGIN-H3] Resolve repoFullName from git remote (IKS-A29, IKS-A32)
-    const repoFullName = await this.resolveRepoFullName();
+    // [LOGIN-H3, IKS-A33] Resolve repo identity from git remote
+    const repo = await this.resolveRepoIdentity();
 
     const hasLocal = await this.hasLocalKey(actorId);
-    const keyStatus = await this.getKeyStatus(saasUrl, token, repoFullName);
+    const keyStatus = await this.getKeyStatus(saasUrl, token, repo);
 
     // [LOGIN-B1] CLI has key, SaaS does not → upload with ECDH
     if (hasLocal && !keyStatus.exists) {
-      await this.uploadKeyToSaas(actorId, saasUrl, token, repoFullName, keyStatus.ecdhPublicKey);
+      await this.uploadKeyToSaas(actorId, saasUrl, token, repo, keyStatus.ecdhPublicKey);
       this.handleSuccess(
         { loggedIn: true, user: actorId, keySynced: true },
         options,
@@ -244,7 +245,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
 
     // [LOGIN-C1] SaaS has key, CLI does not → download with ECDH
     if (!hasLocal && keyStatus.exists && keyStatus.hasPrivateKey) {
-      await this.downloadKeyFromSaas(actorId, saasUrl, token, repoFullName);
+      await this.downloadKeyFromSaas(actorId, saasUrl, token, repo);
       this.handleSuccess(
         { loggedIn: true, user: actorId, keySynced: true },
         options,
@@ -272,10 +273,10 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       if (localPublicKey && saasPublicKey && localPublicKey !== saasPublicKey) {
         // [LOGIN-F1] --force-local: upload local key, archive SaaS key
         if (options.forceLocal) {
-          await this.uploadKeyToSaas(actorId, saasUrl, token, repoFullName, keyStatus.ecdhPublicKey);
+          await this.uploadKeyToSaas(actorId, saasUrl, token, repo, keyStatus.ecdhPublicKey);
           console.log('Previous cloud key archived. Local key is now canonical.');
           // [LOGIN-F4] Post-sync verification
-          const postStatus = await this.getKeyStatus(saasUrl, token, repoFullName);
+          const postStatus = await this.getKeyStatus(saasUrl, token, repo);
           const newLocalPub = await keyProvider.getPublicKey(actorId);
           if (postStatus.publicKey === newLocalPub) {
             this.handleSuccess(
@@ -289,10 +290,10 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
 
         // [LOGIN-F2] --force-cloud: download SaaS key, replace local
         if (options.forceCloud) {
-          await this.downloadKeyFromSaas(actorId, saasUrl, token, repoFullName);
+          await this.downloadKeyFromSaas(actorId, saasUrl, token, repo);
           console.log('Previous local key archived. Cloud key is now canonical.');
           // [LOGIN-F4] Post-sync verification
-          const postStatus = await this.getKeyStatus(saasUrl, token, repoFullName);
+          const postStatus = await this.getKeyStatus(saasUrl, token, repo);
           const newLocalPub = await keyProvider.getPublicKey(actorId);
           if (postStatus.publicKey === newLocalPub) {
             this.handleSuccess(
@@ -335,7 +336,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
   }
 
   // ============================================================================
-  // tRPC HELPERS (v2 — ECDH encrypted, repoFullName-scoped)
+  // tRPC HELPERS (v2 — ECDH encrypted, providerHost+repoPath scoped)
   // ============================================================================
 
   // [LOGIN-H1] saasUrl must be explicitly configured — no default (IKS-A28)
@@ -351,14 +352,14 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     throw new Error('No saasUrl configured. Run gitgov init or set saasUrl in .gitgov/config.json');
   }
 
-  // [LOGIN-H3] Resolve repoFullName from git remote origin (IKS-A29, IKS-A32)
-  private async resolveRepoFullName(): Promise<string> {
+  // [LOGIN-H3, IKS-A33] Resolve providerHost + repoPath from git remote origin
+  // Uses parseRemoteUrl from @gitgov/core — shared with SaaS
+  private async resolveRepoIdentity(): Promise<GitRemoteRef> {
     try {
       const { execSync } = await import('child_process');
       const remoteUrl = execSync('git remote get-url origin', { encoding: 'utf-8' }).trim();
-      // Parse owner/repo from https://github.com/owner/repo.git or git@github.com:owner/repo.git
-      const match = remoteUrl.match(/[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
-      if (match) return `${match[1]}/${match[2]}`;
+      const ref = parseRemoteUrl(remoteUrl);
+      if (ref) return ref;
     } catch {
       // Git not available or no remote
     }
@@ -375,8 +376,8 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
   }
 
   /** Call identity.keyStatus via tRPC (IKS-A27 wire format) */
-  private async getKeyStatus(saasUrl: string, token: string, repoFullName: string): Promise<KeyStatusResponse> {
-    const input = encodeURIComponent(JSON.stringify({ json: { repoFullName } }));
+  private async getKeyStatus(saasUrl: string, token: string, repo: GitRemoteRef): Promise<KeyStatusResponse> {
+    const input = encodeURIComponent(JSON.stringify({ json: { providerHost: repo.host, repoPath: repo.path } }));
     const url = `${saasUrl}/trpc/identity.keyStatus?input=${input}`;
     const res = await this.deps.fetchSaas(url, {
       headers: { Authorization: `Bearer ${token}` },
@@ -394,7 +395,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     actorId: string,
     saasUrl: string,
     token: string,
-    repoFullName: string,
+    repo: GitRemoteRef,
     serverEcdhPublicKey: string,
   ): Promise<SyncKeyResponse> {
     const keyProvider = this.dependencyService.getKeyProvider();
@@ -417,7 +418,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ json: { repoFullName, publicKey, privateKeyEnvelope: envelope } }),
+      body: JSON.stringify({ json: { providerHost: repo.host, repoPath: repo.path, publicKey, privateKeyEnvelope: envelope } }),
     });
     if (!res.ok) throw new Error(`Failed to sync key to SaaS: ${res.status}`);
     const body = await res.json() as TrpcResponse<SyncKeyResponse>;
@@ -432,13 +433,13 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     actorId: string,
     saasUrl: string,
     token: string,
-    repoFullName: string,
+    repo: GitRemoteRef,
   ): Promise<void> {
     // [LOGIN-G2] Generate ephemeral keypair for ECDH
     const clientKp = Crypto.generateEphemeralKeypair();
 
     const input = encodeURIComponent(JSON.stringify({
-      json: { repoFullName, clientEcdhPublicKey: clientKp.publicKey },
+      json: { providerHost: repo.host, repoPath: repo.path, clientEcdhPublicKey: clientKp.publicKey },
     }));
     const url = `${saasUrl}/trpc/identity.getKey?input=${input}`;
     const res = await this.deps.fetchSaas(url, {

--- a/packages/cli/src/commands/login/login-command.types.ts
+++ b/packages/cli/src/commands/login/login-command.types.ts
@@ -57,6 +57,8 @@ export type KeyStatusRequest = {
 export type KeyStatusResponse = {
   hasKey: boolean;
   actorExists: boolean;
+  /** Public key of the actor (for case d comparison — avoids downloading private key) */
+  publicKey?: string | null;
 };
 
 // ============================================================================

--- a/packages/cli/src/commands/login/login-command.types.ts
+++ b/packages/cli/src/commands/login/login-command.types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BaseCommandOptions } from '../../interfaces/command';
+import type { EcdhEnvelope } from '@gitgov/core';
 
 // ============================================================================
 // COMMAND OPTIONS
@@ -49,13 +50,8 @@ export type SyncKeyResponse = {
 /** Response from identity.getKey tRPC query */
 export type GetKeyResponse = {
   publicKey: string | null;
-  /** ECDH-encrypted private key envelope */
-  privateKeyEnvelope: {
-    ephemeralPublicKey: string;
-    ciphertext: string;
-    iv: string;
-    authTag: string;
-  };
+  /** ECDH-encrypted private key envelope (type from @gitgov/core) */
+  privateKeyEnvelope: EcdhEnvelope;
 };
 
 /** Wrapper for tRPC response envelope */

--- a/packages/cli/src/commands/login/login-command.types.ts
+++ b/packages/cli/src/commands/login/login-command.types.ts
@@ -1,7 +1,8 @@
 /**
- * Login Command Types
+ * Login Command Types — v2 (Cycle 4, identity_key_sync)
  *
  * Spec: cli/specs/login_command.md §3.3
+ * Updated: REST → tRPC wire format, repoId → orgId, +ECDH, +--force flags
  */
 
 import type { BaseCommandOptions } from '../../interfaces/command';
@@ -11,7 +12,7 @@ import type { BaseCommandOptions } from '../../interfaces/command';
 // ============================================================================
 
 export interface LoginCommandOptions extends BaseCommandOptions {
-  /** SaaS base URL (default: config.json saasUrl or https://cloud.gitgov.dev) */
+  /** SaaS base URL override (default: .gitgov/config.json saasUrl — no hardcoded default) */
   url?: string;
   /** Show current login status */
   status?: boolean;
@@ -19,46 +20,51 @@ export interface LoginCommandOptions extends BaseCommandOptions {
   logout?: boolean;
   /** Login without syncing keys */
   noKeySync?: boolean;
+  /** On key conflict: upload local key, archive SaaS key */
+  forceLocal?: boolean;
+  /** On key conflict: download SaaS key, archive local key */
+  forceCloud?: boolean;
 }
 
 // ============================================================================
-// SAAS API TYPES (§3.3)
+// tRPC RESPONSE TYPES (§3.3 — match identity_service.router.ts)
 // ============================================================================
 
-/** POST /api/identity/sync-key — CLI sends key to SaaS */
-export type SyncKeyRequest = {
-  actorId: string;
-  repoId: string;
-  /** base64 encoded, encrypted in transit (HTTPS) */
-  privateKey: string;
-};
-
-export type SyncKeyResponse = {
-  synced: boolean;
-};
-
-/** GET /api/identity/key — CLI requests key from SaaS */
-export type GetKeyRequest = {
-  actorId: string;
-  repoId: string;
-};
-
-export type GetKeyResponse = {
-  /** null if SaaS doesn't have it */
-  privateKey: string | null;
-};
-
-/** GET /api/identity/status — Check sync status */
-export type KeyStatusRequest = {
-  actorId: string;
-  repoId: string;
-};
-
+/** Response from identity.keyStatus tRPC query */
 export type KeyStatusResponse = {
-  hasKey: boolean;
-  actorExists: boolean;
-  /** Public key of the actor (for case d comparison — avoids downloading private key) */
-  publicKey?: string | null;
+  exists: boolean;
+  hasPrivateKey: boolean;
+  publicKey: string | null;
+  /** Server's X25519 ECDH public key for upload encryption (ECIES pattern) */
+  ecdhPublicKey: string;
+};
+
+/** Response from identity.syncKey tRPC mutation */
+export type SyncKeyResponse = {
+  success: boolean;
+  actorId: string;
+  mode: 'full' | 'verify-only';
+};
+
+/** Response from identity.getKey tRPC query */
+export type GetKeyResponse = {
+  publicKey: string | null;
+  /** ECDH-encrypted private key envelope */
+  privateKeyEnvelope: {
+    ephemeralPublicKey: string;
+    ciphertext: string;
+    iv: string;
+    authTag: string;
+  };
+};
+
+/** Wrapper for tRPC response envelope */
+export type TrpcResponse<T> = {
+  result: {
+    data: {
+      json: T;
+    };
+  };
 };
 
 // ============================================================================

--- a/packages/cli/src/commands/login/login.ts
+++ b/packages/cli/src/commands/login/login.ts
@@ -11,6 +11,8 @@ export function registerLoginCommands(program: Command): void {
     .option('-s, --status', 'Show current login status')
     .option('--logout', 'Remove session token (keys are preserved)')
     .option('--no-key-sync', 'Login without syncing keys')
+    .option('--force-local', 'On key conflict: keep local key, upload to cloud')
+    .option('--force-cloud', 'On key conflict: keep cloud key, download to local')
     .option('--json', 'Output as JSON')
     .option('-v, --verbose', 'Verbose output')
     .option('-q, --quiet', 'Quiet output')

--- a/packages/core/src/adapters/backlog_adapter/backlog_adapter.integration.test.ts
+++ b/packages/core/src/adapters/backlog_adapter/backlog_adapter.integration.test.ts
@@ -203,6 +203,9 @@ describe.each(backends)('BacklogAdapter Integration Tests with %s backend', (_na
       getSyncPreferences: jest.fn().mockResolvedValue(null),
       updateSyncPreferences: jest.fn().mockResolvedValue(undefined),
       getLastSession: jest.fn().mockResolvedValue(null),
+      setCloudToken: jest.fn(),
+      setLastSession: jest.fn(),
+      clearCloudToken: jest.fn(),
     };
 
     // Create identity adapter - will be mocked by jest.doMock
@@ -256,9 +259,17 @@ describe.each(backends)('BacklogAdapter Integration Tests with %s backend', (_na
     } as unknown as ConfigManager;
 
     const mockSessionManager = {
-      updateActorState: jest.fn().mockResolvedValue(undefined),
       loadSession: jest.fn().mockResolvedValue(null),
+      detectActorFromKeyFiles: jest.fn().mockResolvedValue(null),
       getActorState: jest.fn().mockResolvedValue(null),
+      updateActorState: jest.fn().mockResolvedValue(undefined),
+      getCloudSessionToken: jest.fn().mockResolvedValue(null),
+      getSyncPreferences: jest.fn().mockResolvedValue(null),
+      updateSyncPreferences: jest.fn().mockResolvedValue(undefined),
+      getLastSession: jest.fn().mockResolvedValue(null),
+      setCloudToken: jest.fn(),
+      setLastSession: jest.fn(),
+      clearCloudToken: jest.fn(),
     } as unknown as SessionManager;
 
     backlogAdapter = new BacklogAdapter({

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
@@ -50,6 +50,9 @@ interface MockSessionManager {
   getActorState: jest.MockedFunction<(actorId: string) => Promise<any>>;
   updateActorState: jest.MockedFunction<(actorId: string, state: any) => Promise<void>>;
   getLastSession: jest.MockedFunction<() => Promise<any>>;
+  setCloudToken: jest.MockedFunction<(token: string) => Promise<void>>;
+  setLastSession: jest.MockedFunction<(actorId: string, timestamp: string) => Promise<void>>;
+  clearCloudToken: jest.MockedFunction<() => Promise<void>>;
   getSyncPreferences: jest.MockedFunction<() => Promise<any>>;
   updateSyncPreferences: jest.MockedFunction<(prefs: any) => Promise<void>>;
   getCloudSessionToken: jest.MockedFunction<() => Promise<string | null>>;
@@ -102,6 +105,9 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
       getActorState: jest.fn().mockResolvedValue(null),
       updateActorState: jest.fn().mockResolvedValue(undefined),
       getLastSession: jest.fn().mockResolvedValue(null),
+      setCloudToken: jest.fn(),
+      setLastSession: jest.fn(),
+      clearCloudToken: jest.fn(),
       getSyncPreferences: jest.fn().mockResolvedValue(null),
       updateSyncPreferences: jest.fn().mockResolvedValue(undefined),
       getCloudSessionToken: jest.fn().mockResolvedValue(null),

--- a/packages/core/src/adapters/project_adapter/project_adapter.test.ts
+++ b/packages/core/src/adapters/project_adapter/project_adapter.test.ts
@@ -131,6 +131,7 @@ describe('ProjectAdapter', () => {
       getAuditState: jest.fn(),
       updateAuditState: jest.fn(),
       getStateBranch: jest.fn(),
+      getSaasUrl: jest.fn(),
     } as jest.Mocked<IConfigManager>;
 
     // Create mock IProjectInitializer (filesystem abstraction)

--- a/packages/core/src/config_manager/config_manager.test.ts
+++ b/packages/core/src/config_manager/config_manager.test.ts
@@ -13,6 +13,7 @@
  * - F: getAuditState (§4.6)
  * - G: updateAuditState (§4.7)
  * - H: getStateBranch (§4.8)
+ * - I: getSaasUrl (§4.9)
  */
 
 import { ConfigManager } from './index';
@@ -461,6 +462,45 @@ describe('ConfigManager', () => {
       const result = await configManager.getStateBranch();
 
       expect(result).toBe('gitgov-state');
+    });
+  });
+
+  // ==================== §4.9 getSaasUrl (EARS-I) ====================
+
+  describe('4.9. getSaasUrl (EARS-I1 to I2)', () => {
+    it('[EARS-I1] WHEN getSaasUrl is invoked with saasUrl defined, THE SYSTEM SHALL return the SaaS URL', async () => {
+      store.setConfig({
+        protocolVersion: '1.0',
+        projectId: 'test',
+        projectName: 'Test',
+        rootCycle: '001-cycle-init',
+        saasUrl: 'https://cloud.gitgov.dev',
+      });
+
+      const result = await configManager.getSaasUrl();
+
+      expect(result).toBe('https://cloud.gitgov.dev');
+    });
+
+    it('[EARS-I2] WHEN getSaasUrl is invoked without saasUrl in config, THE SYSTEM SHALL return null', async () => {
+      store.setConfig({
+        protocolVersion: '1.0',
+        projectId: 'test',
+        projectName: 'Test',
+        rootCycle: '001-cycle-init',
+      });
+
+      const result = await configManager.getSaasUrl();
+
+      expect(result).toBeNull();
+    });
+
+    it('[EARS-I2] WHEN getSaasUrl is invoked with no config, THE SYSTEM SHALL return null', async () => {
+      // No config set
+
+      const result = await configManager.getSaasUrl();
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/core/src/config_manager/config_manager.ts
+++ b/packages/core/src/config_manager/config_manager.ts
@@ -154,4 +154,13 @@ export class ConfigManager implements IConfigManager {
     const config = await this.loadConfig();
     return config?.state?.branch || 'gitgov-state';
   }
+
+  /**
+   * [EARS-I1, EARS-I2] Get SaaS URL from configuration.
+   * Returns null if not configured — no default (IKS-A28).
+   */
+  async getSaasUrl(): Promise<string | null> {
+    const config = await this.loadConfig();
+    return config?.saasUrl ?? null;
+  }
 }

--- a/packages/core/src/config_manager/config_manager.types.ts
+++ b/packages/core/src/config_manager/config_manager.types.ts
@@ -135,4 +135,10 @@ export interface IConfigManager {
    * Get state branch name from configuration
    */
   getStateBranch(): Promise<string>;
+
+  /**
+   * [EARS-I1, EARS-I2] Get SaaS URL from configuration.
+   * Returns null if not configured — caller decides whether to fail (IKS-A28).
+   */
+  getSaasUrl(): Promise<string | null>;
 }

--- a/packages/core/src/config_manager/config_manager.types.ts
+++ b/packages/core/src/config_manager/config_manager.types.ts
@@ -11,7 +11,7 @@ export type GitGovConfig = {
   projectId: string;
   projectName: string;
   rootCycle: string;
-  /** SaaS URL for cloud features (gitgov login, sync, dashboard). Default: "https://cloud.gitgov.dev" */
+  /** SaaS URL for cloud features (gitgov login, sync, dashboard). No default — must be set explicitly by gitgov init or manually (IKS-A28). */
   saasUrl?: string;
   state?: {
     branch?: string;

--- a/packages/core/src/crypto/ecdh_transport.test.ts
+++ b/packages/core/src/crypto/ecdh_transport.test.ts
@@ -1,0 +1,235 @@
+import { generateEphemeralKeypair, ecdhEncrypt, ecdhDecrypt, deriveServerEcdhKeypair } from './ecdh_transport';
+import type { EcdhEnvelope, EcdhKeypair } from './ecdh_transport.types';
+import { randomBytes } from 'crypto';
+
+describe('4.1.1. ECDH X25519 Transport (EARS-10 to EARS-17)', () => {
+  describe('generateEphemeralKeypair', () => {
+    it('[EARS-10] should generate a valid X25519 keypair with 32-byte raw keys', () => {
+      const keypair = generateEphemeralKeypair();
+      expect(Buffer.from(keypair.publicKey, 'base64')).toHaveLength(32);
+      expect(Buffer.from(keypair.privateKey, 'base64')).toHaveLength(32);
+    });
+
+    it('[EARS-11] should generate unique keypairs per invocation (forward secrecy)', () => {
+      const kp1 = generateEphemeralKeypair();
+      const kp2 = generateEphemeralKeypair();
+      expect(kp1.publicKey).not.toBe(kp2.publicKey);
+      expect(kp1.privateKey).not.toBe(kp2.privateKey);
+    });
+  });
+
+  describe('ecdhEncrypt + ecdhDecrypt round-trip', () => {
+    let clientKeypair: EcdhKeypair;
+    let serverKeypair: EcdhKeypair;
+
+    beforeEach(() => {
+      clientKeypair = generateEphemeralKeypair();
+      serverKeypair = generateEphemeralKeypair();
+    });
+
+    it('[EARS-12] should encrypt and decrypt a payload via ECDH key exchange', async () => {
+      const plaintext = Buffer.from('ed25519-private-key-material-here');
+
+      // Server encrypts for client
+      const envelope = await ecdhEncrypt(plaintext, serverKeypair, clientKeypair.publicKey);
+
+      // Client decrypts
+      const decrypted = await ecdhDecrypt(envelope, clientKeypair.privateKey);
+
+      expect(decrypted).toEqual(plaintext);
+    });
+
+    it('[EARS-13] should produce ciphertext that differs from plaintext', async () => {
+      const plaintext = Buffer.from('sensitive-key-material');
+
+      const envelope = await ecdhEncrypt(plaintext, serverKeypair, clientKeypair.publicKey);
+
+      // Ciphertext is NOT the plaintext
+      const ciphertextBuf = Buffer.from(envelope.ciphertext, 'base64');
+      expect(ciphertextBuf).not.toEqual(plaintext);
+    });
+
+    it('[EARS-17] should work for both directions (server→client and client→server)', async () => {
+      const serverPayload = Buffer.from('server-to-client-key');
+      const clientPayload = Buffer.from('client-to-server-key');
+
+      // Server → Client
+      const serverEnvelope = await ecdhEncrypt(serverPayload, serverKeypair, clientKeypair.publicKey);
+      const clientDecrypted = await ecdhDecrypt(serverEnvelope, clientKeypair.privateKey);
+      expect(clientDecrypted).toEqual(serverPayload);
+
+      // Client → Server
+      const clientEnvelope = await ecdhEncrypt(clientPayload, clientKeypair, serverKeypair.publicKey);
+      const serverDecrypted = await ecdhDecrypt(clientEnvelope, serverKeypair.privateKey);
+      expect(serverDecrypted).toEqual(clientPayload);
+    });
+
+    it('should handle empty payload', async () => {
+      const plaintext = Buffer.alloc(0);
+
+      const envelope = await ecdhEncrypt(plaintext, serverKeypair, clientKeypair.publicKey);
+      const decrypted = await ecdhDecrypt(envelope, clientKeypair.privateKey);
+
+      expect(decrypted).toEqual(plaintext);
+    });
+
+    it('should handle large payload (4KB private key PEM)', async () => {
+      // Simulate a large PKCS8 PEM private key
+      const plaintext = Buffer.alloc(4096, 0x42);
+
+      const envelope = await ecdhEncrypt(plaintext, serverKeypair, clientKeypair.publicKey);
+      const decrypted = await ecdhDecrypt(envelope, clientKeypair.privateKey);
+
+      expect(decrypted).toEqual(plaintext);
+    });
+
+    it('should produce different ciphertext for same plaintext with different keypairs', async () => {
+      const plaintext = Buffer.from('same-key-material');
+
+      const envelope1 = await ecdhEncrypt(plaintext, serverKeypair, clientKeypair.publicKey);
+
+      // New keypairs → different shared secret → different ciphertext
+      const newServerKeypair = generateEphemeralKeypair();
+      const newClientKeypair = generateEphemeralKeypair();
+      const envelope2 = await ecdhEncrypt(plaintext, newServerKeypair, newClientKeypair.publicKey);
+
+      expect(envelope1.ciphertext).not.toBe(envelope2.ciphertext);
+    });
+
+    it('should produce different IV per encryption (nonce uniqueness)', async () => {
+      const plaintext = Buffer.from('same-payload');
+
+      const envelope1 = await ecdhEncrypt(plaintext, serverKeypair, clientKeypair.publicKey);
+      const envelope2 = await ecdhEncrypt(plaintext, serverKeypair, clientKeypair.publicKey);
+
+      expect(envelope1.iv).not.toBe(envelope2.iv);
+    });
+  });
+
+  describe('ecdhDecrypt failure cases', () => {
+    it('[EARS-14] should throw when decrypting with wrong private key', async () => {
+      const clientKeypair = generateEphemeralKeypair();
+      const serverKeypair = generateEphemeralKeypair();
+      const wrongKeypair = generateEphemeralKeypair();
+
+      const envelope = await ecdhEncrypt(
+        Buffer.from('secret'),
+        serverKeypair,
+        clientKeypair.publicKey,
+      );
+
+      // Decrypt with wrong private key → different shared secret → AES auth fails
+      await expect(ecdhDecrypt(envelope, wrongKeypair.privateKey)).rejects.toThrow();
+    });
+
+    it('[EARS-15] should throw when ciphertext is tampered', async () => {
+      const clientKeypair = generateEphemeralKeypair();
+      const serverKeypair = generateEphemeralKeypair();
+
+      const envelope = await ecdhEncrypt(
+        Buffer.from('secret'),
+        serverKeypair,
+        clientKeypair.publicKey,
+      );
+
+      // Tamper with ciphertext
+      const tampered: EcdhEnvelope = {
+        ...envelope,
+        ciphertext: Buffer.from('tampered-data').toString('base64'),
+      };
+
+      await expect(ecdhDecrypt(tampered, clientKeypair.privateKey)).rejects.toThrow();
+    });
+
+    it('[EARS-15] should throw when authTag is tampered', async () => {
+      const clientKeypair = generateEphemeralKeypair();
+      const serverKeypair = generateEphemeralKeypair();
+
+      const envelope = await ecdhEncrypt(
+        Buffer.from('secret'),
+        serverKeypair,
+        clientKeypair.publicKey,
+      );
+
+      // Tamper with authTag
+      const tampered: EcdhEnvelope = {
+        ...envelope,
+        authTag: Buffer.alloc(16, 0xff).toString('base64'),
+      };
+
+      await expect(ecdhDecrypt(tampered, clientKeypair.privateKey)).rejects.toThrow();
+    });
+  });
+
+  describe('deriveServerEcdhKeypair (upload direction)', () => {
+    const masterKey = randomBytes(32).toString('base64');
+
+    it('should derive a valid 32-byte X25519 keypair from MASTER_KEY + orgId', async () => {
+      const kp = await deriveServerEcdhKeypair(masterKey, 'org-123');
+      expect(Buffer.from(kp.publicKey, 'base64')).toHaveLength(32);
+      expect(Buffer.from(kp.privateKey, 'base64')).toHaveLength(32);
+    });
+
+    it('should be deterministic (same inputs → same output)', async () => {
+      const kp1 = await deriveServerEcdhKeypair(masterKey, 'org-123');
+      const kp2 = await deriveServerEcdhKeypair(masterKey, 'org-123');
+      expect(kp1.publicKey).toBe(kp2.publicKey);
+      expect(kp1.privateKey).toBe(kp2.privateKey);
+    });
+
+    it('should derive different keys for different orgs', async () => {
+      const kp1 = await deriveServerEcdhKeypair(masterKey, 'org-1');
+      const kp2 = await deriveServerEcdhKeypair(masterKey, 'org-2');
+      expect(kp1.publicKey).not.toBe(kp2.publicKey);
+    });
+
+    it('should work with ecdhEncrypt/ecdhDecrypt for upload (ECIES pattern)', async () => {
+      const serverKp = await deriveServerEcdhKeypair(masterKey, 'org-upload');
+      const clientKp = generateEphemeralKeypair();
+
+      // Client encrypts FOR the server using server's derived public key
+      const plaintext = Buffer.from('private-key-to-upload');
+      const envelope = await ecdhEncrypt(plaintext, clientKp, serverKp.publicKey);
+
+      // Server decrypts with its derived private key
+      const decrypted = await ecdhDecrypt(envelope, serverKp.privateKey);
+      expect(decrypted).toEqual(plaintext);
+    });
+  });
+
+  describe('EcdhEnvelope wire format', () => {
+    it('[EARS-16] should produce envelope with all required fields as valid base64', async () => {
+      const clientKeypair = generateEphemeralKeypair();
+      const serverKeypair = generateEphemeralKeypair();
+
+      const envelope = await ecdhEncrypt(
+        Buffer.from('payload'),
+        serverKeypair,
+        clientKeypair.publicKey,
+      );
+
+      // All fields present
+      expect(envelope).toMatchObject({
+        ephemeralPublicKey: expect.any(String),
+        ciphertext: expect.any(String),
+        iv: expect.any(String),
+        authTag: expect.any(String),
+      });
+
+      // All valid base64
+      expect(() => Buffer.from(envelope.ephemeralPublicKey, 'base64')).not.toThrow();
+      expect(() => Buffer.from(envelope.ciphertext, 'base64')).not.toThrow();
+      expect(() => Buffer.from(envelope.iv, 'base64')).not.toThrow();
+      expect(() => Buffer.from(envelope.authTag, 'base64')).not.toThrow();
+
+      // IV is 12 bytes (AES-GCM standard)
+      expect(Buffer.from(envelope.iv, 'base64')).toHaveLength(12);
+
+      // AuthTag is 16 bytes (AES-GCM standard)
+      expect(Buffer.from(envelope.authTag, 'base64')).toHaveLength(16);
+
+      // Ephemeral public key is 32 bytes (X25519)
+      expect(Buffer.from(envelope.ephemeralPublicKey, 'base64')).toHaveLength(32);
+    });
+  });
+});

--- a/packages/core/src/crypto/ecdh_transport.ts
+++ b/packages/core/src/crypto/ecdh_transport.ts
@@ -1,0 +1,228 @@
+/**
+ * ECDH X25519 Ephemeral Transport — key exchange + AES-256-GCM encryption.
+ *
+ * Provides application-layer encryption for private key material transfer
+ * between CLI and SaaS, with forward secrecy via ephemeral keypairs.
+ *
+ * Both client and server sides are implemented here so that CLI and SaaS
+ * import from the same source — coherence by construction.
+ *
+ * Protocol: IKS-A13, EARS-10..17 (crypto_module.md §4.1.1)
+ *
+ * Security properties:
+ *   - Forward secrecy: ephemeral keypairs are per-request
+ *   - Defense-in-depth: encrypts above TLS (protects against TLS termination proxies)
+ *   - Authenticated encryption: AES-256-GCM provides confidentiality + integrity
+ *   - Key derivation: HKDF-SHA256 with fixed info string for domain separation
+ */
+import {
+  generateKeyPairSync,
+  diffieHellman,
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  createPrivateKey,
+  createPublicKey,
+} from 'crypto';
+import { deriveHkdfKey } from './signatures';
+import type { EcdhKeypair, EcdhEnvelope } from './ecdh_transport.types';
+
+/** HKDF info string for ECDH shared secret → AES key derivation */
+const ECDH_HKDF_INFO = 'gitgov-ecdh-transport-v1';
+
+/** HKDF info string for server-side static ECDH key derivation from MASTER_KEY */
+const SERVER_ECDH_KEY_INFO = 'gitgov-ecdh-server-key-v1';
+
+/**
+ * Generates an ephemeral X25519 keypair for one side of the exchange.
+ *
+ * The keypair MUST be discarded after the exchange completes (forward secrecy).
+ * Do NOT persist or reuse these keys across requests.
+ *
+ * [EARS-10] Returns valid X25519 keypair (32 bytes raw)
+ * [EARS-11] Unique per invocation (forward secrecy)
+ */
+export function generateEphemeralKeypair(): EcdhKeypair {
+  const { publicKey, privateKey } = generateKeyPairSync('x25519', {
+    publicKeyEncoding: { type: 'spki', format: 'der' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'der' },
+  });
+
+  // X25519 SPKI DER: 12-byte header + 32-byte raw key
+  const rawPublicKey = publicKey.subarray(-32);
+  // X25519 PKCS8 DER: 16-byte header + 32-byte raw key
+  const rawPrivateKey = privateKey.subarray(-32);
+
+  return {
+    publicKey: rawPublicKey.toString('base64'),
+    privateKey: rawPrivateKey.toString('base64'),
+  };
+}
+
+/**
+ * X25519 SPKI DER prefix (RFC 7748).
+ * Structure: SEQUENCE { SEQUENCE { OID 1.3.101.110 }, BIT STRING { raw key } }
+ */
+const X25519_SPKI_HEADER = Buffer.from([
+  0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65,
+  0x6e, 0x03, 0x21, 0x00,
+]);
+
+/**
+ * X25519 PKCS8 DER prefix (RFC 8410).
+ * Structure: SEQUENCE { version, SEQUENCE { OID }, OCTET STRING { OCTET STRING { raw key } } }
+ */
+const X25519_PKCS8_HEADER = Buffer.from([
+  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06,
+  0x03, 0x2b, 0x65, 0x6e, 0x04, 0x22, 0x04, 0x20,
+]);
+
+/**
+ * Derives the shared AES-256 key from the X25519 Diffie-Hellman exchange.
+ *
+ * Both sides call this with:
+ *   - Their own private key
+ *   - The other side's public key
+ * And get the same shared secret, which is then expanded via HKDF-SHA256
+ * to produce the AES-256 encryption key.
+ *
+ * @param myPrivateKeyBase64 - Our ephemeral X25519 private key (raw, base64)
+ * @param theirPublicKeyBase64 - Their ephemeral X25519 public key (raw, base64)
+ * @returns 32-byte AES-256 key derived via HKDF
+ */
+async function deriveSharedKey(
+  myPrivateKeyBase64: string,
+  theirPublicKeyBase64: string,
+): Promise<Buffer> {
+  const myPrivateKeyDer = Buffer.concat([
+    X25519_PKCS8_HEADER,
+    Buffer.from(myPrivateKeyBase64, 'base64'),
+  ]);
+  const theirPublicKeyDer = Buffer.concat([
+    X25519_SPKI_HEADER,
+    Buffer.from(theirPublicKeyBase64, 'base64'),
+  ]);
+
+  const myKey = createPrivateKey({ key: myPrivateKeyDer, type: 'pkcs8', format: 'der' });
+  const theirKey = createPublicKey({ key: theirPublicKeyDer, type: 'spki', format: 'der' });
+
+  const sharedSecret = diffieHellman({ privateKey: myKey, publicKey: theirKey });
+
+  // HKDF expands the raw DH output into a proper AES-256 key
+  return deriveHkdfKey(sharedSecret.toString('base64'), ECDH_HKDF_INFO, 32);
+}
+
+/**
+ * Encrypts data for transport using ECDH key exchange.
+ *
+ * Server-side: encrypts payload for the client.
+ * Client-side: encrypts payload for the server (sync-key with private key).
+ *
+ * [EARS-12] Round-trip encrypt→decrypt returns original plaintext
+ * [EARS-13] Ciphertext differs from plaintext (raw key never in envelope)
+ *
+ * @param plaintext - Data to encrypt (e.g., private key bytes)
+ * @param myKeypair - Our ephemeral X25519 keypair (generated for this request)
+ * @param theirPublicKeyBase64 - The other side's ephemeral public key
+ * @returns EcdhEnvelope containing our public key + ciphertext + AES params
+ */
+export async function ecdhEncrypt(
+  plaintext: Buffer,
+  myKeypair: EcdhKeypair,
+  theirPublicKeyBase64: string,
+): Promise<EcdhEnvelope> {
+  const aesKey = await deriveSharedKey(myKeypair.privateKey, theirPublicKeyBase64);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', aesKey, iv);
+
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    ephemeralPublicKey: myKeypair.publicKey,
+    ciphertext: encrypted.toString('base64'),
+    iv: iv.toString('base64'),
+    authTag: authTag.toString('base64'),
+  };
+}
+
+/**
+ * Decrypts an ECDH envelope received from the other side.
+ *
+ * Client-side: decrypts payload from the server (key download).
+ * Server-side: decrypts payload from the client (sync-key with private key).
+ *
+ * @param envelope - EcdhEnvelope received from the other side
+ * @param myPrivateKeyBase64 - Our ephemeral X25519 private key (raw, base64)
+ * @returns Decrypted plaintext as Buffer
+ * @throws Error if decryption fails (tampered data, wrong key)
+ */
+export async function ecdhDecrypt(
+  envelope: EcdhEnvelope,
+  myPrivateKeyBase64: string,
+): Promise<Buffer> {
+  const aesKey = await deriveSharedKey(myPrivateKeyBase64, envelope.ephemeralPublicKey);
+
+  const decipher = createDecipheriv(
+    'aes-256-gcm',
+    aesKey,
+    Buffer.from(envelope.iv, 'base64'),
+  );
+  decipher.setAuthTag(Buffer.from(envelope.authTag, 'base64'));
+
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(envelope.ciphertext, 'base64')),
+    decipher.final(),
+  ]);
+
+  return decrypted;
+}
+
+/**
+ * Derives a deterministic X25519 keypair for server-side ECDH from MASTER_KEY.
+ *
+ * Used for the upload direction (client→server, e.g. sync-key): the client
+ * needs the server's public key BEFORE encrypting, so the server must have
+ * a stable (but rotatable) public key. The key is derived per-org via HKDF,
+ * so compromising one org's ECDH key doesn't affect others.
+ *
+ * The client fetches the server's public key from the key-status endpoint,
+ * then uses it with ecdhEncrypt (ECIES pattern):
+ *   1. Client generates ephemeral keypair
+ *   2. Client encrypts: ecdhEncrypt(data, clientKp, serverDerivedPub)
+ *   3. Server decrypts: ecdhDecrypt(envelope, serverDerivedPriv)
+ *
+ * For the download direction (server→client), use generateEphemeralKeypair()
+ * instead — that provides full forward secrecy.
+ *
+ * Rotation: when MASTER_KEY rotates, the derived key changes. The client
+ * re-fetches via key-status. Old ciphertexts cannot be decrypted with the
+ * new key (this is acceptable — ECDH transport is per-request, not storage).
+ *
+ * @param masterKeyBase64 - Base64-encoded MASTER_KEY (32+ bytes)
+ * @param orgId - Organization ID for domain separation
+ * @returns Deterministic X25519 keypair scoped to the org
+ */
+export async function deriveServerEcdhKeypair(
+  masterKeyBase64: string,
+  orgId: string,
+): Promise<EcdhKeypair> {
+  // Derive 32 bytes of key material via HKDF
+  const seed = await deriveHkdfKey(
+    masterKeyBase64,
+    `${SERVER_ECDH_KEY_INFO}:${orgId}`,
+    32,
+  );
+
+  // X25519 accepts any 32-byte scalar as a private key (clamping is automatic).
+  // Use the HKDF output directly as the raw private key.
+  const privateKeyBase64 = seed.toString('base64');
+
+  // Derive the public key: wrap in PKCS8 DER → createPrivateKey → createPublicKey
+  const privateKeyDer = Buffer.concat([X25519_PKCS8_HEADER, seed]);
+  const privateKeyObj = createPrivateKey({ key: privateKeyDer, type: 'pkcs8', format: 'der' });
+  const publicKeyDer = createPublicKey(privateKeyObj).export({ type: 'spki', format: 'der' }) as Buffer;
+  const publicKeyBase64 = publicKeyDer.subarray(-32).toString('base64');
+
+  return { publicKey: publicKeyBase64, privateKey: privateKeyBase64 };
+}

--- a/packages/core/src/crypto/ecdh_transport.types.ts
+++ b/packages/core/src/crypto/ecdh_transport.types.ts
@@ -1,0 +1,54 @@
+/**
+ * ECDH X25519 Ephemeral Transport Layer types.
+ *
+ * Wire format for key material transfer between CLI and SaaS.
+ * Both sides import from this file — coherence by construction.
+ *
+ * Protocol (IKS-A13, IKS-G6..G10):
+ *   1. Client generates X25519 ephemeral keypair
+ *   2. Client sends ephemeral public key to server
+ *   3. Server generates its own X25519 ephemeral keypair
+ *   4. Server derives shared secret (X25519 DH + HKDF)
+ *   5. Server encrypts payload with AES-256-GCM using derived key
+ *   6. Server sends EcdhEnvelope (server pubkey + ciphertext + iv + authTag)
+ *   7. Client derives same shared secret + decrypts
+ *   8. Both discard ephemeral keypairs (forward secrecy)
+ */
+
+/**
+ * Ephemeral X25519 keypair for one side of the exchange.
+ * Private key MUST be discarded after deriving the shared secret.
+ */
+export type EcdhKeypair = {
+  /** Raw X25519 public key, base64-encoded (32 bytes -> 44 chars) */
+  publicKey: string;
+  /** Raw X25519 private key, base64-encoded (32 bytes -> 44 chars) */
+  privateKey: string;
+};
+
+/**
+ * Wire format envelope sent from server to client (or client to server)
+ * containing ECDH-encrypted payload.
+ *
+ * The recipient combines their ephemeral private key with the sender's
+ * ephemeral public key to derive the shared secret and decrypt.
+ */
+export type EcdhEnvelope = {
+  /** Sender's ephemeral X25519 public key, base64-encoded */
+  ephemeralPublicKey: string;
+  /** AES-256-GCM encrypted payload, base64-encoded */
+  ciphertext: string;
+  /** AES-256-GCM initialization vector, base64-encoded (12 bytes) */
+  iv: string;
+  /** AES-256-GCM authentication tag, base64-encoded (16 bytes) */
+  authTag: string;
+};
+
+/**
+ * Request from client to server that includes the client's ephemeral
+ * public key for the key exchange. Used as a header or body field.
+ */
+export type EcdhClientHello = {
+  /** Client's ephemeral X25519 public key, base64-encoded */
+  clientPublicKey: string;
+};

--- a/packages/core/src/crypto/index.ts
+++ b/packages/core/src/crypto/index.ts
@@ -1,2 +1,4 @@
 export * from "./checksum";
 export * from "./signatures";
+export * from "./ecdh_transport";
+export * from "./ecdh_transport.types";

--- a/packages/core/src/crypto/signatures.ts
+++ b/packages/core/src/crypto/signatures.ts
@@ -58,6 +58,37 @@ export function derivePublicKey(privateKeyBase64: string): string {
 }
 
 /**
+ * SPKI DER prefix for raw Ed25519 public key (RFC 8410): 12-byte algorithm
+ * identifier followed by the 32-byte raw public key.
+ *
+ * Exposed so consumers can construct an SPKI-formatted key for `node:crypto.verify()`
+ * without redefining the prefix bytes (which is a documented standard, not a magic
+ * number — see RFC 8410 §3).
+ */
+export const SPKI_ED25519_HEADER: Buffer = Buffer.from([
+  0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65,
+  0x70, 0x03, 0x21, 0x00,
+]);
+
+/**
+ * Reconstructs an SPKI DER-encoded public key from a raw 32-byte Ed25519 key.
+ *
+ * Inverse of `derivePublicKey`: takes the base64-encoded raw key (as stored
+ * in `ActorRecord.publicKey` and `ActorKey.publicKey`) and returns the SPKI
+ * DER buffer that `node:crypto.verify()` accepts as `{ key, type: 'spki', format: 'der' }`.
+ *
+ * Used by:
+ *   - `verifySignatures()` internally (Ed25519 signature verification path)
+ *   - e2e tests verifying signatures produced by `PrismaKeyProvider.sign()`
+ *
+ * @param publicKeyBase64 Base64-encoded raw Ed25519 public key (32 bytes -> 44 chars)
+ * @returns 44-byte SPKI DER buffer (12-byte prefix + 32-byte raw key)
+ */
+export function ed25519PublicKeyToSpki(publicKeyBase64: string): Buffer {
+  return Buffer.concat([SPKI_ED25519_HEADER, Buffer.from(publicKeyBase64, 'base64')]);
+}
+
+/**
  * Derives a fixed-length symmetric key from a master key using HKDF-SHA256.
  *
  * Used by the 3-level key hierarchy in PrismaKeyProvider (Cycle 2 of

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -112,7 +112,10 @@ export type {
   CommitInfo,
   ChangedFile,
   CommitAuthor,
+  GitRemoteRef,
 } from './types';
+
+export { parseRemoteUrl } from './types';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // ERRORS

--- a/packages/core/src/git/parse_remote_url.test.ts
+++ b/packages/core/src/git/parse_remote_url.test.ts
@@ -1,0 +1,70 @@
+import { parseRemoteUrl } from './types';
+
+describe('parseRemoteUrl (GM9-GM11)', () => {
+  describe('[GM9] HTTPS URLs', () => {
+    it('should parse standard GitHub HTTPS URL', () => {
+      const ref = parseRemoteUrl('https://github.com/gitgovernance/monorepo.git');
+      expect(ref).toEqual({ host: 'github.com', path: 'gitgovernance/monorepo' });
+    });
+
+    it('should parse HTTPS URL without .git suffix', () => {
+      const ref = parseRemoteUrl('https://github.com/owner/repo');
+      expect(ref).toEqual({ host: 'github.com', path: 'owner/repo' });
+    });
+
+    it('should parse GitLab nested namespace HTTPS URL', () => {
+      const ref = parseRemoteUrl('https://gitlab.mycompany.com/group/subgroup/project.git');
+      expect(ref).toEqual({ host: 'gitlab.mycompany.com', path: 'group/subgroup/project' });
+    });
+
+    it('should parse self-hosted GitHub Enterprise HTTPS URL', () => {
+      const ref = parseRemoteUrl('https://github.corp.com/team/service.git');
+      expect(ref).toEqual({ host: 'github.corp.com', path: 'team/service' });
+    });
+
+    it('should parse Bitbucket HTTPS URL', () => {
+      const ref = parseRemoteUrl('https://bitbucket.org/workspace/repo.git');
+      expect(ref).toEqual({ host: 'bitbucket.org', path: 'workspace/repo' });
+    });
+  });
+
+  describe('[GM10] SSH URLs', () => {
+    it('should parse standard GitHub SSH URL', () => {
+      const ref = parseRemoteUrl('git@github.com:gitgovernance/monorepo.git');
+      expect(ref).toEqual({ host: 'github.com', path: 'gitgovernance/monorepo' });
+    });
+
+    it('should parse SSH URL without .git suffix', () => {
+      const ref = parseRemoteUrl('git@github.com:owner/repo');
+      expect(ref).toEqual({ host: 'github.com', path: 'owner/repo' });
+    });
+
+    it('should parse GitLab SSH URL with nested namespace', () => {
+      const ref = parseRemoteUrl('git@gitlab.mycompany.com:group/subgroup/project.git');
+      expect(ref).toEqual({ host: 'gitlab.mycompany.com', path: 'group/subgroup/project' });
+    });
+
+    it('should parse self-hosted SSH URL', () => {
+      const ref = parseRemoteUrl('git@gitea.internal.net:user/project.git');
+      expect(ref).toEqual({ host: 'gitea.internal.net', path: 'user/project' });
+    });
+  });
+
+  describe('[GM11] Unparseable URLs', () => {
+    it('should return null for empty string', () => {
+      expect(parseRemoteUrl('')).toBeNull();
+    });
+
+    it('should return null for local path', () => {
+      expect(parseRemoteUrl('/path/to/repo')).toBeNull();
+    });
+
+    it('should return null for relative path', () => {
+      expect(parseRemoteUrl('../other-repo')).toBeNull();
+    });
+
+    it('should return null for random string', () => {
+      expect(parseRemoteUrl('not-a-url')).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/git/parse_remote_url.test.ts
+++ b/packages/core/src/git/parse_remote_url.test.ts
@@ -4,49 +4,49 @@ describe('parseRemoteUrl (GM9-GM11)', () => {
   describe('[GM9] HTTPS URLs', () => {
     it('should parse standard GitHub HTTPS URL', () => {
       const ref = parseRemoteUrl('https://github.com/gitgovernance/monorepo.git');
-      expect(ref).toEqual({ host: 'github.com', path: 'gitgovernance/monorepo' });
+      expect(ref).toEqual({ providerHost: 'github.com', repoPath: 'gitgovernance/monorepo' });
     });
 
     it('should parse HTTPS URL without .git suffix', () => {
       const ref = parseRemoteUrl('https://github.com/owner/repo');
-      expect(ref).toEqual({ host: 'github.com', path: 'owner/repo' });
+      expect(ref).toEqual({ providerHost: 'github.com', repoPath: 'owner/repo' });
     });
 
     it('should parse GitLab nested namespace HTTPS URL', () => {
       const ref = parseRemoteUrl('https://gitlab.mycompany.com/group/subgroup/project.git');
-      expect(ref).toEqual({ host: 'gitlab.mycompany.com', path: 'group/subgroup/project' });
+      expect(ref).toEqual({ providerHost: 'gitlab.mycompany.com', repoPath: 'group/subgroup/project' });
     });
 
     it('should parse self-hosted GitHub Enterprise HTTPS URL', () => {
       const ref = parseRemoteUrl('https://github.corp.com/team/service.git');
-      expect(ref).toEqual({ host: 'github.corp.com', path: 'team/service' });
+      expect(ref).toEqual({ providerHost: 'github.corp.com', repoPath: 'team/service' });
     });
 
     it('should parse Bitbucket HTTPS URL', () => {
       const ref = parseRemoteUrl('https://bitbucket.org/workspace/repo.git');
-      expect(ref).toEqual({ host: 'bitbucket.org', path: 'workspace/repo' });
+      expect(ref).toEqual({ providerHost: 'bitbucket.org', repoPath: 'workspace/repo' });
     });
   });
 
   describe('[GM10] SSH URLs', () => {
     it('should parse standard GitHub SSH URL', () => {
       const ref = parseRemoteUrl('git@github.com:gitgovernance/monorepo.git');
-      expect(ref).toEqual({ host: 'github.com', path: 'gitgovernance/monorepo' });
+      expect(ref).toEqual({ providerHost: 'github.com', repoPath: 'gitgovernance/monorepo' });
     });
 
     it('should parse SSH URL without .git suffix', () => {
       const ref = parseRemoteUrl('git@github.com:owner/repo');
-      expect(ref).toEqual({ host: 'github.com', path: 'owner/repo' });
+      expect(ref).toEqual({ providerHost: 'github.com', repoPath: 'owner/repo' });
     });
 
     it('should parse GitLab SSH URL with nested namespace', () => {
       const ref = parseRemoteUrl('git@gitlab.mycompany.com:group/subgroup/project.git');
-      expect(ref).toEqual({ host: 'gitlab.mycompany.com', path: 'group/subgroup/project' });
+      expect(ref).toEqual({ providerHost: 'gitlab.mycompany.com', repoPath: 'group/subgroup/project' });
     });
 
     it('should parse self-hosted SSH URL', () => {
       const ref = parseRemoteUrl('git@gitea.internal.net:user/project.git');
-      expect(ref).toEqual({ host: 'gitea.internal.net', path: 'user/project' });
+      expect(ref).toEqual({ providerHost: 'gitea.internal.net', repoPath: 'user/project' });
     });
   });
 

--- a/packages/core/src/git/types.ts
+++ b/packages/core/src/git/types.ts
@@ -98,28 +98,30 @@ export type CommitAuthor = {
  * Parsed reference to a git remote URL.
  *
  * Represents the decomposed identity of a git remote:
- *   host: the server (github.com, gitlab.mycompany.com, gitea.internal.net)
- *   path: the repo path on that server (owner/repo, group/subgroup/project)
+ *   providerHost: the server (github.com, gitlab.mycompany.com, gitea.internal.net)
+ *   repoPath: the repo path on that server (owner/repo, group/subgroup/project)
  *
- * Used by CLI (parse from git remote URL) and SaaS (resolve to Repository).
- * Created via parseRemoteUrl(). Shared between CLI and SaaS via @gitgov/core.
+ * Single source of truth shape — CLI parses from git remote, SaaS resolves to Repository.
+ * Both consumers import this type from @gitgov/core/git and use it directly without
+ * inline reconstruction. SaaS defines its zod schema co-located with the type guard
+ * `z.ZodType<GitRemoteRef>` so the type checker enforces shape coherence.
  *
  * IKS-A33, Cycle 4 identity_key_sync
  */
 export type GitRemoteRef = {
   /** Host of the git server (e.g. "github.com", "gitlab.mycompany.com") */
-  host: string;
+  providerHost: string;
   /** Path of the repository on the server (e.g. "owner/repo", "group/subgroup/project") */
-  path: string;
+  repoPath: string;
 };
 
 /**
- * [GM9, GM10, GM11] Parse a git remote URL into { host, path }.
+ * [GM9, GM10, GM11] Parse a git remote URL into a GitRemoteRef.
  *
  * Supports:
- *   HTTPS: https://github.com/owner/repo.git → { host: "github.com", path: "owner/repo" }
- *   SSH:   git@github.com:owner/repo.git     → { host: "github.com", path: "owner/repo" }
- *   Nested: https://gitlab.co/group/sub/proj.git → { host: "gitlab.co", path: "group/sub/proj" }
+ *   HTTPS: https://github.com/owner/repo.git → { providerHost: "github.com", repoPath: "owner/repo" }
+ *   SSH:   git@github.com:owner/repo.git     → { providerHost: "github.com", repoPath: "owner/repo" }
+ *   Nested: https://gitlab.co/group/sub/proj.git → { providerHost: "gitlab.co", repoPath: "group/sub/proj" }
  *
  * Returns null if the URL cannot be parsed. Pure function — no I/O.
  */
@@ -127,13 +129,13 @@ export function parseRemoteUrl(url: string): GitRemoteRef | null {
   // HTTPS: https://github.com/owner/repo.git
   const httpsMatch = url.match(/^https?:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
   if (httpsMatch?.[1] && httpsMatch[2]) {
-    return { host: httpsMatch[1], path: httpsMatch[2] };
+    return { providerHost: httpsMatch[1], repoPath: httpsMatch[2] };
   }
 
   // SSH: git@github.com:owner/repo.git
   const sshMatch = url.match(/^[^@]+@([^:]+):(.+?)(?:\.git)?$/);
   if (sshMatch?.[1] && sshMatch[2]) {
-    return { host: sshMatch[1], path: sshMatch[2] };
+    return { providerHost: sshMatch[1], repoPath: sshMatch[2] };
   }
 
   return null;

--- a/packages/core/src/git/types.ts
+++ b/packages/core/src/git/types.ts
@@ -93,3 +93,48 @@ export type CommitAuthor = {
   /** Author email */
   email: string;
 };
+
+/**
+ * Parsed reference to a git remote URL.
+ *
+ * Represents the decomposed identity of a git remote:
+ *   host: the server (github.com, gitlab.mycompany.com, gitea.internal.net)
+ *   path: the repo path on that server (owner/repo, group/subgroup/project)
+ *
+ * Used by CLI (parse from git remote URL) and SaaS (resolve to Repository).
+ * Created via parseRemoteUrl(). Shared between CLI and SaaS via @gitgov/core.
+ *
+ * IKS-A33, Cycle 4 identity_key_sync
+ */
+export type GitRemoteRef = {
+  /** Host of the git server (e.g. "github.com", "gitlab.mycompany.com") */
+  host: string;
+  /** Path of the repository on the server (e.g. "owner/repo", "group/subgroup/project") */
+  path: string;
+};
+
+/**
+ * [GM9, GM10, GM11] Parse a git remote URL into { host, path }.
+ *
+ * Supports:
+ *   HTTPS: https://github.com/owner/repo.git → { host: "github.com", path: "owner/repo" }
+ *   SSH:   git@github.com:owner/repo.git     → { host: "github.com", path: "owner/repo" }
+ *   Nested: https://gitlab.co/group/sub/proj.git → { host: "gitlab.co", path: "group/sub/proj" }
+ *
+ * Returns null if the URL cannot be parsed. Pure function — no I/O.
+ */
+export function parseRemoteUrl(url: string): GitRemoteRef | null {
+  // HTTPS: https://github.com/owner/repo.git
+  const httpsMatch = url.match(/^https?:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
+  if (httpsMatch?.[1] && httpsMatch[2]) {
+    return { host: httpsMatch[1], path: httpsMatch[2] };
+  }
+
+  // SSH: git@github.com:owner/repo.git
+  const sshMatch = url.match(/^[^@]+@([^:]+):(.+?)(?:\.git)?$/);
+  if (sshMatch?.[1] && sshMatch[2]) {
+    return { host: sshMatch[1], path: sshMatch[2] };
+  }
+
+  return null;
+}

--- a/packages/core/src/hook_handler/hook_handler.test.ts
+++ b/packages/core/src/hook_handler/hook_handler.test.ts
@@ -50,6 +50,9 @@ function createMockDependencies(overrides?: Partial<{
       getLastSession: jest.fn().mockResolvedValue(
         'lastSessionReturns' in opts ? opts.lastSessionReturns : { actorId: 'actor-123', timestamp: new Date().toISOString() }
       ),
+      setCloudToken: jest.fn(),
+      setLastSession: jest.fn(),
+      clearCloudToken: jest.fn(),
     } as unknown as HookHandlerDependencies['sessionManager'],
 
     executionAdapter: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,6 +63,9 @@ export { KeyProviderError } from "./key_provider/index";
 // KeyPair type — used by storeKey() in PrismaKeyProvider + createActor() in IdentityAdapter
 export type { KeyPair } from "./key_provider/index";
 
+// ECDH transport types — used by identity endpoints (CLI + SaaS)
+export type { EcdhKeypair, EcdhEnvelope, EcdhClientHello } from "./crypto/ecdh_transport.types";
+
 // Lint type exports (pure types only - Fs types are in @gitgov/core/fs)
 export type { RecordStores, LintOptions, FixReport, LintResult, ValidatorType, LintReport, ILintModule } from "./lint/index";
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -140,8 +140,8 @@ export type {
 export { generateTaskId, generateExecutionId, generateFeedbackId, generateCycleId, generateActorId, generateAgentId } from "./utils/id_generator";
 
 // Git direct exports (interface + types + errors)
-export type { IGitModule, ExecOptions, ExecResult, GetCommitHistoryOptions, CommitInfo, ChangedFile, CommitAuthor } from "./git/index";
-export { GitError, GitCommandError, FileNotFoundError, BranchNotFoundError, BranchAlreadyExistsError, MergeConflictError } from "./git/index";
+export type { IGitModule, ExecOptions, ExecResult, GetCommitHistoryOptions, CommitInfo, ChangedFile, CommitAuthor, GitRemoteRef } from "./git/index";
+export { GitError, GitCommandError, FileNotFoundError, BranchNotFoundError, BranchAlreadyExistsError, MergeConflictError, parseRemoteUrl } from "./git/index";
 export type {
   GitGovTaskRecord,
   GitGovCycleRecord,

--- a/packages/core/src/integration/feedback_backlog_integration.test.ts
+++ b/packages/core/src/integration/feedback_backlog_integration.test.ts
@@ -118,6 +118,9 @@ describe('FeedbackAdapter <-> BacklogAdapter Integration (Real Event Communicati
       getSyncPreferences: jest.fn().mockResolvedValue(null),
       updateSyncPreferences: jest.fn().mockResolvedValue(undefined),
       getLastSession: jest.fn().mockResolvedValue(null),
+      setCloudToken: jest.fn(),
+      setLastSession: jest.fn(),
+      clearCloudToken: jest.fn(),
     };
 
     // Create REAL IdentityAdapter

--- a/packages/core/src/session_manager/session_manager.test.ts
+++ b/packages/core/src/session_manager/session_manager.test.ts
@@ -13,6 +13,7 @@
  * - F: getSyncPreferences (§4.6)
  * - G: getLastSession (§4.7)
  * - H: updateSyncPreferences (§4.8)
+ * - I: Cloud Session Management (§4.9) — setCloudToken, setLastSession, clearCloudToken
  */
 
 import { SessionManager } from './session_manager';
@@ -406,6 +407,65 @@ describe('SessionManager', () => {
         enabled: true,
         pullIntervalSeconds: 45
       });
+    });
+  });
+
+  // ==================== §4.9 Cloud Session Management (EARS-I1 to I3) ====================
+
+  describe('4.9. Cloud Session Management (EARS-I1 to I3)', () => {
+    it('[EARS-I1] WHEN setCloudToken is called, THE SYSTEM SHALL persist the cloud token', async () => {
+      await sessionManager.setCloudToken('test-session-token');
+
+      const session = store.getSession();
+      expect(session?.cloud?.sessionToken).toBe('test-session-token');
+    });
+
+    it('[EARS-I1] should preserve existing session data when setting cloud token', async () => {
+      store.setSession({
+        lastSession: { actorId: 'human:camilo', timestamp: '2026-04-12T00:00:00Z' },
+        actorState: { 'human:camilo': { activeTaskId: 'task-1' } },
+      });
+
+      await sessionManager.setCloudToken('new-token');
+
+      const session = store.getSession();
+      expect(session?.cloud?.sessionToken).toBe('new-token');
+      expect(session?.lastSession?.actorId).toBe('human:camilo');
+      expect(session?.actorState?.['human:camilo']?.activeTaskId).toBe('task-1');
+    });
+
+    it('[EARS-I2] WHEN setLastSession is called, THE SYSTEM SHALL persist lastSession', async () => {
+      await sessionManager.setLastSession('human:testuser', '2026-04-12T10:00:00Z');
+
+      const session = store.getSession();
+      expect(session?.lastSession).toEqual({
+        actorId: 'human:testuser',
+        timestamp: '2026-04-12T10:00:00Z',
+      });
+    });
+
+    it('[EARS-I3] WHEN clearCloudToken is called, THE SYSTEM SHALL remove cloud token preserving rest', async () => {
+      store.setSession({
+        cloud: { sessionToken: 'existing-token' },
+        lastSession: { actorId: 'human:camilo', timestamp: '2026-04-12T00:00:00Z' },
+        actorState: { 'human:camilo': { activeTaskId: 'task-1' } },
+      });
+
+      await sessionManager.clearCloudToken();
+
+      const session = store.getSession();
+      expect(session?.cloud).toBeUndefined();
+      // Everything else preserved
+      expect(session?.lastSession?.actorId).toBe('human:camilo');
+      expect(session?.actorState?.['human:camilo']?.activeTaskId).toBe('task-1');
+    });
+
+    it('[EARS-I3] should succeed gracefully when no cloud token exists', async () => {
+      // No session set — clearCloudToken should not throw
+      await sessionManager.clearCloudToken();
+
+      const session = store.getSession();
+      expect(session?.cloud).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/session_manager/session_manager.ts
+++ b/packages/core/src/session_manager/session_manager.ts
@@ -177,4 +177,31 @@ export class SessionManager implements ISessionManager {
     const session = await this.loadSession();
     return session?.lastSession || null;
   }
+
+  /**
+   * [EARS-I1] Set cloud session token
+   */
+  async setCloudToken(token: string): Promise<void> {
+    const session = await this.loadSession() ?? {};
+    session.cloud = { sessionToken: token };
+    await this.sessionStore.saveSession(session);
+  }
+
+  /**
+   * [EARS-I2] Set last session info
+   */
+  async setLastSession(actorId: string, timestamp: string): Promise<void> {
+    const session = await this.loadSession() ?? {};
+    session.lastSession = { actorId, timestamp };
+    await this.sessionStore.saveSession(session);
+  }
+
+  /**
+   * [EARS-I3] Remove cloud token, preserve everything else
+   */
+  async clearCloudToken(): Promise<void> {
+    const session = await this.loadSession() ?? {};
+    delete session.cloud;
+    await this.sessionStore.saveSession(session);
+  }
 }

--- a/packages/core/src/session_manager/session_manager.types.ts
+++ b/packages/core/src/session_manager/session_manager.types.ts
@@ -116,4 +116,19 @@ export interface ISessionManager {
    * Get last session info (last human who interacted)
    */
   getLastSession(): Promise<{ actorId: string; timestamp: string } | null>;
+
+  /**
+   * [EARS-I1] Set cloud session token (used by gitgov login)
+   */
+  setCloudToken(token: string): Promise<void>;
+
+  /**
+   * [EARS-I2] Set last session info (actorId + timestamp)
+   */
+  setLastSession(actorId: string, timestamp: string): Promise<void>;
+
+  /**
+   * [EARS-I3] Remove cloud token without deleting keys (used by gitgov login --logout)
+   */
+  clearCloudToken(): Promise<void>;
 }


### PR DESCRIPTION
## Summary

Core + CLI side of the `identity_key_sync` epic (Cycles 3-4). The SaaS-API / webapp / specs side lives in a parallel PR on the `gitgovernance/private` repo.

- **Cycle 3 — ECDH X25519 transport** (`packages/core/src/crypto`): ephemeral keypair exchange for key sync endpoints; `ed25519PublicKeyToSpki` helper exported from core
- **Cycle 4 — `gitgov login` v2** (`packages/cli/src/commands/login`): tRPC wire format, ECDH encrypt/decrypt, `--force-local`/`--force-cloud`, 5 key-state cases (a..e), 19/20 tests + 1 todo
- **ConfigManager + ISessionManager** (`packages/core/src/config_manager` + `packages/core/src/session_manager`): `getSaasUrl()` (EARS-I1/I2) + cloud-token methods (`setCloudToken`, `setLastSession`, `clearCloudToken`)
- **GitRemoteRef + parseRemoteUrl** (`packages/core/src/git`): canonical shape `{providerHost, repoPath}` imported by CLI and SaaS (IKS-A33/A34). 13 tests (GM9/GM10/GM11) covering N-segment paths for GitLab nested namespaces. Shape field rename from initial draft `{host, path}` to `{providerHost, repoPath}` to align with SaaS domain language (IKS-A34)

## Scope

9 commits, 25 files changed (+1468 / -254). No breaking changes outside the epic.

Commits (newest first):

| SHA | Description |
|---|---|
| `4fd9e76d` | refactor(core,cli): GitRemoteRef rename — host→providerHost, path→repoPath (Task 4.7, IKS-A34) |
| `2c88ff74` | test(core): parseRemoteUrl tests — GM9/GM10/GM11 (13 tests) |
| `f2369d72` | feat(core,cli): GitRemoteRef + parseRemoteUrl + providerHost in login |
| `90fda44f` | feat(core,cli): ISessionManager cloud methods + repoFullName resolution |
| `3941faf2` | feat(cli): login command v2 — tRPC + ECDH + orgId + --force flags |
| `541a8a47` | feat(core): add ConfigManager.getSaasUrl() — EARS-I1/I2 |
| `f8a94e9e` | fix(cli,core): audit fixes — public key compare, no default URL, 5min timeout |
| `babc4240` | feat(core): add ECDH X25519 ephemeral transport for key sync |
| `5eb647a7` | feat(core): export ed25519PublicKeyToSpki helper for SPKI reconstruction |

## Tests

- **core/git**: 183/183 (local_git + github_git + memory_git + parse_remote_url)
- **cli/login**: 19/20 + 1 todo (`LOGIN-H2` 5-min timeout — deferred to E2E because it requires timer mocking)
- **core ECDH**: unit tests for round-trip + forward secrecy + tampered ciphertext detection
- **tsc --noEmit**: 0 errors

## Companion PR

Must land together with `gitgovernance/private#20` (saas-api + saas-web + specs). The SaaS PR includes:

- `saas-api` identity tRPC router with 3 endpoints (`sync-key`, `get-key`, `key-status`)
- `saas-api` OAuth CLI controller (Task 4.0)
- `saas-web` login page + org switcher adjustments
- All blueprint specs synced with `IKS-A33`..`A39` + `IKS-S1`..`S3` decisions
- Task 4.10 Playwright smoke verify evidence + Task 4.11 runtime fixes

## Test plan

- [ ] Clone branch, `pnpm install`, `pnpm tsc --noEmit` green in core + cli
- [ ] Run `pnpm --filter @gitgov/core test src/git/` — 183/183
- [ ] Run `pnpm --filter @gitgov/cli test src/commands/login/` — 19/20 + 1 todo
- [ ] `parseRemoteUrl` accepts SSH + HTTPS, GitHub + GitLab nested namespaces
- [ ] Smoke: `gitgov login` with a running SaaS-API + saas-web (see companion PR) — OAuth real + ECDH key sync end-to-end