### PR TITLE
feat(core,cli): deleteBranch + finalize + GitHubProjectInitializer + key succession + smart init

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -61,6 +61,7 @@ Commands:
   sync                   State synchronization (push/pull/resolve/audit)
   hook                   Process Claude Code hook events (passive governance)
   login [options]        Authenticate to GitGovernance (OAuth)
+                         Flags: --force-local (skip cloud sync), --force-cloud (force cloud sync)
   context [options]      Query working context for agents and automation
   push [options]         Alias for "gitgov sync push"
   pull [options]         Alias for "gitgov sync pull"

--- a/packages/cli/e2e/init_command_e2e.test.ts
+++ b/packages/cli/e2e/init_command_e2e.test.ts
@@ -135,6 +135,11 @@ describe('Init CLI Command - Edge Cases E2E Tests', () => {
       expect(fs.existsSync(path.join(worktreeBasePath, '.gitgov'))).toBe(true);
       expect(fs.existsSync(path.join(worktreeBasePath, '.gitgov', 'config.json'))).toBe(true);
 
+      // saasUrl written to config.json with default value
+      const configContent = JSON.parse(fs.readFileSync(path.join(worktreeBasePath, '.gitgov', 'config.json'), 'utf-8'));
+      expect(configContent.saasUrl).toBeDefined();
+      expect(configContent.saasUrl).toBe('https://app.gitgov.dev');
+
       // EARS-FPI14: policy.yml created with defaults during init
       const policyPath = path.join(worktreeBasePath, '.gitgov', 'policy.yml');
       expect(fs.existsSync(policyPath)).toBe(true);

--- a/packages/cli/e2e/init_command_e2e.test.ts
+++ b/packages/cli/e2e/init_command_e2e.test.ts
@@ -612,6 +612,28 @@ describe('Init CLI Command - Edge Cases E2E Tests', () => {
       expect(fs.existsSync(path.join(worktreeBasePath, '.gitgov', 'config.json'))).toBe(true);
     });
 
+    it('[EARS-A9] WHEN --login provided THEN actorId SHALL be human:${login}', () => {
+      setupWithRemoteGitgovState('case-a9-login');
+
+      // Force local to bypass Smart Init, use --login for actorId
+      const result = runCliCommand(
+        ['init', '--name', 'Login Test', '--login', 'cagodoy', '--actor-name', 'Camilo', '--force-local', '--quiet'],
+        { cwd: testProjectRoot },
+      );
+
+      expect(result.success).toBe(true);
+
+      // Verify actor file has human:cagodoy, NOT human:camilo
+      const actorsDir = path.join(worktreeBasePath, '.gitgov', 'actors');
+      const actorFiles = fs.readdirSync(actorsDir).filter(f => f.startsWith('human'));
+      expect(actorFiles.length).toBeGreaterThanOrEqual(1);
+
+      // Read the actor record — payload.id should be human:cagodoy
+      const actorContent = JSON.parse(fs.readFileSync(path.join(actorsDir, actorFiles[0]), 'utf-8'));
+      expect(actorContent.payload.id).toBe('human:cagodoy');
+      expect(actorContent.payload.displayName).toBe('Camilo');
+    });
+
     it('[EARS-E14] WHEN remote exists but no gitgov-state THEN init SHALL proceed normally', () => {
       // Setup WITHOUT pushing gitgov-state to remote
       testProjectRoot = path.join(tempDir, `case5-no-state-${Date.now()}`);

--- a/packages/cli/e2e/init_command_e2e.test.ts
+++ b/packages/cli/e2e/init_command_e2e.test.ts
@@ -533,4 +533,102 @@ describe('Init CLI Command - Edge Cases E2E Tests', () => {
       expect(fs.existsSync(path.join(worktreeBasePath, '.gitgov', 'config.json'))).toBe(true);
     });
   });
+
+  // ============================================================================
+  // CASE 5: Smart Init — Remote has gitgov-state (cloud-first detection, Task 5.4)
+  // ============================================================================
+  describe('CASE 5: Smart Init — Remote has gitgov-state (Task 5.4)', () => {
+    let testProjectRoot: string;
+    let remotePath: string;
+    let worktreeBasePath: string;
+
+    /**
+     * Setup: create repo + bare remote + push main + create gitgov-state on remote.
+     * This simulates the state after the SaaS did Remote Init (Task 5.2).
+     */
+    const setupWithRemoteGitgovState = (caseName: string) => {
+      testProjectRoot = path.join(tempDir, `${caseName}-${Date.now()}`);
+      remotePath = path.join(tempDir, `${caseName}-remote-${Date.now()}`);
+
+      createGitRepo(testProjectRoot, true);
+      createBareRemote(remotePath);
+      addRemote(testProjectRoot, remotePath);
+      execSync('git push -u origin main', { cwd: testProjectRoot, stdio: 'pipe' });
+
+      // Simulate Remote Init: create gitgov-state branch on the remote with a .gitgov/config.json
+      const clonePath = path.join(tempDir, `${caseName}-clone-${Date.now()}`);
+      execSync(`git clone "${remotePath}" "${clonePath}"`, { stdio: 'pipe' });
+      execSync('git config user.name "SaaS Bot"', { cwd: clonePath, stdio: 'pipe' });
+      execSync('git config user.email "bot@gitgov.dev"', { cwd: clonePath, stdio: 'pipe' });
+      execSync('git checkout --orphan gitgov-state', { cwd: clonePath, stdio: 'pipe' });
+      execSync('git rm -rf .', { cwd: clonePath, stdio: 'pipe' });
+      fs.mkdirSync(path.join(clonePath, '.gitgov'), { recursive: true });
+      fs.writeFileSync(path.join(clonePath, '.gitgov', 'config.json'), JSON.stringify({ projectId: 'remote-init-test' }));
+      execSync('git add .gitgov/', { cwd: clonePath, stdio: 'pipe' });
+      execSync('git commit -m "gitgov: remote init"', { cwd: clonePath, stdio: 'pipe' });
+      execSync('git push origin gitgov-state', { cwd: clonePath, stdio: 'pipe' });
+      fs.rmSync(clonePath, { recursive: true, force: true });
+
+      worktreeBasePath = getWorktreeBasePath(testProjectRoot);
+    };
+
+    afterEach(() => {
+      process.chdir(originalCwd);
+      if (worktreeBasePath) cleanupWorktree(testProjectRoot, worktreeBasePath);
+    });
+
+    it('[EARS-E12] WHEN remote has gitgov-state THEN init SHALL abort suggesting gitgov login', () => {
+      setupWithRemoteGitgovState('case5-abort');
+
+      // Verify remote actually has the branch
+      const lsRemote = execSync('git ls-remote --heads origin gitgov-state', { cwd: testProjectRoot, encoding: 'utf8' });
+      expect(lsRemote.trim()).not.toBe('');
+
+      const result = runCliCommand(
+        ['init', '--name', 'Cloud Project', '--actor-name', 'Test User'],
+        { cwd: testProjectRoot, expectError: true },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.output + (result.error ?? '')).toMatch(/gitgov login/i);
+      expect(fs.existsSync(path.join(worktreeBasePath, '.gitgov'))).toBe(false);
+    });
+
+    it('[EARS-E13] WHEN remote has gitgov-state AND --force-local THEN init SHALL proceed', () => {
+      setupWithRemoteGitgovState('case5-force');
+
+      const result = runCliCommand(
+        ['init', '--name', 'Force Local Project', '--actor-name', 'Test User', '--force-local', '--quiet'],
+        { cwd: testProjectRoot },
+      );
+
+      expect(result.success).toBe(true);
+      expect(fs.existsSync(path.join(worktreeBasePath, '.gitgov'))).toBe(true);
+      expect(fs.existsSync(path.join(worktreeBasePath, '.gitgov', 'config.json'))).toBe(true);
+    });
+
+    it('[EARS-E14] WHEN remote exists but no gitgov-state THEN init SHALL proceed normally', () => {
+      // Setup WITHOUT pushing gitgov-state to remote
+      testProjectRoot = path.join(tempDir, `case5-no-state-${Date.now()}`);
+      remotePath = path.join(tempDir, `case5-no-state-remote-${Date.now()}`);
+
+      createGitRepo(testProjectRoot, true);
+      createBareRemote(remotePath);
+      addRemote(testProjectRoot, remotePath);
+      execSync('git push -u origin main', { cwd: testProjectRoot, stdio: 'pipe' });
+      worktreeBasePath = getWorktreeBasePath(testProjectRoot);
+
+      // Verify remote does NOT have gitgov-state
+      const lsRemote = execSync('git ls-remote --heads origin gitgov-state', { cwd: testProjectRoot, encoding: 'utf8' });
+      expect(lsRemote.trim()).toBe('');
+
+      const result = runCliCommand(
+        ['init', '--name', 'Fresh Project', '--actor-name', 'Test User', '--quiet'],
+        { cwd: testProjectRoot },
+      );
+
+      expect(result.success).toBe(true);
+      expect(fs.existsSync(path.join(worktreeBasePath, '.gitgov'))).toBe(true);
+    });
+  });
 });

--- a/packages/cli/src/commands/init/init-command.test.ts
+++ b/packages/cli/src/commands/init/init-command.test.ts
@@ -115,15 +115,13 @@ describe('InitCommand', () => {
       });
 
       expect(mockProjectAdapter.validateEnvironment).toHaveBeenCalled();
-      expect(mockProjectAdapter.initializeProject).toHaveBeenCalledWith({
-        name: 'Test Project',
-        template: undefined,
-        actorName: 'Test User',
-        actorEmail: undefined,
-        methodology: undefined,
-        skipValidation: undefined,
-        verbose: undefined
-      });
+      expect(mockProjectAdapter.initializeProject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Test Project',
+          actorName: 'Test User',
+          saasUrl: 'https://app.gitgov.dev',
+        })
+      );
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('🚀 Initializing GitGovernance Project...'));
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('✅ GitGovernance initialized successfully!'));
     });
@@ -216,6 +214,22 @@ describe('InitCommand', () => {
       );
     });
 
+    it('[EARS-A9] should create actor with human:${login} when --login provided', async () => {
+      await initCommand.execute({
+        name: 'Login Project',
+        login: 'cagodoy',
+        actorName: 'Camilo Acuña Godoy',
+      });
+
+      expect(mockProjectAdapter.initializeProject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Login Project',
+          login: 'cagodoy',
+          actorName: 'Camilo Acuña Godoy',
+        })
+      );
+    });
+
     it('[EARS-A7] should create actor with type=\'human\' by default', async () => {
       await initCommand.execute({
         name: 'Human Project',
@@ -241,15 +255,15 @@ describe('InitCommand', () => {
         template: 'basic'
       });
 
-      expect(mockProjectAdapter.initializeProject).toHaveBeenCalledWith({
-        name: 'Integration Test',
-        template: 'basic',
-        actorName: 'Integration User',
-        actorEmail: undefined,
-        methodology: 'scrum',
-        skipValidation: undefined,
-        verbose: undefined
-      });
+      expect(mockProjectAdapter.initializeProject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Integration Test',
+          template: 'basic',
+          actorName: 'Integration User',
+          methodology: 'scrum',
+          saasUrl: 'https://app.gitgov.dev',
+        })
+      );
     });
 
     it('[EARS-B2] should handle ProjectAdapter validation errors', async () => {
@@ -402,15 +416,17 @@ describe('InitCommand', () => {
         cache: false
       });
 
-      expect(mockProjectAdapter.initializeProject).toHaveBeenCalledWith({
-        name: 'Full Test',
-        template: 'enterprise',
-        actorName: 'Full User',
-        actorEmail: 'user@example.com',
-        methodology: 'scrum',
-        skipValidation: undefined,
-        verbose: true
-      });
+      expect(mockProjectAdapter.initializeProject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Full Test',
+          template: 'enterprise',
+          actorName: 'Full User',
+          actorEmail: 'user@example.com',
+          methodology: 'scrum',
+          verbose: true,
+          saasUrl: 'https://app.gitgov.dev',
+        })
+      );
     });
 
     it('[EARS-D2] should show user-friendly error messages with troubleshooting suggestions', async () => {
@@ -486,15 +502,15 @@ describe('InitCommand', () => {
         template: 'enterprise'
       });
 
-      expect(mockProjectAdapter.initializeProject).toHaveBeenCalledWith({
-        name: 'Custom Project',
-        template: 'enterprise',
-        actorName: 'Custom User',
-        actorEmail: undefined,
-        methodology: 'kanban',
-        skipValidation: undefined,
-        verbose: undefined
-      });
+      expect(mockProjectAdapter.initializeProject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Custom Project',
+          template: 'enterprise',
+          actorName: 'Custom User',
+          methodology: 'kanban',
+          saasUrl: 'https://app.gitgov.dev',
+        })
+      );
     });
   });
 

--- a/packages/cli/src/commands/init/init-command.test.ts
+++ b/packages/cli/src/commands/init/init-command.test.ts
@@ -75,8 +75,13 @@ describe('InitCommand', () => {
       validateEnvironment: jest.fn()
     };
 
-    // Mock execSync for git config
-    (execSync as jest.MockedFunction<typeof execSync>).mockReturnValue('Test User\n');
+    // Mock execSync: git config returns user name, ls-remote returns empty (no remote branch)
+    (execSync as jest.MockedFunction<typeof execSync>).mockImplementation((cmd: unknown) => {
+      if (typeof cmd === 'string' && cmd.includes('ls-remote')) {
+        return '';
+      }
+      return 'Test User\n';
+    });
 
     // Create InitCommand (DI is mocked at module level)
     initCommand = new InitCommand();
@@ -440,7 +445,10 @@ describe('InitCommand', () => {
     });
 
     it('[EARS-D3] should use interactive prompts and intelligent defaults for UX excellence', async () => {
-      (execSync as jest.MockedFunction<typeof execSync>).mockReturnValue('John Doe\n');
+      (execSync as jest.MockedFunction<typeof execSync>).mockImplementation((cmd: unknown) => {
+        if (typeof cmd === 'string' && cmd.includes('ls-remote')) return '';
+        return 'John Doe\n';
+      });
 
       await initCommand.execute({
         name: 'Test Project'
@@ -618,6 +626,54 @@ describe('InitCommand', () => {
       const structureIndex = mockConsoleLog.mock.calls.indexOf(structureCall!);
       const pathLine = mockConsoleLog.mock.calls[structureIndex + 1];
       expect(pathLine?.[0]).toContain('~/.gitgov/');
+    });
+  });
+
+  // ============================================================================
+  // §4.6. Smart Init — Remote Detection (Task 5.4, IKS-T7/T8 CLI side)
+  // ============================================================================
+  describe('4.6. Smart Init — Remote Detection (Task 5.4)', () => {
+    it('should abort init when gitgov-state exists on remote', async () => {
+      (execSync as jest.MockedFunction<typeof execSync>).mockImplementation((cmd: unknown) => {
+        if (typeof cmd === 'string' && cmd.includes('ls-remote')) {
+          return 'abc123def456\trefs/heads/gitgov-state\n';
+        }
+        return 'Test User\n';
+      });
+
+      await initCommand.execute({ name: 'Cloud Project' });
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('gitgov login'),
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      expect(mockProjectAdapter.initializeProject).not.toHaveBeenCalled();
+    });
+
+    it('should proceed when gitgov-state does not exist on remote', async () => {
+      (execSync as jest.MockedFunction<typeof execSync>).mockImplementation((cmd: unknown) => {
+        if (typeof cmd === 'string' && cmd.includes('ls-remote')) {
+          return '';
+        }
+        return 'Test User\n';
+      });
+
+      await initCommand.execute({ name: 'Fresh Project' });
+
+      expect(mockProjectAdapter.initializeProject).toHaveBeenCalled();
+    });
+
+    it('should proceed with --force-local even when remote branch exists', async () => {
+      (execSync as jest.MockedFunction<typeof execSync>).mockImplementation((cmd: unknown) => {
+        if (typeof cmd === 'string' && cmd.includes('ls-remote')) {
+          return 'abc123def456\trefs/heads/gitgov-state\n';
+        }
+        return 'Test User\n';
+      });
+
+      await initCommand.execute({ name: 'Force Local Project', forceLocal: true });
+
+      expect(mockProjectAdapter.initializeProject).toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/commands/init/init-command.test.ts
+++ b/packages/cli/src/commands/init/init-command.test.ts
@@ -692,4 +692,23 @@ describe('InitCommand', () => {
       expect(mockProjectAdapter.initializeProject).toHaveBeenCalled();
     });
   });
+
+  // ============================================================================
+  // §4.7. Post-Init State Commit (EARS-G1)
+  // ============================================================================
+  describe('4.7. Post-Init State Commit (EARS-G1)', () => {
+    it('[EARS-G1] should commit initialized files to gitgov-state worktree', async () => {
+      await initCommand.execute({ name: 'G1 Test', actorName: 'Test User' });
+
+      const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+      const addCalls = mockExecSync.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('git add') && call[0].includes('config.json')
+      );
+      const commitCalls = mockExecSync.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('git commit') && call[0].includes('initial project structure')
+      );
+      expect(addCalls.length).toBeGreaterThanOrEqual(1);
+      expect(commitCalls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
 });

--- a/packages/cli/src/commands/init/init-command.ts
+++ b/packages/cli/src/commands/init/init-command.ts
@@ -4,7 +4,7 @@ import { DependencyInjectionService } from '../../services/dependency-injection'
 import * as pathUtils from 'path';
 import * as os from 'os';
 import { createHash } from 'crypto';
-import { existsSync, promises as fsPromises } from 'fs';
+import { existsSync, realpathSync, promises as fsPromises } from 'fs';
 
 /**
  * Init Command Options interface
@@ -107,6 +107,9 @@ export class InitCommand {
       // 6. Format success output with visual impact
       this.showSuccessOutput(result, options);
 
+      // [EARS-G1] Commit initialized files to gitgov-state branch
+      await this.commitStateToWorktree();
+
     } catch (error) {
       // 7. Format errors for user-friendly display
       this.handleError(error, options);
@@ -159,6 +162,45 @@ export class InitCommand {
 
     this.container.setInitMode(projectRoot);
     return this.container.getProjectAdapter();
+  }
+
+  /**
+   * [EARS-G1] Commit initialized files to gitgov-state branch in the worktree.
+   * Then best-effort push to remote if available.
+   */
+  private async commitStateToWorktree(): Promise<void> {
+    try {
+      const { execSync } = await import('child_process');
+      const repoRoot = process.cwd();
+      const resolvedRoot = realpathSync(repoRoot);
+      const hash = createHash('sha256').update(resolvedRoot).digest('hex').slice(0, 12);
+      const worktreePath = pathUtils.join(os.homedir(), '.gitgov', 'worktrees', hash);
+
+      // Commit protocol files (exclude .session.json, keys/)
+      execSync('git add .gitgov/config.json .gitgov/policy.yml .gitgov/actors .gitgov/cycles', {
+        cwd: worktreePath,
+        stdio: 'pipe',
+      });
+      execSync('git commit -m "gitgov: initial project structure"', {
+        cwd: worktreePath,
+        stdio: 'pipe',
+      });
+
+      // Best-effort push to remote
+      try {
+        execSync('git push origin gitgov-state', {
+          cwd: repoRoot,
+          stdio: 'pipe',
+          timeout: 10000,
+          env: { ...process.env, GIT_SSH_COMMAND: 'ssh -o ConnectTimeout=5 -o BatchMode=yes' },
+        });
+      } catch {
+        console.log('\n⚠️  Could not push to remote.');
+        console.log('   Run \'gitgov sync push\' when your remote is ready.\n');
+      }
+    } catch {
+      // Non-fatal — files stay in worktree, user can sync push later
+    }
   }
 
   /**

--- a/packages/cli/src/commands/init/init-command.ts
+++ b/packages/cli/src/commands/init/init-command.ts
@@ -18,6 +18,7 @@ export interface InitCommandOptions {
   actorEmail?: string;
   force?: boolean;
   forceLocal?: boolean;
+  login?: string;
   saasUrl?: string;
   cache?: boolean; // Note: --no-cache sets this to false
   skipValidation?: boolean;
@@ -95,6 +96,7 @@ export class InitCommand {
       if (completeOptions.methodology) projectInitOptions.methodology = completeOptions.methodology;
       if (completeOptions.skipValidation) projectInitOptions.skipValidation = completeOptions.skipValidation;
       if (completeOptions.verbose) projectInitOptions.verbose = completeOptions.verbose;
+      if (completeOptions.login) projectInitOptions.login = completeOptions.login;
       const saasUrl = completeOptions.saasUrl || process.env['GITGOV_SAAS_URL'] || 'https://app.gitgov.dev';
       projectInitOptions.saasUrl = saasUrl;
 

--- a/packages/cli/src/commands/init/init-command.ts
+++ b/packages/cli/src/commands/init/init-command.ts
@@ -17,6 +17,7 @@ export interface InitCommandOptions {
   actorName?: string;
   actorEmail?: string;
   force?: boolean;
+  forceLocal?: boolean;
   cache?: boolean; // Note: --no-cache sets this to false
   skipValidation?: boolean;
   json?: boolean;
@@ -43,16 +44,38 @@ export class InitCommand {
         await this.validateEnvironment(options);
       }
 
-      // 2. Interactive prompts for missing information
+      // 2. Smart Init: check if gitgov-state exists on remote (Task 5.4, IKS-T7/T8)
+      if (!options.forceLocal && !options.skipValidation) {
+        const remoteHasBranch = await this.checkRemoteForGitgovState();
+        if (remoteHasBranch) {
+          if (options.json) {
+            console.log(JSON.stringify({
+              success: false,
+              error: 'Project already initialized from cloud',
+              suggestion: 'gitgov login',
+              exitCode: 1,
+            }, null, 2));
+          } else {
+            console.log("⚠️  The branch 'gitgov-state' already exists on the remote.");
+            console.log("    This project was initialized from the cloud (Remote Init).\n");
+            console.log("💡 Run 'gitgov login' to download your identity and sync.\n");
+            console.log("    If you want to force a local init anyway, use --force-local.");
+          }
+          process.exit(1);
+          return;
+        }
+      }
+
+      // 3. Interactive prompts for missing information
       const completeOptions = await this.gatherMissingInfo(options);
 
-      // 3. Setup visual progress tracking
+      // 4. Setup visual progress tracking
       const progressTracker = this.createProgressTracker(options);
 
-      // 4. Get ProjectAdapter from dependency injection
+      // 5. Get ProjectAdapter from dependency injection
       const projectAdapter = await this.getProjectAdapter();
 
-      // 5. Delegate ALL business logic to ProjectAdapter
+      // 6. Delegate ALL business logic to ProjectAdapter
       progressTracker.start("🚀 Initializing GitGovernance Project...\n");
 
       // [EARS-D1] Build ProjectInitOptions handling all flag combinations correctly
@@ -294,6 +317,25 @@ export class InitCommand {
       console.log("   • Use 'gitgov task new' to create work items");
       console.log("   • Use 'gitgov status' for project dashboard");
       console.log("   • All changes are local until you commit to Git");
+    }
+  }
+
+  /**
+   * [EARS-F1/F2] Check if gitgov-state branch exists on the remote (Task 5.4).
+   * Uses `git ls-remote` — no API needed, works with any git remote.
+   * Returns false on any error (no remote, offline, etc.) — conservative fallback.
+   */
+  private async checkRemoteForGitgovState(): Promise<boolean> {
+    try {
+      const { execSync } = await import('child_process');
+      const output = execSync('git ls-remote --heads origin gitgov-state', {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        timeout: 10000,
+      }).trim();
+      return output.length > 0;
+    } catch {
+      return false;
     }
   }
 

--- a/packages/cli/src/commands/init/init-command.ts
+++ b/packages/cli/src/commands/init/init-command.ts
@@ -18,6 +18,7 @@ export interface InitCommandOptions {
   actorEmail?: string;
   force?: boolean;
   forceLocal?: boolean;
+  saasUrl?: string;
   cache?: boolean; // Note: --no-cache sets this to false
   skipValidation?: boolean;
   json?: boolean;
@@ -94,6 +95,8 @@ export class InitCommand {
       if (completeOptions.methodology) projectInitOptions.methodology = completeOptions.methodology;
       if (completeOptions.skipValidation) projectInitOptions.skipValidation = completeOptions.skipValidation;
       if (completeOptions.verbose) projectInitOptions.verbose = completeOptions.verbose;
+      const saasUrl = completeOptions.saasUrl || process.env['GITGOV_SAAS_URL'] || 'https://app.gitgov.dev';
+      projectInitOptions.saasUrl = saasUrl;
 
       const result = await projectAdapter.initializeProject(projectInitOptions);
 

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -18,6 +18,7 @@ export function registerInitCommands(program: Command): void {
     .option('-a, --actor-name <name>', 'Actor display name (default: git user.name)')
     .option('-e, --actor-email <email>', 'Actor email (default: git user.email)')
     .option('-f, --force', 'Re-initialize forcefully (requires confirmation)')
+    .option('--force-local', 'Proceed with local init even if gitgov-state exists on remote')
     .option('--no-cache', 'Skip RecordProjector initialization (faster init)')
     .option('--skip-validation', 'Skip environment validation (advanced users)')
     .option('--json', 'Output in JSON format for automation')

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -19,6 +19,7 @@ export function registerInitCommands(program: Command): void {
     .option('-e, --actor-email <email>', 'Actor email (default: git user.email)')
     .option('-f, --force', 'Re-initialize forcefully (requires confirmation)')
     .option('--force-local', 'Proceed with local init even if gitgov-state exists on remote')
+    .option('-l, --login <login>', 'GitHub login for actorId (creates human:${login})')
     .option('--saas-url <url>', 'SaaS URL for cloud sync (written to config.json)')
     .option('--no-cache', 'Skip RecordProjector initialization (faster init)')
     .option('--skip-validation', 'Skip environment validation (advanced users)')

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -19,6 +19,7 @@ export function registerInitCommands(program: Command): void {
     .option('-e, --actor-email <email>', 'Actor email (default: git user.email)')
     .option('-f, --force', 'Re-initialize forcefully (requires confirmation)')
     .option('--force-local', 'Proceed with local init even if gitgov-state exists on remote')
+    .option('--saas-url <url>', 'SaaS URL for cloud sync (written to config.json)')
     .option('--no-cache', 'Skip RecordProjector initialization (faster init)')
     .option('--skip-validation', 'Skip environment validation (advanced users)')
     .option('--json', 'Output in JSON format for automation')

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -162,7 +162,7 @@ describe('LoginCommand v2', () => {
 
       expect(deps.openBrowser).toHaveBeenCalledTimes(1);
       const openUrl = (deps.openBrowser as jest.Mock).mock.calls[0][0] as string;
-      expect(openUrl).toContain('/api/auth/cli?callback=');
+      expect(openUrl).toContain('/auth/cli?callback=');
 
       expect(deps.startCallbackServer).toHaveBeenCalledTimes(1);
 

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -101,9 +101,9 @@ const mockProcessExit = jest.spyOn(process, 'exit').mockImplementation(() => und
 
 // ─── tRPC mock helpers ────────────────────────────────────────────────────
 
-/** Wrap a response in tRPC envelope */
+/** Wrap a response in tRPC v11 envelope (no superjson) */
 function trpcWrap<T>(data: T): TrpcResponse<T> {
-  return { result: { data: { json: data } } };
+  return { result: { data } };
 }
 
 /** Default keyStatus response (no key) */
@@ -595,6 +595,97 @@ describe('LoginCommand v2', () => {
     });
 
     it.todo('[LOGIN-H2] should timeout after 5 minutes with error message (requires timer mock — deferred to E2E)');
+  });
+
+  // ============================================================================
+  // §4.10. Repo Not Connected (LOGIN-K1, Task 5.11)
+  // ============================================================================
+  describe('4.10. Repo Not Connected (LOGIN-K1)', () => {
+    it('[LOGIN-K1] should show actionable error when repo is not connected to SaaS', async () => {
+      mockHasPrivateKey.mockResolvedValue(true);
+
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) {
+            return { ok: false, status: 404, text: async () => 'Not found' };
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        'This repository is not connected to GitGovernance.'
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Connect it at:')
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  // ============================================================================
+  // §4.11. Post-Sync State Push (LOGIN-L1 to L2)
+  // ============================================================================
+  describe('4.11. Post-Sync State Push (LOGIN-L1 to L2)', () => {
+    it('[LOGIN-L1] should push gitgov-state to remote after key sync succeeds', async () => {
+      const { execSync } = await import('child_process');
+      const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+      mockExecSync.mockReturnValue('https://github.com/testorg/testrepo.git\n');
+
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPrivateKey.mockResolvedValue('base64-priv-key');
+      mockGetPublicKey.mockResolvedValue('base64-pub-key');
+
+      const syncResponse = { success: true, actorId: 'human:camilo', mode: 'full' as const };
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) return { ok: true, json: async () => trpcWrap(noKeyStatus) };
+          if (url.includes('identity.syncKey')) return { ok: true, json: async () => trpcWrap(syncResponse) };
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      const pushCalls = mockExecSync.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('git push origin gitgov-state')
+      );
+      expect(pushCalls.length).toBe(1);
+    });
+
+    it('[LOGIN-L2] should skip push silently when gitgov-state branch does not exist locally', async () => {
+      const { execSync } = await import('child_process');
+      const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('git push origin gitgov-state')) {
+          throw new Error('error: src refspec gitgov-state does not match any');
+        }
+        return 'https://github.com/testorg/testrepo.git\n';
+      });
+
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPrivateKey.mockResolvedValue('base64-priv-key');
+      mockGetPublicKey.mockResolvedValue('base64-pub-key');
+
+      const syncResponse = { success: true, actorId: 'human:camilo', mode: 'full' as const };
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) return { ok: true, json: async () => trpcWrap(noKeyStatus) };
+          if (url.includes('identity.syncKey')) return { ok: true, json: async () => trpcWrap(syncResponse) };
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // Login should still succeed despite push failure
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Logged in as'));
+    });
   });
 
   // ============================================================================

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -592,4 +592,57 @@ describe('LoginCommand v2', () => {
 
     it.todo('[LOGIN-H2] should timeout after 5 minutes with error message (requires timer mock — deferred to E2E)');
   });
+
+  // ============================================================================
+  // §4.9. Cloud-First Bootstrap (LOGIN-J1 to J2, Task 5.5)
+  // ============================================================================
+  describe('4.9. Cloud-First Bootstrap (LOGIN-J1 to J2)', () => {
+    it('[LOGIN-J1] should fetch origin gitgov-state before resolving saasUrl', async () => {
+      const { execSync } = await import('child_process');
+      (execSync as jest.MockedFunction<typeof execSync>).mockReturnValue('https://github.com/testorg/testrepo.git\n');
+
+      mockGetConfig.mockResolvedValue({ saasUrl: 'https://app.gitgov.dev' });
+      mockHasPrivateKey.mockResolvedValue(false);
+
+      const deps = createMockDeps({
+        fetchSaas: createTrpcFetch({
+          'keyStatus': noKeyStatus,
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      expect(execSync).toHaveBeenCalledWith(
+        'git fetch origin gitgov-state',
+        expect.objectContaining({ stdio: 'pipe' }),
+      );
+    });
+
+    it('[LOGIN-J2] should continue login flow when fetch fails (no remote/offline)', async () => {
+      const { execSync } = await import('child_process');
+      (execSync as jest.MockedFunction<typeof execSync>).mockImplementation((cmd: unknown) => {
+        if (typeof cmd === 'string' && cmd.includes('fetch')) {
+          throw new Error('fatal: could not read from remote repository');
+        }
+        return 'https://github.com/testorg/testrepo.git\n';
+      });
+
+      mockGetConfig.mockResolvedValue({ saasUrl: 'https://app.gitgov.dev' });
+      mockHasPrivateKey.mockResolvedValue(false);
+
+      const deps = createMockDeps({
+        fetchSaas: createTrpcFetch({
+          'keyStatus': noKeyStatus,
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // Login should proceed despite fetch failure
+      expect(deps.startCallbackServer).toHaveBeenCalled();
+      expect(mockSetCloudToken).toHaveBeenCalledWith('test-session-token');
+    });
+  });
 });

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -454,20 +454,16 @@ describe('LoginCommand v2', () => {
       expect(mockProcessExit).toHaveBeenCalledWith(1);
     });
 
-    it('[LOGIN-F4] should verify keyStatus matches after --force-local resolve', async () => {
+    it('[LOGIN-F4] should succeed on --force-local without post-sync re-verification', async () => {
       mockHasPrivateKey.mockResolvedValue(true);
       mockGetPrivateKey.mockResolvedValue('local-priv');
       mockGetPublicKey.mockResolvedValue('local-pub-key');
 
-      let callCount = 0;
       const syncResponse: SyncKeyResponse = { success: true, actorId: 'human:camilo', mode: 'full' };
       const deps = createMockDeps({
         fetchSaas: jest.fn().mockImplementation(async (url: string) => {
           if (url.includes('identity.keyStatus')) {
-            callCount++;
-            // First call: different key. Second call (post-verify): local key uploaded
-            const pub = callCount === 1 ? 'different-saas-key' : 'local-pub-key';
-            return { ok: true, json: async () => trpcWrap(keyStatusWith(pub)) };
+            return { ok: true, json: async () => trpcWrap(keyStatusWith('different-saas-key')) };
           }
           if (url.includes('identity.syncKey')) return { ok: true, json: async () => trpcWrap(syncResponse) };
           return { ok: false, json: async () => ({}) };
@@ -477,11 +473,56 @@ describe('LoginCommand v2', () => {
       const cmd = new LoginCommand(deps);
       await cmd.executeLogin({ ...defaultOptions, forceLocal: true });
 
-      // keyStatus called twice: initial check + post-sync verification
+      // syncKey response is trusted — no second keyStatus call needed
       const keyStatusCalls = (deps.fetchSaas as jest.Mock).mock.calls.filter(
         (c: [string]) => c[0].includes('identity.keyStatus')
       );
-      expect(keyStatusCalls.length).toBeGreaterThanOrEqual(2);
+      expect(keyStatusCalls).toHaveLength(1);
+    });
+  });
+
+  // ==================== §4.13 Key Succession Response (LOGIN-N1) ====================
+
+  describe('4.13. Key Succession Response (LOGIN-N1)', () => {
+    it('[LOGIN-N1] should update session to newActorId on succession response', async () => {
+      mockHasPrivateKey.mockResolvedValue(true);
+      mockGetPrivateKey.mockResolvedValue('local-private-key');
+      mockGetPublicKey.mockResolvedValue('local-public-key');
+
+      const successionResponse: SyncKeyResponse = {
+        success: true,
+        actorId: 'human:camilo-v2',
+        mode: 'full',
+        rotated: true,
+        newActorId: 'human:camilo-v2',
+        oldActorId: 'human:camilo',
+      };
+
+      const deps = createMockDeps({
+        fetchSaas: jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) {
+            return { ok: true, json: async () => trpcWrap(keyStatusWith('different-saas-key')) };
+          }
+          if (url.includes('identity.syncKey')) {
+            return { ok: true, json: async () => trpcWrap(successionResponse) };
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin({ ...defaultOptions, forceLocal: true });
+
+      // Session should be updated to the NEW actorId
+      expect(mockSetLastSession).toHaveBeenCalledWith(
+        'human:camilo-v2',
+        expect.any(String),
+      );
+
+      // Output should mention the identity change
+      const output = mockConsoleLog.mock.calls.map(c => c[0]).join('\n');
+      expect(output).toContain('human:camilo-v2');
+      expect(output).toContain('succession');
     });
   });
 

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -60,6 +60,7 @@ const mockSetPrivateKey = jest.fn();
 const mockHasPrivateKey = jest.fn();
 const mockGetPublicKey = jest.fn();
 const mockGetConfig = jest.fn();
+const mockGetCurrentActor = jest.fn();
 
 jest.mock('../../services/dependency-injection', () => ({
   DependencyInjectionService: {
@@ -76,6 +77,9 @@ jest.mock('../../services/dependency-injection', () => ({
         hasPrivateKey: mockHasPrivateKey,
         getPublicKey: mockGetPublicKey,
       } as unknown as IKeyProvider),
+      getIdentityAdapter: jest.fn().mockResolvedValue({
+        getCurrentActor: mockGetCurrentActor,
+      }),
       getConfigManager: jest.fn().mockResolvedValue({
         loadConfig: mockGetConfig,
         getSaasUrl: jest.fn().mockImplementation(async () => {
@@ -616,6 +620,35 @@ describe('LoginCommand v2', () => {
       expect(execSync).toHaveBeenCalledWith(
         'git fetch origin gitgov-state',
         expect.objectContaining({ stdio: 'pipe' }),
+      );
+    });
+
+    it('[LOGIN-J3] should use local actor actorId for key sync instead of github login', async () => {
+      const { execSync } = await import('child_process');
+      (execSync as jest.MockedFunction<typeof execSync>).mockImplementation((cmd: unknown) => {
+        if (typeof cmd === 'string' && cmd.includes('fetch')) return '';
+        return 'https://github.com/testorg/testrepo.git\n';
+      });
+
+      mockGetConfig.mockResolvedValue({ saasUrl: 'https://app.gitgov.dev' });
+      mockGetCurrentActor.mockResolvedValue({
+        id: 'human:camilo-acua-godoy',
+        type: 'human',
+        displayName: 'Camilo Acuña Godoy',
+      });
+      mockHasPrivateKey.mockResolvedValue(false);
+
+      const deps = createMockDeps({
+        fetchSaas: createTrpcFetch({ 'keyStatus': noKeyStatus }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // Should use local actorId, not human:camilo (github login)
+      expect(mockSetLastSession).toHaveBeenCalledWith(
+        'human:camilo-acua-godoy',
+        expect.any(String),
       );
     });
 

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -91,6 +91,18 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
   // [LOGIN-A1] OAuth flow → open browser, start callback server, store session token
   async executeLogin(options: LoginCommandOptions): Promise<void> {
     try {
+      // [LOGIN-J1] Cloud-first bootstrap: fetch remote gitgov-state so DI can discover it
+      try {
+        const { execSync } = await import('child_process');
+        execSync('git fetch origin gitgov-state', {
+          cwd: process.cwd(),
+          stdio: 'pipe',
+          timeout: 15000,
+        });
+      } catch {
+        // [LOGIN-J2] Fetch failed — continue, DI will use cached refs or fail with clear message
+      }
+
       const saasUrl = await this.resolveSaasUrl(options);
 
       console.log(`Opening browser for authentication at ${saasUrl}...`);

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -53,12 +53,12 @@ function createDefaultDeps(): LoginDeps {
 
             if (token && login && id) {
               clearTimeout(timeoutHandle);
-              res.writeHead(200, { 'Content-Type': 'text/html' });
+              res.writeHead(200, { 'Content-Type': 'text/html', 'Connection': 'close' });
               res.end('<html><body><h1>Login successful!</h1><p>You can close this window.</p></body></html>');
               server.close();
               resolve({ token, user: { login, id: Number(id) } });
             } else {
-              res.writeHead(400, { 'Content-Type': 'text/plain' });
+              res.writeHead(400, { 'Content-Type': 'text/plain', 'Connection': 'close' });
               res.end('Missing token, login, or id');
             }
           });

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -303,20 +303,30 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
 
       // [LOGIN-D2 / LOGIN-F1..F4] Keys differ → conflict resolution
       if (localPublicKey && saasPublicKey && localPublicKey !== saasPublicKey) {
-        // [LOGIN-F1] --force-local: upload local key, archive SaaS key
+        // [LOGIN-F1] --force-local: upload local key → triggers succession on SaaS
         if (options.forceLocal) {
-          await this.uploadKeyToSaas(actorId, saasUrl, token, repo, keyStatus.ecdhPublicKey);
-          console.log('Previous cloud key archived. Local key is now canonical.');
-          // [LOGIN-F4] Post-sync verification
-          const postStatus = await this.getKeyStatus(saasUrl, token, repo);
-          const newLocalPub = await keyProvider.getPublicKey(actorId);
-          if (postStatus.publicKey === newLocalPub) {
+          const syncResult = await this.uploadKeyToSaas(actorId, saasUrl, token, repo, keyStatus.ecdhPublicKey);
+
+          // [IKS-SUC8] Handle succession response — SaaS created a new versioned actor
+          if (syncResult.rotated && syncResult.newActorId) {
+            const sessionManager = await this.dependencyService.getSessionManager();
+            await sessionManager.setLastSession(syncResult.newActorId, new Date().toISOString());
+            console.log(`Identity updated: ${actorId} → ${syncResult.newActorId}`);
             this.handleSuccess(
-              { loggedIn: true, user: actorId, keySynced: true },
+              { loggedIn: true, user: syncResult.newActorId, keySynced: true, rotated: true, oldActorId: actorId },
               options,
-              `Logged in as ${actorId}\nKey conflict resolved (local key uploaded)`
+              `Logged in as ${syncResult.newActorId}\nKey conflict resolved via succession (local key uploaded)`
             );
+            return;
           }
+
+          // Non-succession upload (legacy path or no ActorRecord in projection)
+          console.log('Previous cloud key archived. Local key is now canonical.');
+          this.handleSuccess(
+            { loggedIn: true, user: actorId, keySynced: true },
+            options,
+            `Logged in as ${actorId}\nKey conflict resolved (local key uploaded)`
+          );
           return;
         }
 

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -105,11 +105,12 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
 
       const saasUrl = await this.resolveSaasUrl(options);
 
-      console.log(`Opening browser for authentication at ${saasUrl}...`);
-
       // Start local callback server and open browser in parallel
       const callbackPromise = this.deps.startCallbackServer(CALLBACK_PORT);
-      const oauthUrl = `${saasUrl}/auth/cli?callback=http://localhost:${CALLBACK_PORT}/auth/callback`;
+      const webUrl = process.env['GITGOV_WEB_URL'] ?? saasUrl.replace(':3001', ':3000');
+      const oauthUrl = `${webUrl}/auth/cli?callback=http://localhost:${CALLBACK_PORT}/auth/callback`;
+
+      console.log(`Opening browser for authentication at ${oauthUrl}`);
       await this.deps.openBrowser(oauthUrl);
 
       // Wait for callback with token

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -109,7 +109,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
 
       // Start local callback server and open browser in parallel
       const callbackPromise = this.deps.startCallbackServer(CALLBACK_PORT);
-      const oauthUrl = `${saasUrl}/api/auth/cli?callback=http://localhost:${CALLBACK_PORT}/auth/callback`;
+      const oauthUrl = `${saasUrl}/auth/cli?callback=http://localhost:${CALLBACK_PORT}/auth/callback`;
       await this.deps.openBrowser(oauthUrl);
 
       // Wait for callback with token

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -118,22 +118,27 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       // Store session token via SessionManager public API
       const sessionManager = await this.dependencyService.getSessionManager();
       await sessionManager.setCloudToken(token);
-      await sessionManager.setLastSession(`human:${user.login}`, new Date().toISOString());
 
-      console.log(`Logged in as ${user.login} (human:${user.login})`);
+      // Discover local actor — use its actorId for key sync, not github login
+      const localActor = await this.findLocalHumanActor();
+      const actorId = localActor?.actorId ?? `human:${user.login}`;
+
+      await sessionManager.setLastSession(actorId, new Date().toISOString());
+
+      console.log(`Logged in as ${user.login} (${actorId})`);
 
       // [LOGIN-B3] Skip key sync if --no-key-sync
       if (options.noKeySync) {
         this.handleSuccess(
-          { loggedIn: true, user: user.login, actorId: `human:${user.login}`, keySynced: false },
+          { loggedIn: true, user: user.login, actorId, keySynced: false },
           options,
           `Logged in (key sync skipped)`
         );
         return;
       }
 
-      // Key sync detection and execution
-      await this.syncKeys(`human:${user.login}`, saasUrl, token, options);
+      // Key sync: use local actorId for FsKeyProvider, GitHub identity for SaaS context
+      await this.syncKeys(actorId, saasUrl, token, options);
 
     } catch (error) {
       this.handleError(
@@ -376,6 +381,19 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       // Git not available or no remote
     }
     throw new Error('Could not determine repository. Ensure you are in a git repository with a remote origin.');
+  }
+
+  private async findLocalHumanActor(): Promise<{ actorId: string; displayName: string } | null> {
+    try {
+      const identityAdapter = await this.dependencyService.getIdentityAdapter();
+      const currentActor = await identityAdapter.getCurrentActor();
+      if (currentActor && currentActor.type === 'human') {
+        return { actorId: currentActor.id, displayName: currentActor.displayName };
+      }
+    } catch {
+      // No actor found or adapter not available
+    }
+    return null;
   }
 
   private async hasLocalKey(actorId: string): Promise<boolean> {

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -44,6 +44,7 @@ function createDefaultDeps(): LoginDeps {
     startCallbackServer: (port: number) => {
       return new Promise((resolve, reject) => {
         import('http').then(({ createServer }) => {
+          let timeoutHandle: ReturnType<typeof setTimeout>;
           const server = createServer((req, res) => {
             const url = new URL(req.url ?? '/', `http://localhost:${port}`);
             const token = url.searchParams.get('token');
@@ -51,6 +52,7 @@ function createDefaultDeps(): LoginDeps {
             const id = url.searchParams.get('id');
 
             if (token && login && id) {
+              clearTimeout(timeoutHandle);
               res.writeHead(200, { 'Content-Type': 'text/html' });
               res.end('<html><body><h1>Login successful!</h1><p>You can close this window.</p></body></html>');
               server.close();
@@ -63,7 +65,7 @@ function createDefaultDeps(): LoginDeps {
           server.listen(port, () => {});
           server.on('error', reject);
           // [LOGIN-H2] Timeout after 5 minutes
-          setTimeout(() => {
+          timeoutHandle = setTimeout(() => {
             server.close();
             reject(new Error('Login timeout — no callback received within 5 minutes'));
           }, CALLBACK_TIMEOUT_MS);
@@ -140,6 +142,9 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
 
       // Key sync: use local actorId for FsKeyProvider, GitHub identity for SaaS context
       await this.syncKeys(actorId, saasUrl, token, options);
+
+      // [LOGIN-L1, LOGIN-L2] Push gitgov-state so SaaS can index ActorRecord
+      await this.pushGitgovState();
 
     } catch (error) {
       this.handleError(
@@ -250,6 +255,15 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     const hasLocal = await this.hasLocalKey(actorId);
     const keyStatus = await this.getKeyStatus(saasUrl, token, repo);
 
+    // [LOGIN-K1] Repo not connected — keyStatus returned fallback (empty ecdhPublicKey)
+    if (!keyStatus.exists && keyStatus.ecdhPublicKey === '') {
+      const webUrl = process.env['GITGOV_WEB_URL'] ?? saasUrl.replace(':3001', ':3000');
+      console.error('This repository is not connected to GitGovernance.');
+      console.error(`  Connect it at: ${webUrl}`);
+      console.error('  After connecting, run `gitgov login` again.');
+      process.exit(1);
+    }
+
     // [LOGIN-B1] CLI has key, SaaS does not → upload with ECDH
     if (hasLocal && !keyStatus.exists) {
       await this.uploadKeyToSaas(actorId, saasUrl, token, repo, keyStatus.ecdhPublicKey);
@@ -353,6 +367,26 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     }
   }
 
+  /**
+   * [LOGIN-L1] Push gitgov-state to remote after successful key sync.
+   * [LOGIN-L2] Skip silently if branch doesn't exist locally (cloud-first flow).
+   * Best-effort — logs warning on failure but does not fail the login.
+   */
+  private async pushGitgovState(): Promise<void> {
+    try {
+      const { execSync } = await import('child_process');
+      execSync('git rev-parse --verify gitgov-state', { cwd: process.cwd(), stdio: 'pipe', timeout: 2000 });
+      execSync('git push origin gitgov-state', {
+        cwd: process.cwd(),
+        stdio: 'pipe',
+        timeout: 5000,
+        env: { ...process.env, GIT_SSH_COMMAND: 'ssh -o ConnectTimeout=3 -o BatchMode=yes' },
+      });
+    } catch {
+      // [LOGIN-L2] No local branch, no remote, offline, or permissions error
+    }
+  }
+
   // ============================================================================
   // tRPC HELPERS (v2 — ECDH encrypted, providerHost+repoPath scoped)
   // ============================================================================
@@ -408,14 +442,17 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
 
   /** Call identity.keyStatus via tRPC (IKS-A27 wire format) */
   private async getKeyStatus(saasUrl: string, token: string, repo: GitRemoteRef): Promise<KeyStatusResponse> {
-    const input = encodeURIComponent(JSON.stringify({ json: repo }));
+    const input = encodeURIComponent(JSON.stringify(repo));
     const url = `${saasUrl}/trpc/identity.keyStatus?input=${input}`;
     const res = await this.deps.fetchSaas(url, {
       headers: { Authorization: `Bearer ${token}` },
     });
-    if (!res.ok) return { exists: false, hasPrivateKey: false, publicKey: null, ecdhPublicKey: '' };
+    if (!res.ok) {
+      console.error(`[keyStatus] ${res.status}`);
+      return { exists: false, hasPrivateKey: false, publicKey: null, ecdhPublicKey: '' };
+    }
     const body = await res.json() as TrpcResponse<KeyStatusResponse>;
-    return body.result.data.json;
+    return body.result.data;
   }
 
   /**
@@ -449,11 +486,14 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ json: { ...repo, publicKey, privateKeyEnvelope: envelope } }),
+      body: JSON.stringify({ ...repo, publicKey, privateKeyEnvelope: envelope }),
     });
-    if (!res.ok) throw new Error(`Failed to sync key to SaaS: ${res.status}`);
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => '');
+      throw new Error(`Failed to sync key to SaaS: ${res.status} ${errBody.slice(0, 300)}`);
+    }
     const body = await res.json() as TrpcResponse<SyncKeyResponse>;
-    return body.result.data.json;
+    return body.result.data;
   }
 
   /**
@@ -470,7 +510,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     const clientKp = Crypto.generateEphemeralKeypair();
 
     const input = encodeURIComponent(JSON.stringify({
-      json: { ...repo, clientEcdhPublicKey: clientKp.publicKey },
+      ...repo, clientEcdhPublicKey: clientKp.publicKey,
     }));
     const url = `${saasUrl}/trpc/identity.getKey?input=${input}`;
     const res = await this.deps.fetchSaas(url, {
@@ -479,7 +519,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
     if (!res.ok) throw new Error(`Failed to download key from SaaS: ${res.status}`);
 
     const body = await res.json() as TrpcResponse<GetKeyResponse>;
-    const { privateKeyEnvelope } = body.result.data.json;
+    const { privateKeyEnvelope } = body.result.data;
 
     // [LOGIN-G2] Decrypt ECDH envelope
     let decryptedKey: Buffer;

--- a/packages/cli/src/commands/login/login-command.types.ts
+++ b/packages/cli/src/commands/login/login-command.types.ts
@@ -54,12 +54,10 @@ export type GetKeyResponse = {
   privateKeyEnvelope: EcdhEnvelope;
 };
 
-/** Wrapper for tRPC response envelope */
+/** Wrapper for tRPC v11 response envelope (no superjson) */
 export type TrpcResponse<T> = {
   result: {
-    data: {
-      json: T;
-    };
+    data: T;
   };
 };
 

--- a/packages/cli/src/commands/login/login-command.types.ts
+++ b/packages/cli/src/commands/login/login-command.types.ts
@@ -45,6 +45,9 @@ export type SyncKeyResponse = {
   success: boolean;
   actorId: string;
   mode: 'full' | 'verify-only';
+  rotated?: boolean;
+  newActorId?: string;
+  oldActorId?: string;
 };
 
 /** Response from identity.getKey tRPC query */

--- a/packages/cli/src/services/dependency-injection.test.ts
+++ b/packages/cli/src/services/dependency-injection.test.ts
@@ -662,6 +662,11 @@ jest.doMock('@gitgov/core/fs', () => ({
   DEFAULT_ID_ENCODER: { encode: (id: string) => id, decode: (encoded: string) => encoded },
   findProjectRoot: jest.fn().mockReturnValue('/tmp/test-gitgov'),
   findGitgovRoot: jest.fn().mockReturnValue('/tmp/test-gitgov'),
+  getWorktreeBasePath: jest.fn((repoRoot: string) => {
+    const { createHash } = require('crypto');
+    const hash = createHash('sha256').update(repoRoot).digest('hex').slice(0, 12);
+    return require('path').join(require('os').homedir(), '.gitgov', 'worktrees', hash);
+  }),
   createSessionManager: jest.fn().mockReturnValue({
     loadSession: jest.fn().mockResolvedValue(null),
     saveSession: jest.fn().mockResolvedValue(undefined),
@@ -678,8 +683,8 @@ const { Git, Adapters, KeyProvider, EventBus, RecordProjection, RecordMetrics, A
 describe('DependencyInjectionService', () => {
   let diService: DependencyInjectionService;
   const mockRepoRoot = '/tmp/test-gitgov';
-  // Worktree base path is computed from repoRoot via sha256 hash
-  const mockWorktreeBasePath = DependencyInjectionService.getWorktreeBasePath(mockRepoRoot);
+  // Worktree base path is computed from repoRoot via core's getWorktreeBasePath
+  const mockWorktreeBasePath = corefs.getWorktreeBasePath(mockRepoRoot);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -763,9 +768,9 @@ describe('DependencyInjectionService', () => {
   });
 
   // ============================================================================
-  // §4.3. Adapter Factories (EARS-C1 to C11)
+  // §4.3. Adapter Factories (EARS-C1 to C12)
   // ============================================================================
-  describe('4.3. Adapter Factories (EARS-C1 to C11)', () => {
+  describe('4.3. Adapter Factories (EARS-C1 to C12)', () => {
     it('[EARS-C1] should create RecordProjector with all dependencies', async () => {
       const projector = await diService.getRecordProjector();
       expect(projector).toBeDefined();
@@ -889,6 +894,15 @@ describe('DependencyInjectionService', () => {
       const callArgs = createAgentRunner.mock.calls[0][0];
       expect(callArgs.projectRoot).toBe(mockRepoRoot);
       expect(callArgs.gitgovPath).toContain('.gitgov');
+    });
+
+    it('[EARS-C13] should make keyProvider accessible via getKeyProvider after getIdentityAdapter', async () => {
+      await diService.getIdentityAdapter();
+
+      const keyProvider = diService.getKeyProvider();
+      expect(keyProvider).toBeDefined();
+      expect(keyProvider.hasPrivateKey).toBeDefined();
+      expect(keyProvider.sign).toBeDefined();
     });
   });
 

--- a/packages/cli/src/services/dependency-injection.ts
+++ b/packages/cli/src/services/dependency-injection.ts
@@ -941,7 +941,13 @@ export class DependencyInjectionService {
     }
 
     try {
-      // If projectRoot is not set yet, compute worktree path from repo root
+      // [IKS-WTP2] Initialize stores first to ensure worktree is bootstrapped.
+      try {
+        await this.initializeStores();
+      } catch {
+        // Fall through to projectRoot computation below.
+      }
+
       if (!this.projectRoot) {
         const root = findProjectRoot();
         if (!root) {
@@ -978,6 +984,18 @@ export class DependencyInjectionService {
     }
 
     try {
+      // [IKS-WTP2] Initialize stores first to ensure worktree is bootstrapped.
+      // This is critical for cloud-first flow where login runs before init —
+      // the worktree must exist with git content (actors, config) before
+      // session/keys are written, otherwise subsequent CLI commands can't
+      // find the actor records.
+      try {
+        await this.initializeStores();
+      } catch {
+        // Stores may fail (e.g., no gitgov-state branch yet).
+        // Fall through to projectRoot computation below.
+      }
+
       if (!this.projectRoot) {
         const root = findProjectRoot();
         if (!root) {

--- a/packages/cli/src/services/dependency-injection.ts
+++ b/packages/cli/src/services/dependency-injection.ts
@@ -1,8 +1,7 @@
 import * as path from 'path';
 import * as os from 'os';
-import { createHash } from 'crypto';
 import { Adapters, Config, Session, EventBus, Lint, Git, SourceAuditor, FindingDetector, Runner, KeyProvider, RecordProjection, RecordMetrics, AuditOrchestrator, PolicyEvaluator } from '@gitgov/core';
-import { FsRecordStore, DEFAULT_ID_ENCODER, FsFileLister, FsProjectInitializer, FsLintModule, FsWorktreeSyncStateModule, GitModule, createAgentRunner, createConfigManager, findProjectRoot, createSessionManager, FsRecordProjection } from '@gitgov/core/fs';
+import { FsRecordStore, DEFAULT_ID_ENCODER, FsFileLister, FsProjectInitializer, FsLintModule, FsWorktreeSyncStateModule, GitModule, createAgentRunner, createConfigManager, findProjectRoot, createSessionManager, FsRecordProjection, getWorktreeBasePath } from '@gitgov/core/fs';
 import type { IFsLintModule } from '@gitgov/core/fs';
 import type {
   GitGovTaskRecord, GitGovCycleRecord, GitGovFeedbackRecord, GitGovExecutionRecord, GitGovActorRecord, GitGovAgentRecord,
@@ -66,12 +65,6 @@ export class DependencyInjectionService {
     return DependencyInjectionService.instance;
   }
 
-  /** Compute worktree base path from repo root */
-  static getWorktreeBasePath(repoRoot: string): string {
-    const hash = createHash('sha256').update(repoRoot).digest('hex').slice(0, 12);
-    return path.join(os.homedir(), '.gitgov', 'worktrees', hash);
-  }
-
   /**
    * Configure DI for init mode — sets projectRoot to worktree path,
    * bypassing .gitgov discovery and bootstrap.
@@ -79,7 +72,7 @@ export class DependencyInjectionService {
    */
   setInitMode(projectRoot: string): void {
     this.repoRoot = projectRoot;
-    this.projectRoot = DependencyInjectionService.getWorktreeBasePath(projectRoot);
+    this.projectRoot = getWorktreeBasePath(projectRoot);
     this.initModeEnabled = true;
   }
 
@@ -109,7 +102,7 @@ export class DependencyInjectionService {
 
       const gitModule = await this.getGitModule();
       const repoRoot = await gitModule.getRepoRoot();
-      const worktreeBasePath = DependencyInjectionService.getWorktreeBasePath(repoRoot);
+      const worktreeBasePath = getWorktreeBasePath(repoRoot);
       const gitgovPath = path.join(worktreeBasePath, '.gitgov');
 
       // [CLIINT-A1] Check if worktree .gitgov/ exists
@@ -356,14 +349,14 @@ export class DependencyInjectionService {
       const eventBus = new EventBus.EventBus();
 
       // Create KeyProvider for filesystem-based key storage
-      const keyProvider = new KeyProvider.FsKeyProvider({
+      this.keyProvider = new KeyProvider.FsKeyProvider({
         keysDir: path.join(this.projectRoot!, '.gitgov', 'keys')
       });
 
       // Create IdentityAdapter with dependencies
       return new Adapters.IdentityAdapter({
         stores: { actors: this.stores.actors },
-        keyProvider,
+        keyProvider: this.keyProvider,
         sessionManager: await this.getSessionManager(),
         eventBus,
       });
@@ -955,7 +948,7 @@ export class DependencyInjectionService {
           throw new Error("Could not find project root");
         }
         this.repoRoot = root;
-        this.projectRoot = DependencyInjectionService.getWorktreeBasePath(root);
+        this.projectRoot = getWorktreeBasePath(root);
       }
 
       // Create ConfigManager instance using factory function
@@ -991,7 +984,7 @@ export class DependencyInjectionService {
           throw new Error("Could not find project root");
         }
         this.repoRoot = root;
-        this.projectRoot = DependencyInjectionService.getWorktreeBasePath(root);
+        this.projectRoot = getWorktreeBasePath(root);
       }
 
       this.sessionManager = createSessionManager(this.projectRoot);
@@ -1046,7 +1039,7 @@ export class DependencyInjectionService {
           return false;
         }
         this.repoRoot = root;
-        this.projectRoot = DependencyInjectionService.getWorktreeBasePath(root);
+        this.projectRoot = getWorktreeBasePath(root);
       }
 
       // [CLIINT-A3] Check if worktree .gitgov directory exists

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
@@ -364,7 +364,7 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
   });
 
   describe('revokeActor', () => {
-    it('[EARS-D1] should revoke an existing actor', async () => {
+    it('[EARS-D1] should revoke an existing actor and sign the revocation', async () => {
       const existingRecord = { ...sampleRecord };
       mockActorStore.get.mockResolvedValue(existingRecord);
       mockActorStore.put.mockResolvedValue(undefined);
@@ -373,8 +373,37 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
       const result = await identityAdapter.revokeActor('human:test-user', 'human:test-user');
 
       expect(mockActorStore.get).toHaveBeenCalledWith('human:test-user');
-      expect(mockActorStore.put).toHaveBeenCalled();
       expect(result.status).toBe('revoked');
+
+      // [IKS-SUC1] Verify revocation signature REPLACES original (§6.5)
+      const putCall = mockActorStore.put.mock.calls[0]!;
+      const storedRecord = putCall[1];
+      expect(storedRecord.header.signatures).toHaveLength(1);
+      const revocationSig = storedRecord.header.signatures[0]!;
+      expect(revocationSig.keyId).toBe('human:test-user');
+      expect(revocationSig.role).toBe('author');
+      expect(revocationSig.notes).toContain('Revoking');
+      expect(storedRecord.header.payloadChecksum).toBe('new-checksum');
+    });
+
+    it('[EARS-D1b] should sign revocation with the revokedBy actor keyId', async () => {
+      const existingRecord = { ...sampleRecord };
+      mockActorStore.get.mockResolvedValue(existingRecord);
+      mockActorStore.put.mockResolvedValue(undefined);
+      mockedCalculatePayloadChecksum.mockReturnValue('admin-revoke-checksum');
+
+      await identityAdapter.revokeActor('human:test-user', 'human:admin', 'compromised');
+
+      expect(mockKeyProvider.sign).toHaveBeenCalledWith(
+        'human:admin',
+        expect.any(Uint8Array)
+      );
+      const putCall = mockActorStore.put.mock.calls[0]!;
+      const storedRecord = putCall[1];
+      expect(storedRecord.header.signatures).toHaveLength(1);
+      const revocationSig = storedRecord.header.signatures[0]!;
+      expect(revocationSig.keyId).toBe('human:admin');
+      expect(revocationSig.notes).toContain('compromised');
     });
 
     it('[EARS-D2] should throw error when actor does not exist', async () => {
@@ -596,6 +625,71 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
       expect(mockKeyProvider.setPrivateKey).toHaveBeenCalledWith(
         newActorId,
         newPrivateKey
+      );
+    });
+
+    it('[EARS-F1b] should sign new actor with OLD actorId as keyId (IKS-SUC2)', async () => {
+      const pubKey = 'NEW_PUBLIC_KEY_BASE64_44_CHARS_LONG_AAAAAAAAAAA=';
+      const privKey = 'new-private-key-base64';
+      const successorId = 'human:new-test-user-v2';
+
+      jest.spyOn(identityAdapter, 'getActor').mockResolvedValue(sampleActorPayload);
+      mockedGenerateKeys.mockResolvedValueOnce({ publicKey: pubKey, privateKey: privKey });
+      mockedGenerateActorId.mockReturnValueOnce(successorId);
+      mockedCreateActorRecord.mockReturnValueOnce({ ...sampleActorPayload, id: successorId, publicKey: pubKey });
+      mockedCalculatePayloadChecksum.mockReturnValueOnce('new-checksum');
+      mockedValidateFullActorRecord.mockResolvedValueOnce(undefined);
+      mockActorStore.put.mockResolvedValue(undefined);
+      mockActorStore.get
+        .mockResolvedValueOnce(sampleRecord)
+        .mockResolvedValueOnce(sampleRecord);
+
+      await identityAdapter.rotateActorKey('human:test-user');
+
+      // [IKS-SUC2] Verify keyProvider.sign was called with OLD actorId for the new actor signature
+      expect(mockKeyProvider.sign).toHaveBeenCalledWith(
+        'human:test-user',
+        expect.any(Uint8Array)
+      );
+
+      // Verify new actor record was stored with signature using old actorId as keyId
+      const firstPutCall = mockActorStore.put.mock.calls[0]!;
+      const newActorRecord = firstPutCall[1];
+      expect(newActorRecord.header.signatures[0].keyId).toBe('human:test-user');
+      expect(newActorRecord.header.signatures[0].notes).toContain('successor of human:test-user');
+    });
+
+    it('[EARS-F1b] should accept external keys instead of generating (IKS-SUC3)', async () => {
+      const externalPublicKey = 'external-pub-key-base64-xxxxxxxxxxxxxxx=';
+      const externalPrivateKey = 'external-priv-key-base64-xxxxxxxxxxxxxx=';
+      const baseId = 'human:new-test-user';
+      const successorId = 'human:new-test-user-v2';
+
+      jest.spyOn(identityAdapter, 'getActor').mockResolvedValue(sampleActorPayload);
+      mockedGenerateActorId.mockReturnValueOnce(baseId);
+      mockedCreateActorRecord.mockReturnValueOnce({ ...sampleActorPayload, id: successorId, publicKey: externalPublicKey });
+      mockedCalculatePayloadChecksum.mockReturnValueOnce('ext-checksum');
+      mockedValidateFullActorRecord.mockResolvedValueOnce(undefined);
+      mockActorStore.put.mockResolvedValue(undefined);
+      mockActorStore.get
+        .mockResolvedValueOnce(sampleRecord)
+        .mockResolvedValueOnce(sampleRecord);
+
+      const result = await identityAdapter.rotateActorKey('human:test-user', {
+        newPublicKey: externalPublicKey,
+        newPrivateKey: externalPrivateKey,
+      });
+
+      // [IKS-SUC3] Verify generateKeys was NOT called (external keys used)
+      expect(mockedGenerateKeys).not.toHaveBeenCalled();
+
+      // Verify new actor uses the provided external key
+      expect(result.newActor.publicKey).toBe(externalPublicKey);
+
+      // Verify the external private key was persisted
+      expect(mockKeyProvider.setPrivateKey).toHaveBeenCalledWith(
+        successorId,
+        externalPrivateKey,
       );
     });
 

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
@@ -251,6 +251,63 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
       console.warn = originalWarn;
     });
 
+    it('[EARS-C1+IKS-A46] should succeed when constructed WITHOUT sessionManager (pre-P9 cleanup positive path)', async () => {
+      // Construct an adapter without sessionManager — the saas-api Remote Init pattern.
+      // Post-IKS-A46 pre-P9 cleanup, sessionManager is optional in IdentityAdapterDependencies.
+      // createActor does NOT touch sessionManager, so construction + createActor must succeed.
+      const adapterWithoutSession = new IdentityAdapter({
+        stores: { actors: mockActorStore },
+        keyProvider: mockKeyProvider,
+        // sessionManager omitted intentionally
+      });
+
+      const inputPayload = {
+        type: 'human' as const,
+        displayName: 'Remote Init User',
+        roles: ['author'] as [string, ...string[]]
+      };
+
+      mockedGenerateKeys.mockResolvedValue({
+        publicKey: 'remote-init-public-key',
+        privateKey: 'remote-init-private-key'
+      });
+      mockedGenerateActorId.mockReturnValue('human:remote-init-user');
+      mockedCreateActorRecord.mockReturnValue({
+        ...sampleActorPayload,
+        id: 'human:remote-init-user',
+        displayName: 'Remote Init User',
+        publicKey: 'remote-init-public-key',
+      });
+      mockedCalculatePayloadChecksum.mockReturnValue('checksum');
+      mockedSignPayload.mockReturnValue({
+        keyId: 'human:remote-init-user',
+        role: 'author',
+        notes: 'Actor registration',
+        signature: 'remote-init-signature',
+        timestamp: 1234567890
+      });
+      mockedValidateFullActorRecord.mockResolvedValue(undefined);
+      mockActorStore.put.mockResolvedValue(undefined);
+
+      const originalWarn = console.warn;
+      console.warn = jest.fn();
+
+      // Must NOT throw — createActor is sessionManager-independent
+      const result = await adapterWithoutSession.createActor(inputPayload, 'human:remote-init-user');
+
+      expect(result.id).toBe('human:remote-init-user');
+      expect(mockActorStore.put).toHaveBeenCalled();
+      expect(mockKeyProvider.setPrivateKey).toHaveBeenCalledWith(
+        'human:remote-init-user',
+        'remote-init-private-key'
+      );
+      // sessionManager was never touched (no stub to call)
+      expect(mockSessionManager.loadSession).not.toHaveBeenCalled();
+      expect(mockSessionManager.getActorState).not.toHaveBeenCalled();
+
+      console.warn = originalWarn;
+    });
+
     it('[EARS-C3] should persist private key via KeyProvider', async () => {
       const inputPayload = {
         type: 'human' as const,
@@ -555,6 +612,57 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
 
       await expect(identityAdapter.rotateActorKey('human:test-user'))
         .rejects.toThrow('Cannot rotate key for revoked actor: human:test-user');
+    });
+
+    it('[EARS-F8] should succeed without sessionManager, skipping actorState migration (IKS-A46 pre-P9 cleanup)', async () => {
+      // Construct adapter WITHOUT sessionManager — the saas-api Remote Init pattern
+      const adapterWithoutSession = new IdentityAdapter({
+        stores: { actors: mockActorStore },
+        keyProvider: mockKeyProvider,
+        // sessionManager omitted intentionally
+      });
+
+      const existingActor = sampleActorPayload;
+      const baseActorId = 'human:new-test-user';
+      const newActorId = 'human:new-test-user-v2';
+      const newPublicKey = 'NEW_PUBLIC_KEY_BASE64_44_CHARS_LONG_AAAAAAAAAAA=';
+      const newPrivateKey = 'new-private-key-base64';
+
+      jest.spyOn(adapterWithoutSession, 'getActor').mockResolvedValue(existingActor);
+      mockedGenerateKeys.mockResolvedValueOnce({
+        publicKey: newPublicKey,
+        privateKey: newPrivateKey
+      });
+      mockedGenerateActorId.mockReturnValueOnce(baseActorId);
+      mockedCreateActorRecord.mockReturnValueOnce({
+        ...existingActor,
+        id: newActorId,
+        publicKey: newPublicKey
+      });
+      mockedCalculatePayloadChecksum.mockReturnValueOnce('new-checksum');
+      mockedSignPayload.mockReturnValueOnce({
+        keyId: newActorId,
+        role: 'author',
+        notes: 'Key rotation',
+        signature: 'new-signature',
+        timestamp: Date.now()
+      });
+      mockedValidateFullActorRecord.mockResolvedValueOnce(undefined);
+      mockActorStore.put.mockResolvedValue(undefined);
+      mockActorStore.list.mockResolvedValue(['human:test-user']);
+      mockActorStore.get
+        .mockResolvedValueOnce(sampleRecord)
+        .mockResolvedValueOnce(sampleRecord);
+
+      const result = await adapterWithoutSession.rotateActorKey('human:test-user');
+
+      // Rotation succeeds: new actor created, old revoked, key persisted
+      expect(result.oldActor.status).toBe('revoked');
+      expect(result.newActor.id).toBe(newActorId);
+      expect(mockKeyProvider.setPrivateKey).toHaveBeenCalledWith(newActorId, newPrivateKey);
+      // sessionManager methods were NEVER invoked — the `if (this.sessionManager)` block skipped
+      expect(mockSessionManager.getActorState).not.toHaveBeenCalled();
+      expect(mockSessionManager.updateActorState).not.toHaveBeenCalled();
     });
 
     it('[EARS-F4] should throw error if validateFullActorRecord fails', async () => {
@@ -880,6 +988,20 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
 
       await expect(identityAdapter.getCurrentActor())
         .rejects.toThrow("❌ No active actors found. Run 'gitgov init' first.");
+    });
+
+    it('[EARS-M4] should throw clear error when sessionManager is undefined (IKS-A46 pre-P9 cleanup)', async () => {
+      // Construct an adapter WITHOUT sessionManager (post-IKS-A46 pre-P9 cleanup: optional field)
+      const adapterWithoutSession = new IdentityAdapter({
+        stores: { actors: mockActorStore },
+        keyProvider: mockKeyProvider,
+        // sessionManager omitted intentionally — this is the saas-api Remote Init pattern
+      });
+
+      await expect(adapterWithoutSession.getCurrentActor())
+        .rejects.toThrow(
+          'IdentityAdapter.getCurrentActor requires a sessionManager. Construct the adapter with { sessionManager } to use this method.'
+        );
     });
   });
 

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
@@ -14,7 +14,13 @@ jest.mock('../../record_factories/actor_factory');
 jest.mock('../../record_validations/actor_validator');
 jest.mock('../../crypto/signatures');
 jest.mock('../../crypto/checksum');
-jest.mock('../../utils/id_generator');
+jest.mock('../../utils/id_generator', () => {
+  const actual = jest.requireActual('../../utils/id_generator');
+  return {
+    ...actual,
+    generateActorId: jest.fn(),
+  };
+});
 
 import type { KeyProvider } from '../../key_provider/key_provider';
 

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.test.ts
@@ -370,7 +370,7 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
       mockActorStore.put.mockResolvedValue(undefined);
       mockedCalculatePayloadChecksum.mockReturnValue('new-checksum');
 
-      const result = await identityAdapter.revokeActor('human:test-user');
+      const result = await identityAdapter.revokeActor('human:test-user', 'human:test-user');
 
       expect(mockActorStore.get).toHaveBeenCalledWith('human:test-user');
       expect(mockActorStore.put).toHaveBeenCalled();
@@ -380,7 +380,7 @@ describe('IdentityAdapter - ActorRecord Operations', () => {
     it('[EARS-D2] should throw error when actor does not exist', async () => {
       mockActorStore.get.mockResolvedValue(null);
 
-      await expect(identityAdapter.revokeActor('non-existent'))
+      await expect(identityAdapter.revokeActor('non-existent', 'human:admin'))
         .rejects.toThrow('ActorRecord with id non-existent not found');
     });
   });

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.ts
@@ -290,7 +290,8 @@ export class IdentityAdapter implements IIdentityAdapter {
   }
 
   async rotateActorKey(
-    actorId: string
+    actorId: string,
+    options?: { newPublicKey?: string; newPrivateKey?: string }
   ): Promise<{ oldActor: ActorRecord; newActor: ActorRecord }> {
     // Read existing actor
     const oldActor = await this.getActor(actorId);
@@ -302,8 +303,17 @@ export class IdentityAdapter implements IIdentityAdapter {
       throw new Error(`Cannot rotate key for revoked actor: ${actorId}`);
     }
 
-    // Generate new keys for the new actor
-    const { publicKey: newPublicKey, privateKey: newPrivateKey } = await generateKeys();
+    // [IKS-SUC3] Use provided keys or generate new ones
+    let newPublicKey: string;
+    let newPrivateKey: string;
+    if (options?.newPublicKey && options?.newPrivateKey) {
+      newPublicKey = options.newPublicKey;
+      newPrivateKey = options.newPrivateKey;
+    } else {
+      const generated = await generateKeys();
+      newPublicKey = generated.publicKey;
+      newPrivateKey = generated.privateKey;
+    }
 
     // Generate new actor ID following the pattern from actor_protocol_faq.md
     // Pattern: {baseId}-v{N} where N is the version number (using hyphens to match schema pattern)
@@ -338,8 +348,12 @@ export class IdentityAdapter implements IIdentityAdapter {
     // Calculate checksum for the new payload
     const payloadChecksum = calculatePayloadChecksum(validatedNewPayload);
 
-    // Create signature for the new record (self-signed for bootstrap)
-    const signature = signPayload(validatedNewPayload, newPrivateKey, newActorId, 'author', 'Key rotation');
+    // [IKS-SUC2] Sign new actor with OLD key (proof of ownership per RFC-02 §6.3).
+    // The old key proves "I, human:camilo, authorize human:camilo-v2 as my successor."
+    const notes = `Key rotation — successor of ${actorId}`;
+    const successorSignature = await this.createSignature(
+      payloadChecksum, actorId, 'author', notes
+    );
 
     // Create the complete GitGovRecord structure for new actor
     const newRecord: GitGovActorRecord = {
@@ -347,15 +361,15 @@ export class IdentityAdapter implements IIdentityAdapter {
         version: '1.0',
         type: 'actor',
         payloadChecksum,
-        signatures: [signature]
+        signatures: [successorSignature]
       },
       payload: validatedNewPayload
     };
 
-    // Validate the complete new record
+    // Validate the complete new record using old actor's public key
     await validateFullActorRecord(newRecord, async (keyId) => {
-      if (keyId === newActorId) {
-        return newPublicKey; // Self-referential for bootstrap
+      if (keyId === actorId) {
+        return oldActor.publicKey;
       }
       const signerActor = await this.getActor(keyId);
       return signerActor?.publicKey || null;
@@ -364,12 +378,12 @@ export class IdentityAdapter implements IIdentityAdapter {
     // Store the new actor record
     await this.stores.actors.put(newRecord.payload.id, newRecord);
 
-    // Revoke old actor and mark succession
+    // Revoke old actor and mark succession — signed with OLD key (still available)
     const revokedOldActor = await this.revokeActor(
       actorId,
-      'system',
+      actorId,
       'rotation',
-      newActorId // Mark succession
+      newActorId
     );
 
     // Update session to point to the new actor using SessionManager.
@@ -407,7 +421,7 @@ export class IdentityAdapter implements IIdentityAdapter {
     };
   }
 
-  async revokeActor(actorId: string, revokedBy: string = "system", reason: "compromised" | "rotation" | "manual" = "manual", supersededBy?: string): Promise<ActorRecord> {
+  async revokeActor(actorId: string, revokedBy: string, reason: "compromised" | "rotation" | "manual" = "manual", supersededBy?: string): Promise<ActorRecord> {
     // Read the existing actor
     const existingRecord = await this.stores.actors.get(actorId);
     if (!existingRecord) {
@@ -421,15 +435,23 @@ export class IdentityAdapter implements IIdentityAdapter {
       ...(supersededBy && { supersededBy })
     };
 
-    // Calculate new checksum for the updated payload
+    // [IKS-SUC1] Calculate new checksum and sign the revocation with the revoker's key.
+    // The original creation signatures remain for historical verification (RFC-02 §10.4).
     const payloadChecksum = calculatePayloadChecksum(revokedPayload);
+    const notes = supersededBy
+      ? `Revoking after key ${reason} — successor is ${supersededBy}`
+      : `Revoking: ${reason}`;
+    const revocationSignature = await this.createSignature(
+      payloadChecksum, revokedBy, 'author', notes
+    );
 
-    // Create updated record
+    // Create updated record with revocation signature appended
     const updatedRecord: GitGovActorRecord = {
       ...existingRecord,
       header: {
         ...existingRecord.header,
-        payloadChecksum
+        payloadChecksum,
+        signatures: [...existingRecord.header.signatures, revocationSignature],
       },
       payload: revokedPayload
     };
@@ -459,6 +481,26 @@ export class IdentityAdapter implements IIdentityAdapter {
     }
 
     return revokedPayload;
+  }
+
+  private async createSignature(
+    payloadChecksum: string,
+    signerActorId: string,
+    role: string,
+    notes: string,
+  ): Promise<Signature> {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const digest = `${payloadChecksum}:${signerActorId}:${role}:${notes}:${timestamp}`;
+    const digestHash = createHash('sha256').update(digest).digest();
+    const signatureBytes = await this.keyProvider.sign(signerActorId, new Uint8Array(digestHash));
+
+    return {
+      keyId: signerActorId,
+      role,
+      notes,
+      signature: Buffer.from(signatureBytes).toString('base64'),
+      timestamp,
+    };
   }
 
   async authenticate(_sessionToken: string): Promise<void> {

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.ts
@@ -18,7 +18,7 @@ import { createActorRecord } from '../../record_factories/actor_factory';
 import { validateFullActorRecord } from '../../record_validations/actor_validator';
 import { generateKeys, signPayload, buildSignatureDigest } from '../../crypto/signatures';
 import { calculatePayloadChecksum } from '../../crypto/checksum';
-import { generateActorId } from '../../utils/id_generator';
+import { generateActorId, computeSuccessorActorId } from '../../utils/id_generator';
 import type { ISessionManager } from '../../session_manager';
 
 export class IdentityAdapter implements IIdentityAdapter {
@@ -315,20 +315,8 @@ export class IdentityAdapter implements IIdentityAdapter {
 
     // Generate new actor ID following the pattern from actor_protocol_faq.md
     // Pattern: {baseId}-v{N} where N is the version number (using hyphens to match schema pattern)
-    // Schema pattern: ^(human|agent)(:[a-z0-9-]+)+$ (only allows hyphens, not underscores)
     const baseId = generateActorId(oldActor.type, oldActor.displayName);
-    let newActorId: string;
-
-    // Check if baseId already has a version suffix (e.g., human:camilo-v2)
-    const versionMatch = baseId.match(/^(.+)-v(\d+)$/);
-    if (versionMatch && versionMatch[1] && versionMatch[2]) {
-      const baseWithoutVersion = versionMatch[1];
-      const currentVersion = parseInt(versionMatch[2], 10);
-      newActorId = `${baseWithoutVersion}-v${currentVersion + 1}`;
-    } else {
-      // First rotation: add -v2
-      newActorId = `${baseId}-v2`;
-    }
+    const newActorId = computeSuccessorActorId(baseId);
 
     // Create new actor with same metadata but new keys
     const newActorPayload: ActorRecord = {

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.ts
@@ -25,7 +25,10 @@ import type { ISessionManager } from '../../session_manager';
 export class IdentityAdapter implements IIdentityAdapter {
   private stores: Required<Pick<RecordStores, 'actors'>>;
   private keyProvider: KeyProvider;
-  private sessionManager: ISessionManager;
+  // Optional as of IKS-A46 pre-P9 cleanup. Only `getCurrentActor()` and
+  // `rotateActorKey()` consume it; callers that never use those methods
+  // (e.g., GitHubRemoteInitService) can omit it at construction time.
+  private sessionManager: ISessionManager | undefined;
   private eventBus: IEventStream | undefined;
 
   constructor(dependencies: IdentityAdapterDependencies) {
@@ -242,6 +245,16 @@ export class IdentityAdapter implements IIdentityAdapter {
    * @returns Promise<ActorRecord> - The current active ActorRecord
    */
   async getCurrentActor(): Promise<ActorRecord> {
+    // sessionManager is required for this method — throw if omitted.
+    // IdentityAdapter accepts an optional sessionManager (IKS-A46 pre-P9
+    // cleanup) because createActor/signRecord/etc. don't need it. But
+    // getCurrentActor resolves "who is logged in" — that requires a session.
+    if (!this.sessionManager) {
+      throw new Error(
+        'IdentityAdapter.getCurrentActor requires a sessionManager. ' +
+        'Construct the adapter with { sessionManager } to use this method.',
+      );
+    }
     // 1. Try to get from session
     const session = await this.sessionManager.loadSession();
 
@@ -359,19 +372,26 @@ export class IdentityAdapter implements IIdentityAdapter {
       newActorId // Mark succession
     );
 
-    // Update session to point to the new actor using SessionManager
-    try {
-      // Migrate actorState from old actor to new actor
-      const oldState = await this.sessionManager.getActorState(actorId);
-      if (oldState) {
-        await this.sessionManager.updateActorState(newActorId, oldState);
-      } else {
-        // Create initial state for new actor
-        await this.sessionManager.updateActorState(newActorId, {});
+    // Update session to point to the new actor using SessionManager.
+    // IKS-A46 pre-P9 cleanup: sessionManager is optional on the adapter. If
+    // omitted (e.g., saas-api Remote Init context), skip the state migration
+    // entirely — there is no local session store to update. The new keypair
+    // still persists via keyProvider.setPrivateKey below, so rotation itself
+    // succeeds; only the cached actor state is not migrated.
+    if (this.sessionManager) {
+      try {
+        // Migrate actorState from old actor to new actor
+        const oldState = await this.sessionManager.getActorState(actorId);
+        if (oldState) {
+          await this.sessionManager.updateActorState(newActorId, oldState);
+        } else {
+          // Create initial state for new actor
+          await this.sessionManager.updateActorState(newActorId, {});
+        }
+      } catch (error) {
+        // Non-critical: session update failure logged as warning
+        console.warn(`⚠️  Could not update session for ${newActorId}: ${error instanceof Error ? error.message : 'Unknown error'}`);
       }
-    } catch (error) {
-      // Non-critical: session update failure logged as warning
-      console.warn(`⚠️  Could not update session for ${newActorId}: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
 
     // Persist new private key via KeyProvider

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.ts
@@ -16,8 +16,7 @@ import type { IIdentityAdapter, IdentityAdapterDependencies } from './identity_a
 
 import { createActorRecord } from '../../record_factories/actor_factory';
 import { validateFullActorRecord } from '../../record_validations/actor_validator';
-import { generateKeys, signPayload } from '../../crypto/signatures';
-import { createHash } from 'crypto';
+import { generateKeys, signPayload, buildSignatureDigest } from '../../crypto/signatures';
 import { calculatePayloadChecksum } from '../../crypto/checksum';
 import { generateActorId } from '../../utils/id_generator';
 import type { ISessionManager } from '../../session_manager';
@@ -172,11 +171,10 @@ export class IdentityAdapter implements IIdentityAdapter {
       throw new Error(`Actor not found: ${actorId}`);
     }
 
-    // [EARS-E1] Calculate payload checksum and build digest
+    // [EARS-E1] Calculate payload checksum and build digest via crypto primitive
     const payloadChecksum = calculatePayloadChecksum(record.payload);
     const timestamp = Math.floor(Date.now() / 1000);
-    const digest = `${payloadChecksum}:${actorId}:${role}:${notes}:${timestamp}`;
-    const digestHash = createHash('sha256').update(digest).digest();
+    const digestHash = buildSignatureDigest(payloadChecksum, actorId, role, notes, timestamp);
 
     // [EARS-E1] [IKS-B7] Delegate signing to keyProvider.sign() — NOT getPrivateKey() + signPayload()
     // [EARS-E2] [IKS-B6] sign() throws KeyProviderError('KEY_NOT_FOUND') if no key exists
@@ -445,13 +443,16 @@ export class IdentityAdapter implements IIdentityAdapter {
       payloadChecksum, revokedBy, 'author', notes
     );
 
-    // Create updated record with revocation signature appended
+    // Create updated record with revocation signature. The original creation
+    // signatures are preserved in git history (previous commit). The current
+    // file state has only the revocation signature, which verifies against
+    // the revoked payload's checksum.
     const updatedRecord: GitGovActorRecord = {
       ...existingRecord,
       header: {
         ...existingRecord.header,
         payloadChecksum,
-        signatures: [...existingRecord.header.signatures, revocationSignature],
+        signatures: [revocationSignature],
       },
       payload: revokedPayload
     };
@@ -490,8 +491,7 @@ export class IdentityAdapter implements IIdentityAdapter {
     notes: string,
   ): Promise<Signature> {
     const timestamp = Math.floor(Date.now() / 1000);
-    const digest = `${payloadChecksum}:${signerActorId}:${role}:${notes}:${timestamp}`;
-    const digestHash = createHash('sha256').update(digest).digest();
+    const digestHash = buildSignatureDigest(payloadChecksum, signerActorId, role, notes, timestamp);
     const signatureBytes = await this.keyProvider.sign(signerActorId, new Uint8Array(digestHash));
 
     return {

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.types.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.types.ts
@@ -19,7 +19,7 @@ export interface IIdentityAdapter {
   createActor(payload: ActorPayload, signerId: string): Promise<ActorRecord>;
   getActor(actorId: string): Promise<ActorRecord | null>;
   listActors(): Promise<ActorRecord[]>;
-  revokeActor(actorId: string, revokedBy?: string, reason?: "compromised" | "rotation" | "manual", supersededBy?: string): Promise<ActorRecord>;
+  revokeActor(actorId: string, revokedBy: string, reason?: "compromised" | "rotation" | "manual", supersededBy?: string): Promise<ActorRecord>;
 
   // Succession Chain Resolution
   resolveCurrentActorId(originalActorId: string): Promise<string>;
@@ -28,7 +28,7 @@ export interface IIdentityAdapter {
 
   // Advanced Operations
   signRecord<T extends GitGovRecord>(record: T, actorId: string, role: string, notes: string): Promise<T>;
-  rotateActorKey(actorId: string): Promise<{ oldActor: ActorRecord; newActor: ActorRecord }>;
+  rotateActorKey(actorId: string, options?: { newPublicKey?: string; newPrivateKey?: string }): Promise<{ oldActor: ActorRecord; newActor: ActorRecord }>;
   authenticate(sessionToken: string): Promise<void>;
   getActorPublicKey(keyId: string): Promise<string | null>;
 }

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.types.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.types.ts
@@ -43,8 +43,12 @@ export interface IdentityAdapterDependencies {
   // Key Management
   keyProvider: KeyProvider;
 
-  // Session Management - Required for getCurrentActor and rotateActorKey
-  sessionManager: ISessionManager;
+  // Session Management — optional (only required by getCurrentActor and
+  // rotateActorKey; createActor/signRecord/getActor/etc. do not need it).
+  // Consumers that only use the sessionManager-independent methods can
+  // omit this field. Added as part of IKS-A46 pre-P9 cleanup to let
+  // `GitHubRemoteInitService` drop its sessionManagerStub workaround.
+  sessionManager?: ISessionManager;
 
   // Optional: Event Bus for event-driven integration (optional dependency)
   eventBus?: IEventStream;

--- a/packages/core/src/adapters/identity_adapter/identity_adapter_succession.test.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter_succession.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration test for key succession with REAL Ed25519 crypto.
+ * No mocks — verifies that rotateActorKey produces records that pass
+ * Three Gates validation offline (IKS-SUC4, EARS-F1c).
+ */
+import { IdentityAdapter } from './identity_adapter';
+import { generateKeys, signPayload, verifySignatures } from '../../crypto/signatures';
+import { calculatePayloadChecksum } from '../../crypto/checksum';
+import { FsKeyProvider } from '../../key_provider/fs/fs_key_provider';
+import type { ActorRecord, GitGovActorRecord } from '../../record_types';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+describe('rotateActorKey — Three Gates with REAL crypto (IKS-SUC4)', () => {
+  let tmpDir: string;
+  let keyProvider: InstanceType<typeof FsKeyProvider>;
+  let actorStore: Record<string, GitGovActorRecord>;
+  let store: { get: jest.Mock; put: jest.Mock; list: jest.Mock; delete: jest.Mock };
+  let oldKeys: { publicKey: string; privateKey: string };
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'suc4-'));
+    keyProvider = new FsKeyProvider({ keysDir: path.join(tmpDir, 'keys') });
+    oldKeys = await generateKeys();
+    await keyProvider.setPrivateKey('human:suc4-test', oldKeys.privateKey);
+
+    actorStore = {};
+    store = {
+      get: jest.fn(async (id: string) => actorStore[id] || null),
+      put: jest.fn(async (id: string, record: GitGovActorRecord) => { actorStore[id] = record; }),
+      list: jest.fn(async () => Object.keys(actorStore)),
+      delete: jest.fn(),
+    };
+
+    const actorPayload: ActorRecord = {
+      id: 'human:suc4-test', type: 'human', displayName: 'SUC4 Test',
+      publicKey: oldKeys.publicKey, roles: ['developer'], status: 'active',
+    };
+    const checksum = calculatePayloadChecksum(actorPayload);
+    const creationSig = signPayload(actorPayload, oldKeys.privateKey, 'human:suc4-test', 'author', 'Genesis');
+    actorStore['human:suc4-test'] = {
+      header: { version: '1.0', type: 'actor', payloadChecksum: checksum, signatures: [creationSig] },
+      payload: actorPayload,
+    };
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('[EARS-F1c] new actor record should pass Three Gates (checksum + signature)', async () => {
+    const adapter = new IdentityAdapter({ stores: { actors: store as any }, keyProvider });
+    const { newActor } = await adapter.rotateActorKey('human:suc4-test');
+
+    const newRecord = actorStore[newActor.id]!;
+    expect(newRecord).toBeDefined();
+
+    // Gate 1: Integrity — payload checksum matches
+    expect(calculatePayloadChecksum(newRecord.payload)).toBe(newRecord.header.payloadChecksum);
+
+    // Gate 2: Schema — has required fields
+    expect(newRecord.payload.id).toContain('v2');
+    expect(newRecord.payload.status).toBe('active');
+    expect(newRecord.payload.publicKey).toHaveLength(44);
+
+    // Gate 3: Authentication — signature verifies with OLD key (proof of ownership)
+    expect(newRecord.header.signatures[0]!.keyId).toBe('human:suc4-test');
+    const valid = await verifySignatures(newRecord, async (keyId) =>
+      keyId === 'human:suc4-test' ? oldKeys.publicKey : null);
+    expect(valid).toBe(true);
+  });
+
+  it('[EARS-D1b] revoked actor record should pass Three Gates (revocation signature only, §6.5)', async () => {
+    const revokedRecord = actorStore['human:suc4-test']!;
+
+    // Gate 1: Integrity
+    expect(calculatePayloadChecksum(revokedRecord.payload)).toBe(revokedRecord.header.payloadChecksum);
+
+    // Revocation metadata
+    expect(revokedRecord.payload.status).toBe('revoked');
+    expect(revokedRecord.payload.supersededBy).toContain('v2');
+
+    // §6.5: revocation signature REPLACES original (1 signature, not 2)
+    expect(revokedRecord.header.signatures).toHaveLength(1);
+    expect(revokedRecord.header.signatures[0]!.notes).toContain('Revoking');
+
+    // Gate 3: Revocation signature verifies with the old key
+    const valid = await verifySignatures(revokedRecord, async (keyId) =>
+      keyId === 'human:suc4-test' ? oldKeys.publicKey : null);
+    expect(valid).toBe(true);
+  });
+
+  it('[EARS-F1b] should work with external keys (IKS-SUC3 + Three Gates)', async () => {
+    // Reset store for a fresh test
+    const freshKeys = await generateKeys();
+    const freshKeyProvider = new FsKeyProvider({ keysDir: path.join(tmpDir, 'keys2') });
+    await freshKeyProvider.setPrivateKey('human:ext-test', freshKeys.privateKey);
+
+    const freshStore: Record<string, GitGovActorRecord> = {};
+    const fStore = {
+      get: jest.fn(async (id: string) => freshStore[id] || null),
+      put: jest.fn(async (id: string, record: GitGovActorRecord) => { freshStore[id] = record; }),
+      list: jest.fn(async () => Object.keys(freshStore)),
+      delete: jest.fn(),
+    };
+
+    const payload: ActorRecord = {
+      id: 'human:ext-test', type: 'human', displayName: 'Ext Test',
+      publicKey: freshKeys.publicKey, roles: ['developer'], status: 'active',
+    };
+    const sig = signPayload(payload, freshKeys.privateKey, 'human:ext-test', 'author', 'Genesis');
+    freshStore['human:ext-test'] = {
+      header: { version: '1.0', type: 'actor', payloadChecksum: calculatePayloadChecksum(payload), signatures: [sig] },
+      payload,
+    };
+
+    // External keys (simulates SaaS providing CLI's uploaded key)
+    const externalKeys = await generateKeys();
+
+    const adapter = new IdentityAdapter({ stores: { actors: fStore as any }, keyProvider: freshKeyProvider });
+    const { newActor } = await adapter.rotateActorKey('human:ext-test', {
+      newPublicKey: externalKeys.publicKey,
+      newPrivateKey: externalKeys.privateKey,
+    });
+
+    // New actor uses external public key
+    expect(newActor.publicKey).toBe(externalKeys.publicKey);
+
+    // Three Gates on new actor
+    const newRecord = freshStore[newActor.id]!;
+    expect(calculatePayloadChecksum(newRecord.payload)).toBe(newRecord.header.payloadChecksum);
+    const valid = await verifySignatures(newRecord, async (keyId) =>
+      keyId === 'human:ext-test' ? freshKeys.publicKey : null);
+    expect(valid).toBe(true);
+  });
+});

--- a/packages/core/src/adapters/project_adapter/project_adapter.test.ts
+++ b/packages/core/src/adapters/project_adapter/project_adapter.test.ts
@@ -164,6 +164,7 @@ describe('ProjectAdapter', () => {
       getActorPath: jest.fn().mockImplementation((actorId: string) => {
         return `/test/project/.gitgov/actors/${actorId}.json`;
       }),
+      finalize: jest.fn().mockResolvedValue(undefined),
     } as jest.Mocked<IProjectInitializer>;
 
     mockFs = fs as jest.Mocked<typeof fs> & { existsSync: jest.MockedFunction<any> };

--- a/packages/core/src/adapters/project_adapter/project_adapter.ts
+++ b/packages/core/src/adapters/project_adapter/project_adapter.ts
@@ -76,11 +76,13 @@ export class ProjectAdapter implements IProjectAdapter {
       // 2.5. [EARS-G1] Copy Agent Prompt to project root for IDE access
       await this.projectInitializer.copyAgentPrompt();
 
-      // 3. Trust Root Creation via IdentityAdapter [EARS-B1]
+      // 3. Trust Root Creation via IdentityAdapter [EARS-B1, EARS-A9]
+      const actorType = (options.type ?? 'human') as 'human' | 'agent';
       const actor = await this.identityAdapter.createActor(
         {
-          type: (options.type ?? 'human') as 'human' | 'agent',
-          displayName: options.actorName || 'Project Owner',
+          ...(options.login && { id: `${actorType}:${options.login}` }),
+          type: actorType,
+          displayName: options.actorName || options.login || 'Project Owner',
           roles: [
             'admin',
             'author',

--- a/packages/core/src/adapters/project_adapter/project_adapter.ts
+++ b/packages/core/src/adapters/project_adapter/project_adapter.ts
@@ -120,6 +120,7 @@ export class ProjectAdapter implements IProjectAdapter {
         projectId,
         projectName: options.name,
         rootCycle: rootCycle.id,
+        ...(options.saasUrl && { saasUrl: options.saasUrl }),
         state: {
           branch: 'gitgov-state',
           sync: {

--- a/packages/core/src/adapters/project_adapter/project_adapter.types.ts
+++ b/packages/core/src/adapters/project_adapter/project_adapter.types.ts
@@ -66,6 +66,8 @@ export type ProjectInitOptions = {
   skipValidation?: boolean;
   /** Verbose logging */
   verbose?: boolean;
+  /** SaaS URL for cloud sync (written to config.json) */
+  saasUrl?: string;
 };
 
 /**

--- a/packages/core/src/adapters/project_adapter/project_adapter.types.ts
+++ b/packages/core/src/adapters/project_adapter/project_adapter.types.ts
@@ -66,6 +66,8 @@ export type ProjectInitOptions = {
   skipValidation?: boolean;
   /** Verbose logging */
   verbose?: boolean;
+  /** GitHub login for actorId generation. actorId = `human:${login}` (IKS-A48) */
+  login?: string;
   /** SaaS URL for cloud sync (written to config.json) */
   saasUrl?: string;
 };

--- a/packages/core/src/crypto/signatures.test.ts
+++ b/packages/core/src/crypto/signatures.test.ts
@@ -1,4 +1,4 @@
-import { generateKeys, signPayload, verifySignatures, derivePublicKey } from './signatures';
+import { generateKeys, signPayload, verifySignatures, derivePublicKey, buildSignatureDigest } from './signatures';
 import type { GitGovRecord, GitGovRecordPayload, GitGovRecordType } from '../record_types';
 import type { ActorRecord } from '../record_types';
 import type { AgentRecord } from '../record_types';
@@ -388,6 +388,60 @@ describe('Crypto Module (Signatures)', () => {
         keyId === 'actor:test' ? derivedPublicKey : null;
 
       await expect(verifySignatures(record, getDerivedKey)).resolves.toBe(true);
+    });
+  });
+
+  describe('4.4. buildSignatureDigest (EARS-18, EARS-19)', () => {
+    it('[EARS-18] should build SHA-256 digest from protocol format string', () => {
+      const { createHash } = require('crypto');
+
+      const checksum = 'abc123def456';
+      const keyId = 'human:camilo';
+      const role = 'author';
+      const notes = 'Test signature';
+      const timestamp = 1752274500;
+
+      const result = buildSignatureDigest(checksum, keyId, role, notes, timestamp);
+
+      // Verify it matches manual computation of the protocol digest format
+      const expectedDigest = `${checksum}:${keyId}:${role}:${notes}:${timestamp}`;
+      const expectedHash = createHash('sha256').update(expectedDigest).digest();
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(result.length).toBe(32); // SHA-256 = 32 bytes
+      expect(result).toEqual(expectedHash);
+    });
+
+    it('[EARS-19] should return identical hash for same parameters (deterministic)', () => {
+      const args = ['checksum-abc', 'human:dev', 'author', 'Some notes', 1700000000] as const;
+
+      const hash1 = buildSignatureDigest(...args);
+      const hash2 = buildSignatureDigest(...args);
+
+      expect(hash1).toEqual(hash2);
+    });
+
+    it('[EARS-18] signPayload should produce signatures verifiable against buildSignatureDigest', async () => {
+      // Ensures signPayload uses buildSignatureDigest internally —
+      // a signature made by signPayload must verify against a digest
+      // reconstructed by buildSignatureDigest with the same parameters.
+      const { publicKey, privateKey } = await generateKeys();
+      const payload = { id: 'task:verify-digest', title: 'test' } as unknown as GitGovRecordPayload;
+
+      const sig = signPayload(payload, privateKey, 'human:test', 'author', 'Digest consistency');
+      const checksum = calculatePayloadChecksum(payload);
+
+      // Reconstruct the digest using buildSignatureDigest
+      const digestHash = buildSignatureDigest(checksum, sig.keyId, sig.role, sig.notes, sig.timestamp);
+
+      // Verify the signature against the reconstructed digest
+      const { verify: ed25519Verify } = require('crypto');
+      const { ed25519PublicKeyToSpki } = require('./signatures');
+      const spkiKey = ed25519PublicKeyToSpki(publicKey);
+      const sigBuffer = Buffer.from(sig.signature, 'base64');
+
+      const isValid = ed25519Verify(null, digestHash, { key: spkiKey, type: 'spki', format: 'der' }, sigBuffer);
+      expect(isValid).toBe(true);
     });
   });
 

--- a/packages/core/src/crypto/signatures.ts
+++ b/packages/core/src/crypto/signatures.ts
@@ -133,7 +133,28 @@ export function deriveHkdfKey(
 }
 
 /**
- * Creates a signature for a given payload.
+ * Builds the SHA-256 digest hash that Ed25519 signatures are computed over.
+ *
+ * The digest string follows the protocol format:
+ *   "{payloadChecksum}:{keyId}:{role}:{notes}:{timestamp}"
+ *
+ * This is a stateless protocol primitive — callers sign the returned hash
+ * using their own signing mechanism (raw key via signPayload, or KeyProvider
+ * via adapter methods).
+ */
+export function buildSignatureDigest(
+  payloadChecksum: string,
+  keyId: string,
+  role: string,
+  notes: string,
+  timestamp: number,
+): Buffer {
+  const digest = `${payloadChecksum}:${keyId}:${role}:${notes}:${timestamp}`;
+  return createHash('sha256').update(digest).digest();
+}
+
+/**
+ * Creates a signature for a given payload using a raw private key.
  */
 export function signPayload(
   payload: GitGovRecordPayload,
@@ -144,10 +165,7 @@ export function signPayload(
 ): Signature {
   const payloadChecksum = calculatePayloadChecksum(payload);
   const timestamp = Math.floor(Date.now() / 1000);
-  const digest = `${payloadChecksum}:${keyId}:${role}:${notes}:${timestamp}`;
-
-  // Per the blueprint, sign the SHA-256 hash of the digest
-  const digestHash = createHash('sha256').update(digest).digest();
+  const digestHash = buildSignatureDigest(payloadChecksum, keyId, role, notes, timestamp);
 
   const signature = sign(null, digestHash, {
     key: Buffer.from(privateKey, 'base64'),

--- a/packages/core/src/git/github/github_git_module.test.ts
+++ b/packages/core/src/git/github/github_git_module.test.ts
@@ -650,11 +650,17 @@ describe('GitHubGitModule', () => {
         .rejects.toThrow(BranchNotFoundError);
     });
 
-    it('[EARS-E3] should throw GitError for HTTP 401 or 403', async () => {
+    it('[EARS-E3] should throw GitHubApiError with PERMISSION_DENIED code for HTTP 401 or 403', async () => {
       mockOctokit.rest.repos.getContent.mockRejectedValue(createOctokitError(403));
 
+      // Backward-compat: GitHubApiError extends GitError, so `toThrow(GitError)` still matches.
       await expect(git.getFileContent('sha', 'file.json')).rejects.toThrow(GitError);
-      await expect(git.getFileContent('sha', 'file.json')).rejects.toThrow(/authentication\/permission error/);
+      await expect(git.getFileContent('sha', 'file.json')).rejects.toThrow(GitHubApiError);
+      await expect(git.getFileContent('sha', 'file.json')).rejects.toMatchObject({
+        name: 'GitHubApiError',
+        code: 'PERMISSION_DENIED',
+        statusCode: 403,
+      });
     });
 
     it('[EARS-E4] should throw appropriate error for HTTP 422', async () => {
@@ -685,28 +691,45 @@ describe('GitHubGitModule', () => {
       }).rejects.toThrow(/non-fast-forward/);
     });
 
-    it('[EARS-E5] should throw GitError for network failures', async () => {
+    it('[EARS-E5] should throw GitHubApiError with NETWORK_ERROR code for network failures', async () => {
       mockOctokit.rest.repos.getContent.mockRejectedValue(new TypeError('fetch failed'));
 
       await expect(git.getFileContent('sha', 'file.json')).rejects.toThrow(GitError);
-      await expect(git.getFileContent('sha', 'file.json')).rejects.toThrow(/network error/);
+      await expect(git.getFileContent('sha', 'file.json')).rejects.toThrow(GitHubApiError);
+      await expect(git.getFileContent('sha', 'file.json')).rejects.toMatchObject({
+        name: 'GitHubApiError',
+        code: 'NETWORK_ERROR',
+      });
     });
 
-    it('[EARS-E3] should translate HTTP 403 to GitError during commit transaction', async () => {
+    it('[EARS-E3] should translate HTTP 403 to GitHubApiError PERMISSION_DENIED during commit transaction', async () => {
       await git.add(['file.json'], { contentMap: { 'file.json': 'content' } });
       // Step 1 (getRef) fails with 403
       mockOctokit.rest.git.getRef.mockRejectedValue(createOctokitError(403));
 
       await expect(git.commit('test')).rejects.toThrow(GitError);
-      await expect(git.commit('test')).rejects.toThrow(/authentication\/permission error/);
+      // Re-stage because the previous commit attempt threw
+      await git.add(['file.json'], { contentMap: { 'file.json': 'content' } });
+      mockOctokit.rest.git.getRef.mockRejectedValue(createOctokitError(403));
+      await expect(git.commit('test')).rejects.toMatchObject({
+        name: 'GitHubApiError',
+        code: 'PERMISSION_DENIED',
+        statusCode: 403,
+      });
     });
 
-    it('[EARS-E5] should translate network error to GitError during commit transaction', async () => {
+    it('[EARS-E5] should translate network error to GitHubApiError NETWORK_ERROR during commit transaction', async () => {
       await git.add(['file.json'], { contentMap: { 'file.json': 'content' } });
       mockOctokit.rest.git.getRef.mockRejectedValue(new TypeError('fetch failed'));
 
       await expect(git.commit('test')).rejects.toThrow(GitError);
-      await expect(git.commit('test')).rejects.toThrow(/network error/);
+      // Re-stage because the previous commit attempt threw
+      await git.add(['file.json'], { contentMap: { 'file.json': 'content' } });
+      mockOctokit.rest.git.getRef.mockRejectedValue(new TypeError('fetch failed'));
+      await expect(git.commit('test')).rejects.toMatchObject({
+        name: 'GitHubApiError',
+        code: 'NETWORK_ERROR',
+      });
     });
   });
 

--- a/packages/core/src/git/github/github_git_module.test.ts
+++ b/packages/core/src/git/github/github_git_module.test.ts
@@ -21,9 +21,11 @@ import { GitHubApiError } from '../../github';
 
 // ==================== Test Helpers ====================
 
-type MockOctokit = Octokit & {
+type MockOctokit = {
+  request: ReturnType<typeof jest.fn>;
   rest: {
     repos: {
+      get: jest.MockedFunction<any>;
       getContent: jest.MockedFunction<any>;
       compareCommits: jest.MockedFunction<any>;
       listCommits: jest.MockedFunction<any>;
@@ -49,6 +51,7 @@ function createMockOctokit(): MockOctokit {
   return {
     rest: {
       repos: {
+        get: jest.fn(),
         getContent: jest.fn(),
         compareCommits: jest.fn(),
         listCommits: jest.fn(),
@@ -68,7 +71,8 @@ function createMockOctokit(): MockOctokit {
         updateRef: jest.fn(),
       },
     },
-  } as unknown as MockOctokit;
+    request: jest.fn(),
+  } as MockOctokit;
 }
 
 function createOctokitError(status: number, message = 'Error'): Error & { status: number } {
@@ -552,6 +556,36 @@ describe('GitHubGitModule', () => {
         .rejects.toThrow(BranchAlreadyExistsError);
     });
 
+    it('[EARS-C6b] should fall back to repo default branch when activeRef does not exist', async () => {
+      // activeRef is 'gitgov-state' (from defaultBranch) — doesn't exist yet
+      mockOctokit.rest.git.getRef
+        .mockRejectedValueOnce(createOctokitError(404, 'Not Found'))
+        // Second call resolves 'main' branch
+        .mockResolvedValueOnce({
+          data: { object: { sha: 'main-sha-456' } },
+        });
+      // repos.get returns the repo's actual default branch
+      mockOctokit.rest.repos.get.mockResolvedValue({
+        data: { default_branch: 'main' },
+      });
+      mockOctokit.rest.git.createRef.mockResolvedValue({
+        data: { ref: 'refs/heads/gitgov-state', object: { sha: 'main-sha-456' } },
+      });
+
+      await git.createBranch('gitgov-state');
+
+      expect(mockOctokit.rest.repos.get).toHaveBeenCalledWith({
+        owner: 'test-org',
+        repo: 'test-repo',
+      });
+      expect(mockOctokit.rest.git.createRef).toHaveBeenCalledWith({
+        owner: 'test-org',
+        repo: 'test-repo',
+        ref: 'refs/heads/gitgov-state',
+        sha: 'main-sha-456',
+      });
+    });
+
     it('[EARS-C7] should return staged file paths from buffer', async () => {
       await git.add(['a.json', 'b.json'], {
         contentMap: { 'a.json': 'a', 'b.json': 'b' },
@@ -736,38 +770,40 @@ describe('GitHubGitModule', () => {
   // ==================== 4.6. Branch Deletion (EARS-F1 to F2) — Cycle 5 identity_key_sync (IKS-A41) ====================
 
   describe('4.6. Branch Deletion (EARS-F1 to F2)', () => {
-    it('[EARS-F1] should call octokit.rest.git.deleteRef and return on success', async () => {
-      mockOctokit.rest.git.deleteRef.mockResolvedValue({ data: undefined });
+    it('[EARS-F1] should delete branch via octokit.request and return on success', async () => {
+      mockOctokit.request.mockResolvedValue({ data: undefined });
 
       await expect(git.deleteBranch('feature-to-delete')).resolves.toBeUndefined();
 
-      expect(mockOctokit.rest.git.deleteRef).toHaveBeenCalledWith({
-        owner: 'test-org',
-        repo: 'test-repo',
-        ref: 'heads/feature-to-delete',
-      });
-      expect(mockOctokit.rest.git.deleteRef).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.request).toHaveBeenCalledWith(
+        'DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}',
+        { owner: 'test-org', repo: 'test-repo', branch: 'feature-to-delete' },
+      );
+      expect(mockOctokit.request).toHaveBeenCalledTimes(1);
     });
 
     it('[EARS-F2] should complete as no-op when GitHub returns 404', async () => {
-      mockOctokit.rest.git.deleteRef.mockRejectedValue(createOctokitError(404, 'Not Found'));
+      mockOctokit.request.mockRejectedValue(createOctokitError(404, 'Not Found'));
 
-      // Idempotent: 404 is swallowed, no throw, no return value
       await expect(git.deleteBranch('never-existed')).resolves.toBeUndefined();
-      expect(mockOctokit.rest.git.deleteRef).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.request).toHaveBeenCalledTimes(1);
     });
 
-    it('[EARS-F2] should throw mapped GitHubApiError for non-404 HTTP errors', async () => {
-      // 401 — authentication error
-      mockOctokit.rest.git.deleteRef.mockRejectedValue(createOctokitError(401, 'Unauthorized'));
+    it('[EARS-F2] should complete as no-op when GitHub returns 422', async () => {
+      mockOctokit.request.mockRejectedValue(createOctokitError(422, 'Reference does not exist'));
+
+      await expect(git.deleteBranch('never-existed')).resolves.toBeUndefined();
+      expect(mockOctokit.request).toHaveBeenCalledTimes(1);
+    });
+
+    it('[EARS-F2] should throw mapped GitHubApiError for non-404/422 HTTP errors', async () => {
+      mockOctokit.request.mockRejectedValue(createOctokitError(401, 'Unauthorized'));
       await expect(git.deleteBranch('protected-branch')).rejects.toThrow(GitHubApiError);
 
-      // 403 — permission error
-      mockOctokit.rest.git.deleteRef.mockRejectedValue(createOctokitError(403, 'Forbidden'));
+      mockOctokit.request.mockRejectedValue(createOctokitError(403, 'Forbidden'));
       await expect(git.deleteBranch('protected-branch')).rejects.toThrow(GitHubApiError);
 
-      // 500 — server error
-      mockOctokit.rest.git.deleteRef.mockRejectedValue(createOctokitError(500, 'Internal Server Error'));
+      mockOctokit.request.mockRejectedValue(createOctokitError(500, 'Internal Server Error'));
       await expect(git.deleteBranch('protected-branch')).rejects.toThrow(GitHubApiError);
     });
   });

--- a/packages/core/src/git/github/github_git_module.test.ts
+++ b/packages/core/src/git/github/github_git_module.test.ts
@@ -17,6 +17,7 @@ import { GitHubGitModule } from './github_git_module';
 import type { GitHubGitModuleOptions } from './github_git_module.types';
 import type { Octokit } from '@octokit/rest';
 import { GitError, FileNotFoundError, BranchNotFoundError, BranchAlreadyExistsError } from '../errors';
+import { GitHubApiError } from '../../github';
 
 // ==================== Test Helpers ====================
 
@@ -34,6 +35,7 @@ type MockOctokit = Octokit & {
       getRef: jest.MockedFunction<any>;
       getBlob: jest.MockedFunction<any>;
       createRef: jest.MockedFunction<any>;
+      deleteRef: jest.MockedFunction<any>;
       getCommit: jest.MockedFunction<any>;
       createBlob: jest.MockedFunction<any>;
       createTree: jest.MockedFunction<any>;
@@ -58,6 +60,7 @@ function createMockOctokit(): MockOctokit {
         getRef: jest.fn(),
         getBlob: jest.fn(),
         createRef: jest.fn(),
+        deleteRef: jest.fn(),
         getCommit: jest.fn(),
         createBlob: jest.fn(),
         createTree: jest.fn(),
@@ -704,6 +707,45 @@ describe('GitHubGitModule', () => {
 
       await expect(git.commit('test')).rejects.toThrow(GitError);
       await expect(git.commit('test')).rejects.toThrow(/network error/);
+    });
+  });
+
+  // ==================== 4.6. Branch Deletion (EARS-F1 to F2) — Cycle 5 identity_key_sync (IKS-A41) ====================
+
+  describe('4.6. Branch Deletion (EARS-F1 to F2)', () => {
+    it('[EARS-F1] should call octokit.rest.git.deleteRef and return on success', async () => {
+      mockOctokit.rest.git.deleteRef.mockResolvedValue({ data: undefined });
+
+      await expect(git.deleteBranch('feature-to-delete')).resolves.toBeUndefined();
+
+      expect(mockOctokit.rest.git.deleteRef).toHaveBeenCalledWith({
+        owner: 'test-org',
+        repo: 'test-repo',
+        ref: 'heads/feature-to-delete',
+      });
+      expect(mockOctokit.rest.git.deleteRef).toHaveBeenCalledTimes(1);
+    });
+
+    it('[EARS-F2] should complete as no-op when GitHub returns 404', async () => {
+      mockOctokit.rest.git.deleteRef.mockRejectedValue(createOctokitError(404, 'Not Found'));
+
+      // Idempotent: 404 is swallowed, no throw, no return value
+      await expect(git.deleteBranch('never-existed')).resolves.toBeUndefined();
+      expect(mockOctokit.rest.git.deleteRef).toHaveBeenCalledTimes(1);
+    });
+
+    it('[EARS-F2] should throw mapped GitHubApiError for non-404 HTTP errors', async () => {
+      // 401 — authentication error
+      mockOctokit.rest.git.deleteRef.mockRejectedValue(createOctokitError(401, 'Unauthorized'));
+      await expect(git.deleteBranch('protected-branch')).rejects.toThrow(GitHubApiError);
+
+      // 403 — permission error
+      mockOctokit.rest.git.deleteRef.mockRejectedValue(createOctokitError(403, 'Forbidden'));
+      await expect(git.deleteBranch('protected-branch')).rejects.toThrow(GitHubApiError);
+
+      // 500 — server error
+      mockOctokit.rest.git.deleteRef.mockRejectedValue(createOctokitError(500, 'Internal Server Error'));
+      await expect(git.deleteBranch('protected-branch')).rejects.toThrow(GitHubApiError);
     });
   });
 });

--- a/packages/core/src/git/github/github_git_module.test.ts
+++ b/packages/core/src/git/github/github_git_module.test.ts
@@ -15,14 +15,13 @@
 
 import { GitHubGitModule } from './github_git_module';
 import type { GitHubGitModuleOptions } from './github_git_module.types';
-import type { Octokit } from '@octokit/rest';
 import { GitError, FileNotFoundError, BranchNotFoundError, BranchAlreadyExistsError } from '../errors';
 import { GitHubApiError } from '../../github';
 
 // ==================== Test Helpers ====================
 
 type MockOctokit = {
-  request: ReturnType<typeof jest.fn>;
+  request: jest.Mock;
   rest: {
     repos: {
       get: jest.MockedFunction<any>;
@@ -157,7 +156,7 @@ describe('GitHubGitModule', () => {
 
   beforeEach(() => {
     mockOctokit = createMockOctokit();
-    git = new GitHubGitModule(defaultOptions, mockOctokit);
+    git = new GitHubGitModule(defaultOptions, mockOctokit as never);
   });
 
   // ==================== 4.1. Read Operations — Content & Refs (EARS-A1 to A6) ====================

--- a/packages/core/src/git/github/github_git_module.ts
+++ b/packages/core/src/git/github/github_git_module.ts
@@ -310,12 +310,32 @@ export class GitHubGitModule implements IGitModule {
 
   /**
    * [EARS-C6] Create branch via Refs API POST
+   *
+   * When startPoint is undefined, resolves the starting SHA from activeRef.
+   * If activeRef doesn't exist (e.g., creating gitgov-state for the first
+   * time via Remote Init), falls back to the repo's default branch via
+   * repos.get API. This supports GitHubProjectInitializer.createProjectStructure()
+   * which calls createBranch(branchName, undefined) before the target branch exists.
    */
   async createBranch(branchName: string, startPoint?: string): Promise<void> {
-    // Resolve startPoint to SHA
-    const sha = startPoint
-      ? await this.getCommitHash(startPoint)
-      : await this.getCommitHash(this.activeRef);
+    let sha: string;
+    if (startPoint) {
+      sha = await this.getCommitHash(startPoint);
+    } else {
+      try {
+        sha = await this.getCommitHash(this.activeRef);
+      } catch (err) {
+        if (err instanceof BranchNotFoundError) {
+          const { data: repoData } = await this.octokit.rest.repos.get({
+            owner: this.owner,
+            repo: this.repo,
+          });
+          sha = await this.getCommitHash(repoData.default_branch);
+        } else {
+          throw err;
+        }
+      }
+    }
 
     try {
       await this.octokit.rest.git.createRef({
@@ -338,8 +358,13 @@ export class GitHubGitModule implements IGitModule {
    * Verifies IGitModule EARS-GM12/GM13. Implements Cycle 5 Task 5.0a (IKS-A41)
    * `EARS-F1`/`EARS-F2` from `github_git_module.md §4.6`.
    *
+   * Uses `octokit.request()` with explicit path segments instead of
+   * `octokit.rest.git.deleteRef()` because the latter URL-encodes
+   * `heads/{branch}` as a single segment (`heads%2F{branch}`), which
+   * GitHub rejects with 422 instead of matching the ref.
+   *
    * - On success: DELETE /repos/{owner}/{repo}/git/refs/heads/{branchName}
-   * - On HTTP 404 (branch missing): returns as no-op (idempotent).
+   * - On HTTP 404 or 422 (branch missing): returns as no-op (idempotent).
    * - On other HTTP errors (401/403/5xx): throws a translated `GitHubApiError`
    *   via `mapOctokitError(err, 'deleteBranch(...)')` (aligns with github_shared_module).
    *
@@ -347,15 +372,16 @@ export class GitHubGitModule implements IGitModule {
    */
   async deleteBranch(branchName: string): Promise<void> {
     try {
-      // [EARS-F1] [EARS-GM12] Call octokit.rest.git.deleteRef on the head ref.
-      await this.octokit.rest.git.deleteRef({
-        owner: this.owner,
-        repo: this.repo,
-        ref: `heads/${branchName}`,
-      });
+      // [EARS-F1] [EARS-GM12] DELETE with branch as separate path segment.
+      await this.octokit.request(
+        'DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}',
+        { owner: this.owner, repo: this.repo, branch: branchName },
+      );
     } catch (error: unknown) {
-      // [EARS-F2] [EARS-GM13] 404 → idempotent no-op.
-      if (isOctokitRequestError(error) && error.status === 404) {
+      // [EARS-F2] [EARS-GM13] 404/422 → idempotent no-op.
+      // GitHub returns 404 when the ref is not found via GET, but 422
+      // via DELETE for the same missing ref.
+      if (isOctokitRequestError(error) && (error.status === 404 || error.status === 422)) {
         return;
       }
       // [EARS-F2] Other HTTP errors → translated GitHubApiError via mapOctokitError.

--- a/packages/core/src/git/github/github_git_module.ts
+++ b/packages/core/src/git/github/github_git_module.ts
@@ -24,7 +24,7 @@ import type {
   ChangedFile,
   CommitAuthor,
 } from '../types';
-import { isOctokitRequestError } from '../../github';
+import { isOctokitRequestError, mapOctokitError } from '../../github';
 import type { GitHubGitModuleOptions } from './github_git_module.types';
 import { GitError, FileNotFoundError, BranchNotFoundError, BranchAlreadyExistsError } from '../errors';
 
@@ -414,6 +414,37 @@ export class GitHubGitModule implements IGitModule {
       }
       const msg = error instanceof Error ? error.message : String(error);
       throw new GitError(`network error: ${msg}`);
+    }
+  }
+
+  /**
+   * Deletes a branch via GitHub Refs API — idempotent semantics.
+   *
+   * Verifies IGitModule EARS-GM12/GM13. Implements Cycle 5 Task 5.0a (IKS-A41)
+   * `EARS-F1`/`EARS-F2` from `github_git_module.md §4.6`.
+   *
+   * - On success: DELETE /repos/{owner}/{repo}/git/refs/heads/{branchName}
+   * - On HTTP 404 (branch missing): returns as no-op (idempotent).
+   * - On other HTTP errors (401/403/5xx): throws a translated `GitHubApiError`
+   *   via `mapOctokitError(err, 'deleteBranch(...)')` (aligns with github_shared_module).
+   *
+   * @param branchName - Branch to delete (without `refs/heads/` prefix)
+   */
+  async deleteBranch(branchName: string): Promise<void> {
+    try {
+      // [EARS-F1] [EARS-GM12] Call octokit.rest.git.deleteRef on the head ref.
+      await this.octokit.rest.git.deleteRef({
+        owner: this.owner,
+        repo: this.repo,
+        ref: `heads/${branchName}`,
+      });
+    } catch (error: unknown) {
+      // [EARS-F2] [EARS-GM13] 404 → idempotent no-op.
+      if (isOctokitRequestError(error) && error.status === 404) {
+        return;
+      }
+      // [EARS-F2] Other HTTP errors → translated GitHubApiError via mapOctokitError.
+      throw mapOctokitError(error, `deleteBranch(${branchName})`);
     }
   }
 

--- a/packages/core/src/git/github/github_git_module.ts
+++ b/packages/core/src/git/github/github_git_module.ts
@@ -95,20 +95,10 @@ export class GitHubGitModule implements IGitModule {
       return Buffer.from(blobData.content, 'base64').toString('utf-8');
     } catch (error: unknown) {
       if (error instanceof GitError) throw error;
-      if (isOctokitRequestError(error)) {
-        if (error.status === 404) {
-          throw new FileNotFoundError(filePath, commitHash);
-        }
-        if (error.status === 401 || error.status === 403) {
-          throw new GitError(`authentication/permission error (${error.status}): getFileContent ${filePath}`);
-        }
-        if (error.status >= 500) {
-          throw new GitError(`GitHub server error (${error.status}): getFileContent ${filePath}`);
-        }
-        throw new GitError(`GitHub API error (${error.status}): getFileContent ${filePath}`);
+      if (isOctokitRequestError(error) && error.status === 404) {
+        throw new FileNotFoundError(filePath, commitHash);
       }
-      const msg = error instanceof Error ? error.message : String(error);
-      throw new GitError(`network error: ${msg}`);
+      throw mapOctokitError(error, `getFileContent(${filePath})`);
     }
   }
 
@@ -130,19 +120,10 @@ export class GitHubGitModule implements IGitModule {
       });
       return data.object.sha;
     } catch (error: unknown) {
-      if (isOctokitRequestError(error)) {
-        if (error.status === 404) {
-          throw new BranchNotFoundError(ref);
-        }
-        if (error.status === 401 || error.status === 403) {
-          throw new GitError(`authentication/permission error (${error.status}): getCommitHash ${ref}`);
-        }
-        if (error.status >= 500) {
-          throw new GitError(`GitHub server error (${error.status}): getCommitHash ${ref}`);
-        }
+      if (isOctokitRequestError(error) && error.status === 404) {
+        throw new BranchNotFoundError(ref);
       }
-      const msg = error instanceof Error ? error.message : String(error);
-      throw new GitError(`network error: ${msg}`);
+      throw mapOctokitError(error, `getCommitHash(${ref})`);
     }
   }
 
@@ -178,17 +159,7 @@ export class GitHubGitModule implements IGitModule {
 
       return files;
     } catch (error: unknown) {
-      if (isOctokitRequestError(error)) {
-        if (error.status === 401 || error.status === 403) {
-          throw new GitError(`authentication/permission error (${error.status}): getChangedFiles ${fromCommit}...${toCommit}`);
-        }
-        if (error.status >= 500) {
-          throw new GitError(`GitHub server error (${error.status}): getChangedFiles`);
-        }
-        throw new GitError(`Failed to compare ${fromCommit}...${toCommit}: HTTP ${error.status}`);
-      }
-      const msg = error instanceof Error ? error.message : String(error);
-      throw new GitError(`network error: ${msg}`);
+      throw mapOctokitError(error, `getChangedFiles(${fromCommit}...${toCommit})`);
     }
   }
 
@@ -215,17 +186,7 @@ export class GitHubGitModule implements IGitModule {
         date: c.commit.author?.date ?? '',
       }));
     } catch (error: unknown) {
-      if (isOctokitRequestError(error)) {
-        if (error.status === 401 || error.status === 403) {
-          throw new GitError(`authentication/permission error (${error.status}): getCommitHistory ${branch}`);
-        }
-        if (error.status >= 500) {
-          throw new GitError(`GitHub server error (${error.status}): getCommitHistory`);
-        }
-        throw new GitError(`Failed to get commit history: HTTP ${error.status}`);
-      }
-      const msg = error instanceof Error ? error.message : String(error);
-      throw new GitError(`network error: ${msg}`);
+      throw mapOctokitError(error, `getCommitHistory(${branch})`);
     }
   }
 
@@ -265,17 +226,7 @@ export class GitHubGitModule implements IGitModule {
 
       return commits;
     } catch (error: unknown) {
-      if (isOctokitRequestError(error)) {
-        if (error.status === 401 || error.status === 403) {
-          throw new GitError(`authentication/permission error (${error.status}): getCommitHistoryRange ${fromHash}...${toHash}`);
-        }
-        if (error.status >= 500) {
-          throw new GitError(`GitHub server error (${error.status}): getCommitHistoryRange`);
-        }
-        throw new GitError(`Failed to get commit range: HTTP ${error.status}`);
-      }
-      const msg = error instanceof Error ? error.message : String(error);
-      throw new GitError(`network error: ${msg}`);
+      throw mapOctokitError(error, `getCommitHistoryRange(${fromHash}...${toHash})`);
     }
   }
 
@@ -291,19 +242,7 @@ export class GitHubGitModule implements IGitModule {
       });
       return data.commit.message;
     } catch (error: unknown) {
-      if (isOctokitRequestError(error)) {
-        if (error.status === 404) {
-          throw new GitError(`Commit not found: ${commitHash}`);
-        }
-        if (error.status === 401 || error.status === 403) {
-          throw new GitError(`authentication/permission error (${error.status}): getCommitMessage ${commitHash}`);
-        }
-        if (error.status >= 500) {
-          throw new GitError(`GitHub server error (${error.status}): getCommitMessage`);
-        }
-      }
-      const msg = error instanceof Error ? error.message : String(error);
-      throw new GitError(`network error: ${msg}`);
+      throw mapOctokitError(error, `getCommitMessage(${commitHash})`);
     }
   }
 
@@ -323,15 +262,8 @@ export class GitHubGitModule implements IGitModule {
       });
       return true;
     } catch (error: unknown) {
-      if (isOctokitRequestError(error)) {
-        if (error.status === 404) return false;
-        if (error.status === 401 || error.status === 403) {
-          throw new GitError(`authentication/permission error (${error.status}): branchExists ${branchName}`);
-        }
-        throw new GitError(`Failed to check branch: HTTP ${error.status}`);
-      }
-      const msg = error instanceof Error ? error.message : String(error);
-      throw new GitError(`network error: ${msg}`);
+      if (isOctokitRequestError(error) && error.status === 404) return false;
+      throw mapOctokitError(error, `branchExists(${branchName})`);
     }
   }
 
@@ -347,17 +279,7 @@ export class GitHubGitModule implements IGitModule {
       });
       return data.map(b => b.name);
     } catch (error: unknown) {
-      if (isOctokitRequestError(error)) {
-        if (error.status === 401 || error.status === 403) {
-          throw new GitError(`authentication/permission error (${error.status}): listRemoteBranches`);
-        }
-        if (error.status >= 500) {
-          throw new GitError(`GitHub server error (${error.status}): listRemoteBranches`);
-        }
-        throw new GitError(`Failed to list branches: HTTP ${error.status}`);
-      }
-      const msg = error instanceof Error ? error.message : String(error);
-      throw new GitError(`network error: ${msg}`);
+      throw mapOctokitError(error, 'listRemoteBranches()');
     }
   }
 
@@ -403,17 +325,10 @@ export class GitHubGitModule implements IGitModule {
         sha,
       });
     } catch (error: unknown) {
-      if (isOctokitRequestError(error)) {
-        if (error.status === 422) {
-          throw new BranchAlreadyExistsError(branchName);
-        }
-        if (error.status === 401 || error.status === 403) {
-          throw new GitError(`authentication/permission error (${error.status}): createBranch ${branchName}`);
-        }
-        throw new GitError(`Failed to create branch ${branchName}: HTTP ${error.status}`);
+      if (isOctokitRequestError(error) && error.status === 422) {
+        throw new BranchAlreadyExistsError(branchName);
       }
-      const msg = error instanceof Error ? error.message : String(error);
-      throw new GitError(`network error: ${msg}`);
+      throw mapOctokitError(error, `createBranch(${branchName})`);
     }
   }
 
@@ -570,17 +485,7 @@ export class GitHubGitModule implements IGitModule {
     return newCommitSha;
     } catch (error: unknown) {
       if (error instanceof GitError) throw error;
-      if (isOctokitRequestError(error)) {
-        if (error.status === 401 || error.status === 403) {
-          throw new GitError(`authentication/permission error (${error.status}): commit`);
-        }
-        if (error.status >= 500) {
-          throw new GitError(`GitHub server error (${error.status}): commit`);
-        }
-        throw new GitError(`GitHub API error (${error.status}): commit`);
-      }
-      const msg = error instanceof Error ? error.message : String(error);
-      throw new GitError(`network error: ${msg}`);
+      throw mapOctokitError(error, 'commit');
     }
   }
 

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -97,6 +97,20 @@ export interface IGitModule {
   rebaseContinue(): Promise<string>;
   rebaseAbort(): Promise<void>;
   createBranch(branchName: string, startPoint?: string): Promise<void>;
+  /**
+   * Delete a branch — idempotent semantics (added for Cycle 5, IKS-A41).
+   *
+   * - If the branch exists, it SHALL be removed.
+   * - If the branch does not exist, the operation SHALL complete as a no-op
+   *   without throwing.
+   *
+   * Added to support `GitHubProjectInitializer.rollback()` which needs to undo
+   * branch creation after a failed remote init. Keeping this in the interface
+   * keeps rollback() provider-agnostic across FS / Memory / GitHub backends.
+   *
+   * Verifies EARS-GM12 (branch exists → remove) and EARS-GM13 (branch not exists → no-op).
+   */
+  deleteBranch(branchName: string): Promise<void>;
   rebase(targetBranch: string): Promise<void>;
 }
 

--- a/packages/core/src/git/local/local_git_module.test.ts
+++ b/packages/core/src/git/local/local_git_module.test.ts
@@ -644,7 +644,7 @@ describe('LocalGitModule', () => {
       await execAsync('git rebase --abort', { cwd: tempRepo });
     });
 
-    it('[EARS-A18] should throw GitCommandError if no rebase/merge in progress', async () => {
+    it('[EARS-A18] should return empty array if no conflicts', async () => {
       // When no conflict, getConflictedFiles should return empty array
       const conflicts = await gitModule.getConflictedFiles();
       expect(conflicts).toEqual([]);
@@ -1407,6 +1407,41 @@ describe('LocalGitModule', () => {
       expect(afterResult.stdout.trim()).toBe('');
 
       removeTempRepo(repoPath);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // 4.8. Branch Deletion (EARS-H1 to H2) — Cycle 5 identity_key_sync (IKS-A41)
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe('4.8. Branch Deletion (EARS-H1 to H2)', () => {
+    it('[EARS-H1] should remove existing branch via git branch -D', async () => {
+      // Arrange: create a branch without checking it out so we can delete it
+      // while HEAD stays on the current branch
+      await execAsync('git branch feature-to-delete', { cwd: tempRepo });
+
+      const existsBefore = await gitModule.branchExists('feature-to-delete');
+      expect(existsBefore).toBe(true);
+
+      // Act
+      await gitModule.deleteBranch('feature-to-delete');
+
+      // Assert
+      const existsAfter = await gitModule.branchExists('feature-to-delete');
+      expect(existsAfter).toBe(false);
+    });
+
+    it('[EARS-H2] should complete as no-op when branch does not exist', async () => {
+      // Arrange: confirm branch is absent to begin with
+      const existsBefore = await gitModule.branchExists('never-existed');
+      expect(existsBefore).toBe(false);
+
+      // Act + Assert: no throw, idempotent return
+      await expect(gitModule.deleteBranch('never-existed')).resolves.toBeUndefined();
+
+      // State unchanged — branch still absent
+      const existsAfter = await gitModule.branchExists('never-existed');
+      expect(existsAfter).toBe(false);
     });
   });
 });

--- a/packages/core/src/git/local/local_git_module.ts
+++ b/packages/core/src/git/local/local_git_module.ts
@@ -1286,8 +1286,37 @@ export class LocalGitModule implements IGitModule {
   }
 
   /**
+   * Deletes a branch — idempotent semantics (verifies IGitModule EARS-GM12/GM13).
+   *
+   * Implements: `git branch -D {branchName}`. If the branch does not exist,
+   * git exits non-zero with stderr containing "not found", which is caught
+   * and mapped to a no-op for idempotent behavior.
+   *
+   * @param branchName - Name of the branch to delete
+   * @throws GitCommandError for errors other than "branch not found"
+   */
+  async deleteBranch(branchName: string): Promise<void> {
+    // [EARS-H1] [EARS-GM12] Delete branch via `git branch -D`
+    const result = await this.execGit(['branch', '-D', branchName]);
+
+    if (result.exitCode !== 0) {
+      // [EARS-H2] [EARS-GM13] Branch not found → idempotent no-op
+      if (result.stderr.toLowerCase().includes('not found')) {
+        logger.debug(`deleteBranch no-op: branch '${branchName}' does not exist`);
+        return;
+      }
+      throw new GitCommandError(
+        `Failed to delete branch ${branchName}`,
+        result.stderr
+      );
+    }
+
+    logger.debug(`Deleted branch: ${branchName}`);
+  }
+
+  /**
    * Rebases current branch onto target branch (git rebase)
-   * 
+   *
    * @param targetBranch - Branch to rebase onto
    * @throws GitCommandError if rebase fails
    * @throws RebaseConflictError if conflicts are detected during rebase

--- a/packages/core/src/git/memory/memory_git_module.test.ts
+++ b/packages/core/src/git/memory/memory_git_module.test.ts
@@ -510,10 +510,17 @@ describe('MemoryGitModule', () => {
 
     it('[EARS-H3] should save to config Map', async () => {
       await git.setConfig('user.name', 'Test User');
+      await git.setConfig('user.email', 'test@example.com');
 
-      // Verify by reading back (we'd need to expose config for proper test,
-      // but setConfig doesn't throw and that's the contract)
-      await expect(git.setConfig('user.email', 'test@example.com')).resolves.not.toThrow();
+      // Verify by reading back the internal state directly.
+      // Justified `as unknown as` cast: MemoryGitModule is a test-only mock
+      // whose whole purpose is to expose state for verification; this EARS
+      // contract (save to config Map) can only be verified by inspecting it.
+      const internalState = (git as unknown as {
+        state: { config: Map<string, string> };
+      }).state;
+      expect(internalState.config.get('user.name')).toBe('Test User');
+      expect(internalState.config.get('user.email')).toBe('test@example.com');
     });
 
     it('[EARS-H4] should be no-op for fetch', async () => {
@@ -534,6 +541,38 @@ describe('MemoryGitModule', () => {
       await git.resetHard('HEAD');
 
       expect(await git.getStagedFiles()).toEqual([]);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // 4.9. Branch Deletion (EARS-I1 to EARS-I2) — Cycle 5 identity_key_sync (IKS-A41)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('4.9. Branch Deletion (EARS-I1 to EARS-I2)', () => {
+    it('[EARS-I1] should remove branch from internal state', async () => {
+      // Arrange: seed a branch in state
+      git.setBranches(['main', 'feature-to-delete']);
+      expect(await git.branchExists('feature-to-delete')).toBe(true);
+
+      // Act
+      await git.deleteBranch('feature-to-delete');
+
+      // Assert: branch removed from state.branches
+      expect(await git.branchExists('feature-to-delete')).toBe(false);
+      // main is untouched
+      expect(await git.branchExists('main')).toBe(true);
+    });
+
+    it('[EARS-I2] should complete as no-op when branch is not in state', async () => {
+      // Arrange: confirm branch absent
+      expect(await git.branchExists('never-existed')).toBe(false);
+
+      // Act + Assert: resolves without throwing
+      await expect(git.deleteBranch('never-existed')).resolves.toBeUndefined();
+
+      // State unchanged
+      expect(await git.branchExists('never-existed')).toBe(false);
+      expect(await git.branchExists('main')).toBe(true);
     });
   });
 });

--- a/packages/core/src/git/memory/memory_git_module.ts
+++ b/packages/core/src/git/memory/memory_git_module.ts
@@ -448,6 +448,21 @@ export class MemoryGitModule implements IGitModule {
     this.state.currentBranch = branchName;
   }
 
+  /**
+   * Deletes a branch — idempotent semantics (verifies IGitModule EARS-GM12/GM13).
+   *
+   * Mutates internal state: removes the branch from `state.branches` if present.
+   * If the branch is not in state, returns without mutating (no-op).
+   *
+   * @param branchName - Name of the branch to delete
+   */
+  async deleteBranch(branchName: string): Promise<void> {
+    // [EARS-I1] [EARS-GM12] Remove branch from internal state if present.
+    // [EARS-I2] [EARS-GM13] Set.delete() returns false but does not throw
+    //          when the key is absent — idempotent by construction.
+    this.state.branches.delete(branchName);
+  }
+
   async rebase(_targetBranch: string): Promise<void> {
     // No-op in memory, unless conflicts are set
     if (this.state.conflictedFiles.length > 0) {

--- a/packages/core/src/github.ts
+++ b/packages/core/src/github.ts
@@ -15,6 +15,8 @@
 
 export type { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 
+import { GitError } from './git/errors';
+
 // ==================== Shared Types ====================
 
 /**
@@ -32,10 +34,16 @@ export type GitHubApiErrorCode =
 
 /**
  * Typed error for GitHub API operations.
- * Used by RecordStore, ConfigStore, and other modules that
+ * Used by RecordStore, ConfigStore, GitHubGitModule, and other modules that
  * interact with GitHub Contents API directly.
+ *
+ * Extends `GitError` so consumers that catch the base git error class
+ * still receive GitHub-backend errors polymorphically. This enables
+ * `catch (err instanceof GitError)` to handle both CLI and API failures
+ * uniformly while still allowing narrow `instanceof GitHubApiError` checks
+ * for backend-specific logic (e.g. inspecting the semantic `code` field).
  */
-export class GitHubApiError extends Error {
+export class GitHubApiError extends GitError {
   constructor(
     message: string,
     /** Semantic error code */

--- a/packages/core/src/github.ts
+++ b/packages/core/src/github.ts
@@ -158,3 +158,7 @@ export type {
 // PolicyConfigLoader
 export { GitHubPolicyConfigLoader } from './policy_evaluator/github/github_policy_config_loader';
 export type { GitHubPolicyConfigLoaderOptions } from './policy_evaluator/github/github_policy_config_loader';
+
+// ProjectInitializer
+export { GitHubProjectInitializer } from './project_initializer/github';
+export type { GitHubProjectInitializerOptions } from './project_initializer/github';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -185,3 +185,10 @@ export * as FeedbackAdapter from "./adapters/feedback_adapter/index";
 export * as IdentityAdapter from "./adapters/identity_adapter/index";
 export * as ProjectAdapter from "./adapters/project_adapter/index";
 export * as WorkflowAdapter from "./adapters/workflow_adapter/index";
+
+// Direct class re-exports for saas consumers. The namespace exports above wrap
+// the class under a namespace so `import { IdentityAdapter } from '@gitgov/core'`
+// yields the namespace (not the class). For consumers that construct adapters
+// per-request (e.g., GitHubRemoteInitService, Cycle 5 Task 5.1b), expose the
+// concrete class under a distinct name to avoid the namespace conflict.
+export { IdentityAdapter as IdentityAdapterClass } from "./adapters/identity_adapter/identity_adapter";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -137,7 +137,11 @@ export type {
 } from "./sarif/index";
 
 // ID generator utilities (protocol-valid ID creation)
-export { generateTaskId, generateExecutionId, generateFeedbackId, generateCycleId, generateActorId, generateAgentId } from "./utils/id_generator";
+export { generateTaskId, generateExecutionId, generateFeedbackId, generateCycleId, generateActorId, generateAgentId, computeSuccessorActorId } from "./utils/id_generator";
+
+// Crypto primitives (protocol-level signing + checksum)
+export { buildSignatureDigest } from "./crypto/signatures";
+export { calculatePayloadChecksum } from "./crypto/checksum";
 
 // Git direct exports (interface + types + errors)
 export type { IGitModule, ExecOptions, ExecResult, GetCommitHistoryOptions, CommitInfo, ChangedFile, CommitAuthor, GitRemoteRef } from "./git/index";

--- a/packages/core/src/key_provider/fs/fs_key_provider.test.ts
+++ b/packages/core/src/key_provider/fs/fs_key_provider.test.ts
@@ -107,7 +107,7 @@ describe('FsKeyProvider', () => {
 
       await provider.setPrivateKey(actorId, privateKey);
 
-      const keyPath = path.join(keysDir, 'actor:human:test.key');
+      const keyPath = path.join(keysDir, 'actor_human_test.key');
       const content = await fs.readFile(keyPath, 'utf-8');
 
       expect(content).toBe(privateKey);
@@ -117,7 +117,7 @@ describe('FsKeyProvider', () => {
       const actorId = 'actor:secure';
       await provider.setPrivateKey(actorId, 'secureKey');
 
-      const keyPath = path.join(keysDir, 'actor:secure.key');
+      const keyPath = path.join(keysDir, 'actor_secure.key');
       const stats = await fs.stat(keyPath);
 
       // Check permissions (0600 = owner read/write only)
@@ -152,6 +152,18 @@ describe('FsKeyProvider', () => {
       expect(result).toBe(privateKey);
     });
 
+    it('[EARS-FKP05] should replace colons with underscores in key filename', async () => {
+      const actorId = 'human:cagodoy';
+      await provider.setPrivateKey(actorId, 'colonKey');
+
+      const expectedPath = path.join(keysDir, 'human_cagodoy.key');
+      const content = await fs.readFile(expectedPath, 'utf-8');
+      expect(content).toBe('colonKey');
+
+      const result = await provider.getPrivateKey(actorId);
+      expect(result).toBe('colonKey');
+    });
+
     it('[EARS-FKP06] should return true if key file exists', async () => {
       const actorId = 'actor:human:exists';
 
@@ -164,7 +176,7 @@ describe('FsKeyProvider', () => {
 
     it('[EARS-FKP07] should trim whitespace from key content', async () => {
       const actorId = 'actor:whitespace';
-      const keyPath = path.join(keysDir, 'actor:whitespace.key');
+      const keyPath = path.join(keysDir, 'actor_whitespace.key');
 
       // Manually write key with whitespace
       await fs.mkdir(keysDir, { recursive: true });
@@ -177,7 +189,7 @@ describe('FsKeyProvider', () => {
 
     it('[EARS-FKP08] should return null for empty key file', async () => {
       const actorId = 'actor:empty';
-      const keyPath = path.join(keysDir, 'actor:empty.key');
+      const keyPath = path.join(keysDir, 'actor_empty.key');
 
       await fs.mkdir(keysDir, { recursive: true });
       await fs.writeFile(keyPath, '', 'utf-8');
@@ -203,7 +215,7 @@ describe('FsKeyProvider', () => {
 
       await customProvider.setPrivateKey('actor:test', 'customKey');
 
-      const keyPath = path.join(keysDir, 'actor:test.privkey');
+      const keyPath = path.join(keysDir, 'actor_test.privkey');
       const content = await fs.readFile(keyPath, 'utf-8');
 
       expect(content).toBe('customKey');

--- a/packages/core/src/key_provider/fs/fs_key_provider.ts
+++ b/packages/core/src/key_provider/fs/fs_key_provider.ts
@@ -206,7 +206,7 @@ export class FsKeyProvider implements KeyProvider {
     // Remove path traversal attempts
     let sanitized = actorId
       .replace(/\.\./g, '')  // Remove ..
-      .replace(/[/\\]/g, '_'); // Replace path separators with underscore
+      .replace(/[/\\:]/g, '_'); // Replace path separators and colons with underscore
 
     // Validate result is not empty
     if (!sanitized || sanitized === '') {

--- a/packages/core/src/key_provider/prisma/prisma_key_provider.test.ts
+++ b/packages/core/src/key_provider/prisma/prisma_key_provider.test.ts
@@ -285,6 +285,23 @@ function createMockActorKeyDelegate(): {
         return { count: matches.length };
       },
     ),
+    deleteMany: jest.fn(
+      async (args: {
+        where: { actorId: string; orgId: string; status: string };
+      }) => {
+        const before = rows.length;
+        const toRemove = rows.filter(
+          (r) =>
+            r.actorId === args.where.actorId &&
+            r.orgId === args.where.orgId &&
+            r.status === args.where.status,
+        );
+        for (const row of toRemove) {
+          rows.splice(rows.indexOf(row), 1);
+        }
+        return { count: before - rows.length };
+      },
+    ),
     update: jest.fn(
       async (args: {
         where: { id: string };
@@ -741,6 +758,27 @@ describe('PrismaKeyProvider v2', () => {
         .length;
       // Cache hit: count didn't increase on subsequent operations
       expect(finalCallCount).toBe(firstCallCount);
+    });
+
+    it('[PKP-F2] should auto-create OrgEncryptionKey on first use when none exists', async () => {
+      const { client, orgKeyRows } = createMockPrismaClient();
+      process.env['MASTER_KEY'] = TEST_MASTER_KEY;
+
+      // NO createOrgEncryptionKey called — provider must auto-create
+      expect(orgKeyRows.size).toBe(0);
+
+      const provider = new PrismaKeyProvider(client, 'org-new');
+      const { privateKey, publicKey } = await generateKeys();
+
+      await provider.storeKey('human:alice', { publicKey, privateKey });
+
+      // OrgEncryptionKey was auto-created
+      expect(orgKeyRows.size).toBe(1);
+      expect(orgKeyRows.has('org-new')).toBe(true);
+
+      // Key was stored successfully using the auto-created org key
+      const retrieved = await provider.getPrivateKey('human:alice');
+      expect(retrieved).toBe(privateKey);
     });
 
     it('[PKP-F3] should encrypt ActorKey with org key, never with MASTER_KEY directly', async () => {

--- a/packages/core/src/key_provider/prisma/prisma_key_provider.ts
+++ b/packages/core/src/key_provider/prisma/prisma_key_provider.ts
@@ -281,6 +281,12 @@ export class PrismaKeyProvider implements KeyProvider {
     // [PKP-G2] Transactional: archive old active + create new active
     try {
       await this.prisma.$transaction(async (tx) => {
+        // [PKP-G2] Remove old archived rows to avoid unique constraint violation
+        // on (actorId, orgId, status) when archiving the current active row
+        await tx.actorKey.deleteMany({
+          where: { actorId, orgId: this.orgId, status: STATUS_ARCHIVED },
+        });
+
         // [PKP-G2] Archive any existing active row for this actor+org
         await tx.actorKey.updateMany({
           where: { actorId, orgId: this.orgId, status: STATUS_ACTIVE },
@@ -335,29 +341,31 @@ export class PrismaKeyProvider implements KeyProvider {
    * [PKP-F2] Lazy-loads the org key on first call and caches it in-instance.
    * Subsequent calls return the cached buffer without touching the DB.
    *
-   * Flow: fetch OrgEncryptionKey row by orgId → HKDF-derive wrapping key
-   * from MASTER_KEY → AES-GCM decrypt encryptedOrgKey → cache result.
-   *
-   * Throws `STORE_FAILED` if no OrgEncryptionKey row exists for this org
-   * (hint: call `createOrgEncryptionKey(prisma, orgId)` first).
+   * Flow: fetch OrgEncryptionKey row by orgId → if missing, auto-create
+   * via createOrgEncryptionKey → HKDF-derive wrapping key from MASTER_KEY
+   * → AES-GCM decrypt encryptedOrgKey → cache result.
    */
   private async getOrgKey(): Promise<Buffer> {
     if (this.orgKeyCache !== null) {
       return this.orgKeyCache;
     }
 
-    const row = await this.prisma.orgEncryptionKey.findUnique({
+    let row = await this.prisma.orgEncryptionKey.findUnique({
       where: { orgId: this.orgId },
     });
     if (!row) {
-      throw new KeyProviderError(
-        `No OrgEncryptionKey for org ${this.orgId}`,
-        'STORE_FAILED',
-        {
-          orgId: this.orgId,
-          hint: 'Call createOrgEncryptionKey(prisma, orgId) when the Organization is created',
-        },
-      );
+      // [PKP-F1] Auto-create on first use — lazy initialization
+      await createOrgEncryptionKey(this.prisma as OrgEncryptionKeyClient, this.orgId);
+      row = await this.prisma.orgEncryptionKey.findUnique({
+        where: { orgId: this.orgId },
+      });
+      if (!row) {
+        throw new KeyProviderError(
+          `Failed to auto-create OrgEncryptionKey for org ${this.orgId}`,
+          'STORE_FAILED',
+          { orgId: this.orgId },
+        );
+      }
     }
 
     const masterKeyBase64 = process.env['MASTER_KEY'];

--- a/packages/core/src/key_provider/prisma/prisma_key_provider.types.ts
+++ b/packages/core/src/key_provider/prisma/prisma_key_provider.types.ts
@@ -76,6 +76,9 @@ export type ActorKeyDelegate = {
     where: { actorId: string; orgId: string; status: string };
     data: { status?: string; lastUsedAt?: Date };
   }): Promise<{ count: number }>;
+  deleteMany(args: {
+    where: { actorId: string; orgId: string; status: string };
+  }): Promise<{ count: number }>;
   update(args: {
     where: { id: string };
     data: {

--- a/packages/core/src/project_initializer/fs/fs_project_initializer.test.ts
+++ b/packages/core/src/project_initializer/fs/fs_project_initializer.test.ts
@@ -538,4 +538,40 @@ describe('FsProjectInitializer', () => {
       expect(policyWrite).toBeUndefined();
     });
   });
+
+  // ==========================================================================
+  // 4.6. Transaction Boundary — finalize no-op (EARS-FPI15) — Cycle 5 IKS-A40
+  // ==========================================================================
+
+  describe('4.6. Transaction Boundary (EARS-FPI15)', () => {
+    let initializer: FsProjectInitializer;
+
+    beforeEach(() => {
+      initializer = new FsProjectInitializer(testRoot);
+      jest.clearAllMocks();
+    });
+
+    it('[EARS-FPI15] should complete as no-op without filesystem I/O', async () => {
+      // Call finalize() and assert zero fs operations were invoked.
+      // The FS backend has no transaction buffer — prior write methods
+      // persist immediately, so finalize() must not touch the filesystem.
+      await initializer.finalize();
+
+      expect(mockFs.mkdir).not.toHaveBeenCalled();
+      expect(mockFs.writeFile).not.toHaveBeenCalled();
+      expect(mockFs.readFile).not.toHaveBeenCalled();
+      expect(mockFs.access).not.toHaveBeenCalled();
+      expect(mockFs.rm).not.toHaveBeenCalled();
+      expect(mockFs.unlink).not.toHaveBeenCalled();
+      expect(mockFs.copyFile).not.toHaveBeenCalled();
+      expect(mockFs.appendFile).not.toHaveBeenCalled();
+    });
+
+    it('[EARS-FPI15] should not throw when called without prior write operations', async () => {
+      // Idempotent: calling finalize() as the very first action on a fresh
+      // initializer must also succeed (no-op), since there are no staged
+      // writes to materialize and no state to depend on.
+      await expect(initializer.finalize()).resolves.toBeUndefined();
+    });
+  });
 });

--- a/packages/core/src/project_initializer/fs/fs_project_initializer.test.ts
+++ b/packages/core/src/project_initializer/fs/fs_project_initializer.test.ts
@@ -572,6 +572,18 @@ describe('FsProjectInitializer', () => {
       // initializer must also succeed (no-op), since there are no staged
       // writes to materialize and no state to depend on.
       await expect(initializer.finalize()).resolves.toBeUndefined();
+
+      // Also verify zero side effects on the filesystem (symmetric with test 1)
+      // to catch any future drift where finalize() might acquire "quiet" I/O
+      // like logging to a file, cache writes, or state mutations.
+      expect(mockFs.mkdir).not.toHaveBeenCalled();
+      expect(mockFs.writeFile).not.toHaveBeenCalled();
+      expect(mockFs.readFile).not.toHaveBeenCalled();
+      expect(mockFs.access).not.toHaveBeenCalled();
+      expect(mockFs.rm).not.toHaveBeenCalled();
+      expect(mockFs.unlink).not.toHaveBeenCalled();
+      expect(mockFs.copyFile).not.toHaveBeenCalled();
+      expect(mockFs.appendFile).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/project_initializer/fs/fs_project_initializer.ts
+++ b/packages/core/src/project_initializer/fs/fs_project_initializer.ts
@@ -155,9 +155,12 @@ export class FsProjectInitializer implements IProjectInitializer {
    * (LSP: both FS and GitHub backends honor the same interface, with trivial
    * or non-trivial implementations according to their durability semantics).
    */
-  async finalize(): Promise<void> {
+  async finalize(): Promise<string | undefined> {
     // [EARS-FPI15] [EARS-PI11] No-op: filesystem writes are persisted immediately
     // by the individual write methods. No transaction buffer to commit.
+    // Returns undefined — there is no commit SHA for the FS backend (no commit
+    // concept). Transactional backends (GitHub) return the atomic commit SHA.
+    return undefined;
   }
 
   /**

--- a/packages/core/src/project_initializer/fs/fs_project_initializer.ts
+++ b/packages/core/src/project_initializer/fs/fs_project_initializer.ts
@@ -141,6 +141,26 @@ export class FsProjectInitializer implements IProjectInitializer {
   }
 
   /**
+   * Finalize the initialization transaction — no-op on filesystem backend.
+   *
+   * Verifies `EARS-FPI15` (FS-specific) and `EARS-PI11` (interface base).
+   *
+   * The filesystem backend has no transaction buffer — all write methods
+   * (`createProjectStructure`, `writeConfig`, `initializeSession`, etc.)
+   * persist immediately to disk via `fs.writeFile`/`fs.mkdir`. By the time
+   * `finalize()` is called, all writes from prior method calls are already
+   * durable, so there is nothing to commit.
+   *
+   * This method exists solely to satisfy the `IProjectInitializer` contract
+   * (LSP: both FS and GitHub backends honor the same interface, with trivial
+   * or non-trivial implementations according to their durability semantics).
+   */
+  async finalize(): Promise<void> {
+    // [EARS-FPI15] [EARS-PI11] No-op: filesystem writes are persisted immediately
+    // by the individual write methods. No transaction buffer to commit.
+  }
+
+  /**
    * Validates environment for GitGovernance initialization.
    * Checks: Git repo exists, write permissions, not already initialized.
    */

--- a/packages/core/src/project_initializer/github/github_project_initializer.test.ts
+++ b/packages/core/src/project_initializer/github/github_project_initializer.test.ts
@@ -1,0 +1,378 @@
+/**
+ * GitHubProjectInitializer Unit Tests
+ *
+ * Tests the seventh sibling of @gitgov/core/github against the
+ * github_project_initializer blueprint (GPI01-GPI13).
+ *
+ * Tests mock IGitModule and ConfigStore directly — this keeps the suite
+ * isolated from Octokit/network details. The real Octokit interaction is
+ * exercised indirectly through github_git_module.test.ts and
+ * github_config_store.test.ts.
+ */
+
+import { GitHubProjectInitializer } from './github_project_initializer';
+import type { IGitModule, CommitAuthor } from '../../git';
+import type { ConfigStore } from '../../config_store';
+import type { GitGovConfig } from '../../config_manager';
+
+// ==================== Mock Helpers ====================
+
+type MockGitModule = {
+  [K in keyof IGitModule]: jest.MockedFunction<IGitModule[K] extends (...args: infer A) => infer R ? (...args: A) => R : never>;
+};
+
+function createMockGitModule(): MockGitModule {
+  return {
+    exec: jest.fn(),
+    init: jest.fn(),
+    getRepoRoot: jest.fn(),
+    getCurrentBranch: jest.fn(),
+    getCommitHash: jest.fn(),
+    setConfig: jest.fn(),
+    getMergeBase: jest.fn(),
+    getChangedFiles: jest.fn(),
+    getStagedFiles: jest.fn(),
+    getFileContent: jest.fn(),
+    getCommitHistory: jest.fn(),
+    getCommitHistoryRange: jest.fn(),
+    getCommitMessage: jest.fn(),
+    hasUncommittedChanges: jest.fn(),
+    isRebaseInProgress: jest.fn(),
+    branchExists: jest.fn(),
+    listRemoteBranches: jest.fn(),
+    isRemoteConfigured: jest.fn(),
+    getBranchRemote: jest.fn(),
+    getConflictedFiles: jest.fn(),
+    checkoutBranch: jest.fn(),
+    stash: jest.fn(),
+    stashPop: jest.fn(),
+    stashDrop: jest.fn(),
+    checkoutOrphanBranch: jest.fn(),
+    fetch: jest.fn(),
+    pull: jest.fn(),
+    pullRebase: jest.fn(),
+    resetHard: jest.fn(),
+    checkoutFilesFromBranch: jest.fn(),
+    add: jest.fn(),
+    rm: jest.fn(),
+    commit: jest.fn(),
+    commitAllowEmpty: jest.fn(),
+    push: jest.fn(),
+    pushWithUpstream: jest.fn(),
+    setUpstream: jest.fn(),
+    rebaseContinue: jest.fn(),
+    rebaseAbort: jest.fn(),
+    createBranch: jest.fn(),
+    deleteBranch: jest.fn(),
+    rebase: jest.fn(),
+  } as unknown as MockGitModule;
+}
+
+type MockConfigStore = {
+  loadConfig: jest.MockedFunction<() => Promise<GitGovConfig | null>>;
+  saveConfig: jest.MockedFunction<(config: GitGovConfig) => Promise<unknown>>;
+};
+
+function createMockConfigStore(): MockConfigStore {
+  return {
+    loadConfig: jest.fn(),
+    saveConfig: jest.fn(),
+  };
+}
+
+const FIXTURE_CONFIG: GitGovConfig = {
+  protocolVersion: '1.0',
+  projectId: 'myorg/myrepo',
+  projectName: 'myrepo',
+  rootCycle: 'cycle-001',
+  saasUrl: 'https://example.com',
+  state: { branch: 'gitgov-state' },
+};
+
+function createInitializer(
+  gitModule: MockGitModule,
+  configStore: MockConfigStore,
+  overrides: Partial<{
+    branch: string;
+    basePath: string;
+    commitMessage: string;
+    commitAuthor: CommitAuthor;
+  }> = {},
+): GitHubProjectInitializer {
+  return new GitHubProjectInitializer(
+    gitModule as unknown as IGitModule,
+    configStore as unknown as ConfigStore<unknown>,
+    {
+      owner: 'myorg',
+      repo: 'myrepo',
+      ...overrides,
+    },
+  );
+}
+
+// ==================== Tests ====================
+
+describe('GitHubProjectInitializer', () => {
+  let gitModule: MockGitModule;
+  let configStore: MockConfigStore;
+
+  beforeEach(() => {
+    gitModule = createMockGitModule();
+    configStore = createMockConfigStore();
+  });
+
+  describe('4.2. Branch Management + Staging (GPI01-GPI03)', () => {
+    it('[GPI01] should create branch and set branchCreatedByThisInit flag', async () => {
+      gitModule.branchExists.mockResolvedValue(false);
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.createProjectStructure();
+
+      expect(gitModule.branchExists).toHaveBeenCalledWith('gitgov-state');
+      expect(gitModule.createBranch).toHaveBeenCalledWith('gitgov-state', undefined);
+
+      // Verify rollback deletes the branch (flag must have been set)
+      await initializer.rollback();
+      expect(gitModule.deleteBranch).toHaveBeenCalledWith('gitgov-state');
+    });
+
+    it('[GPI02] should skip createBranch when branch already exists', async () => {
+      gitModule.branchExists.mockResolvedValue(true);
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.createProjectStructure();
+
+      expect(gitModule.branchExists).toHaveBeenCalledWith('gitgov-state');
+      expect(gitModule.createBranch).not.toHaveBeenCalled();
+
+      // Verify rollback is a no-op (flag was never set)
+      await initializer.rollback();
+      expect(gitModule.deleteBranch).not.toHaveBeenCalled();
+    });
+
+    it('[GPI03] should stage policy.yml with default content in gitModule buffer', async () => {
+      gitModule.branchExists.mockResolvedValue(true);
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.createProjectStructure();
+
+      expect(gitModule.add).toHaveBeenCalledWith(
+        ['.gitgov/policy.yml'],
+        {
+          contentMap: { '.gitgov/policy.yml': 'version: "1.0"\nfailOn: critical\n' },
+        },
+      );
+    });
+  });
+
+  describe('4.3. Rollback Simétrico (GPI04)', () => {
+    it('[GPI04] should call deleteBranch and reset flag when branch was created', async () => {
+      gitModule.branchExists.mockResolvedValue(false);
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.createProjectStructure();
+      await initializer.rollback();
+
+      expect(gitModule.deleteBranch).toHaveBeenCalledWith('gitgov-state');
+      expect(gitModule.deleteBranch).toHaveBeenCalledTimes(1);
+
+      // Second rollback should be a no-op (flag was reset)
+      await initializer.rollback();
+      expect(gitModule.deleteBranch).toHaveBeenCalledTimes(1);
+    });
+
+    it('[GPI04] should be no-op when branch preexisted (flag false)', async () => {
+      gitModule.branchExists.mockResolvedValue(true);
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.createProjectStructure();
+      await initializer.rollback();
+
+      expect(gitModule.deleteBranch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('4.4. Staging de Config + Lectura (GPI05-GPI06)', () => {
+    it('[GPI05] should stage config.json with JSON.stringify(config, null, 2)', async () => {
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.writeConfig(FIXTURE_CONFIG);
+
+      const expectedContent = JSON.stringify(FIXTURE_CONFIG, null, 2);
+      expect(gitModule.add).toHaveBeenCalledWith(
+        ['.gitgov/config.json'],
+        {
+          contentMap: { '.gitgov/config.json': expectedContent },
+        },
+      );
+    });
+
+    it('[GPI05] should NOT call configStore.saveConfig to avoid immediate commit', async () => {
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.writeConfig(FIXTURE_CONFIG);
+
+      expect(configStore.saveConfig).not.toHaveBeenCalled();
+    });
+
+    it('[GPI06] should delegate readFile to gitModule.getFileContent with branch', async () => {
+      gitModule.getFileContent.mockResolvedValue('file contents');
+      const initializer = createInitializer(gitModule, configStore);
+
+      const result = await initializer.readFile('.gitgov/config.json');
+
+      expect(result).toBe('file contents');
+      expect(gitModule.getFileContent).toHaveBeenCalledWith(
+        'gitgov-state',
+        '.gitgov/config.json',
+      );
+    });
+  });
+
+  describe('4.5. Remote-Agnostic No-ops (GPI07-GPI09)', () => {
+    it('[GPI07] should complete initializeSession without gitModule or configStore calls', async () => {
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.initializeSession('human:alice');
+
+      expect(gitModule.add).not.toHaveBeenCalled();
+      expect(gitModule.commit).not.toHaveBeenCalled();
+      expect(gitModule.createBranch).not.toHaveBeenCalled();
+      expect(gitModule.deleteBranch).not.toHaveBeenCalled();
+      expect(configStore.saveConfig).not.toHaveBeenCalled();
+      expect(configStore.loadConfig).not.toHaveBeenCalled();
+    });
+
+    it('[GPI08] should complete copyAgentPrompt without gitModule or configStore calls', async () => {
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.copyAgentPrompt();
+
+      expect(gitModule.add).not.toHaveBeenCalled();
+      expect(gitModule.commit).not.toHaveBeenCalled();
+      expect(gitModule.createBranch).not.toHaveBeenCalled();
+      expect(gitModule.deleteBranch).not.toHaveBeenCalled();
+      expect(configStore.saveConfig).not.toHaveBeenCalled();
+      expect(configStore.loadConfig).not.toHaveBeenCalled();
+    });
+
+    it('[GPI09] should complete setupGitIntegration without gitModule or configStore calls', async () => {
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.setupGitIntegration();
+
+      expect(gitModule.add).not.toHaveBeenCalled();
+      expect(gitModule.commit).not.toHaveBeenCalled();
+      expect(gitModule.createBranch).not.toHaveBeenCalled();
+      expect(gitModule.deleteBranch).not.toHaveBeenCalled();
+      expect(configStore.saveConfig).not.toHaveBeenCalled();
+      expect(configStore.loadConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('4.6. Inspection & Validation (GPI10-GPI12)', () => {
+    it('[GPI10] should return true when branch exists and config.json is loadable', async () => {
+      gitModule.branchExists.mockResolvedValue(true);
+      configStore.loadConfig.mockResolvedValue(FIXTURE_CONFIG);
+      const initializer = createInitializer(gitModule, configStore);
+
+      const result = await initializer.isInitialized();
+
+      expect(result).toBe(true);
+    });
+
+    it('[GPI10] should return false when branch does not exist', async () => {
+      gitModule.branchExists.mockResolvedValue(false);
+      const initializer = createInitializer(gitModule, configStore);
+
+      const result = await initializer.isInitialized();
+
+      expect(result).toBe(false);
+      // Should short-circuit without loading config
+      expect(configStore.loadConfig).not.toHaveBeenCalled();
+    });
+
+    it('[GPI10] should return false when branch exists but config is null', async () => {
+      gitModule.branchExists.mockResolvedValue(true);
+      configStore.loadConfig.mockResolvedValue(null);
+      const initializer = createInitializer(gitModule, configStore);
+
+      const result = await initializer.isInitialized();
+
+      expect(result).toBe(false);
+    });
+
+    it('[GPI11] should return isAlreadyInitialized=false with isValid=true for fresh repo', async () => {
+      gitModule.branchExists.mockResolvedValue(false);
+      const initializer = createInitializer(gitModule, configStore);
+
+      const validation = await initializer.validateEnvironment();
+
+      expect(validation.isValid).toBe(true);
+      expect(validation.isAlreadyInitialized).toBe(false);
+      expect(validation.isGitRepo).toBe(true);
+      expect(validation.hasWritePermissions).toBe(true);
+      expect(validation.hasRemote).toBe(true);
+      expect(validation.currentBranch).toBe('gitgov-state');
+      expect(validation.warnings).toEqual([]);
+    });
+
+    it('[GPI11] should return isAlreadyInitialized=true with warning when config exists', async () => {
+      gitModule.branchExists.mockResolvedValue(true);
+      configStore.loadConfig.mockResolvedValue(FIXTURE_CONFIG);
+      const initializer = createInitializer(gitModule, configStore);
+
+      const validation = await initializer.validateEnvironment();
+
+      expect(validation.isValid).toBe(false);
+      expect(validation.isAlreadyInitialized).toBe(true);
+      expect(validation.warnings.length).toBe(1);
+      expect(validation.warnings[0]).toContain('already initialized');
+      expect(validation.warnings[0]).toContain('.gitgov/config.json');
+      expect(validation.warnings[0]).toContain('gitgov-state');
+    });
+
+    it('[GPI12] should return string literal basePath/actors/<actorId>.json', () => {
+      const initializer = createInitializer(gitModule, configStore);
+
+      const result = initializer.getActorPath('human:alice');
+
+      expect(result).toBe('.gitgov/actors/human:alice.json');
+    });
+  });
+
+  describe('4.7. Transaction Boundary (GPI13)', () => {
+    it('[GPI13] should call gitModule.commit with configured commitMessage and author', async () => {
+      gitModule.commit.mockResolvedValue('abc123');
+      const customAuthor: CommitAuthor = { name: 'Test Bot', email: 'test@example.com' };
+      const initializer = createInitializer(gitModule, configStore, {
+        commitMessage: 'custom message',
+        commitAuthor: customAuthor,
+      });
+
+      await initializer.finalize();
+
+      expect(gitModule.commit).toHaveBeenCalledWith('custom message', customAuthor);
+      expect(gitModule.commit).toHaveBeenCalledTimes(1);
+    });
+
+    it('[GPI13] should use default commitMessage and author when options omit them', async () => {
+      gitModule.commit.mockResolvedValue('abc123');
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.finalize();
+
+      expect(gitModule.commit).toHaveBeenCalledWith('gitgov: remote init', {
+        name: 'gitgov bot',
+        email: 'bot@gitgov.dev',
+      });
+    });
+
+    it('[GPI13] should propagate errors from gitModule.commit to caller', async () => {
+      gitModule.commit.mockRejectedValue(new Error('commit failed'));
+      const initializer = createInitializer(gitModule, configStore);
+
+      await expect(initializer.finalize()).rejects.toThrow('commit failed');
+    });
+  });
+});

--- a/packages/core/src/project_initializer/github/github_project_initializer.ts
+++ b/packages/core/src/project_initializer/github/github_project_initializer.ts
@@ -157,7 +157,9 @@ export class GitHubProjectInitializer implements IProjectInitializer {
   }
 
   // GPI13 — IKS-T6: transaction boundary. Materializes all staged writes in 1 commit.
-  async finalize(): Promise<void> {
-    await this.gitModule.commit(this.commitMessage, this.commitAuthor);
+  // Returns the commit SHA for observability (used by RemoteInitService to emit
+  // `INIT_COMPLETE` event via `RepoStateMachineService.transition` with commitSha).
+  async finalize(): Promise<string | undefined> {
+    return await this.gitModule.commit(this.commitMessage, this.commitAuthor);
   }
 }

--- a/packages/core/src/project_initializer/github/github_project_initializer.ts
+++ b/packages/core/src/project_initializer/github/github_project_initializer.ts
@@ -1,0 +1,163 @@
+import type { CommitAuthor, IGitModule } from '../../git';
+import type { ConfigStore } from '../../config_store';
+import type { GitGovConfig } from '../../config_manager';
+import type {
+  IProjectInitializer,
+  EnvironmentValidation,
+} from '../project_initializer';
+import type { GitHubProjectInitializerOptions } from './github_project_initializer.types';
+
+const DEFAULT_POLICY_YML = `version: "1.0"\nfailOn: critical\n`;
+
+/**
+ * GitHubProjectInitializer — seventh sibling of the @gitgov/core/github family.
+ *
+ * Implements IProjectInitializer against the GitHub REST API using GitHubGitModule
+ * (staging buffer + 6-step atomic commit) and GitHubConfigStore (read-only here).
+ *
+ * Unlike FsProjectInitializer, writes do NOT persist immediately — they stage
+ * into the shared gitModule's staging buffer and materialize in a single commit
+ * via finalize() (IKS-A40, Unit of Work pattern).
+ *
+ * Methods that don't apply to remote state (no local filesystem artifacts) are
+ * documented no-ops:
+ *   - initializeSession:   sessions live in saas-api JWE tokens, not gitgov-state
+ *   - copyAgentPrompt:     no local agent prompts in remote init
+ *   - setupGitIntegration: no local .gitignore in remote state
+ *
+ * Records (ActorRecord, CycleRecord) are NOT written by this initializer — the
+ * saas-api orchestrator stages them directly via gitModule.add({contentMap}) on
+ * the same shared gitModule instance (IKS-A42). Sharing the gitModule means
+ * finalize() commits config.json + policy.yml + actors/{id}.json + cycles/{id}.json
+ * all in a single atomic commit (IKS-T6).
+ *
+ * @see github_project_initializer_module.md for EARS specifications (GPI01-GPI13).
+ */
+export class GitHubProjectInitializer implements IProjectInitializer {
+  private readonly branch: string;
+  private readonly basePath: string;
+  private readonly commitMessage: string;
+  private readonly commitAuthor: CommitAuthor;
+
+  /**
+   * Tracks whether createProjectStructure() created the branch in this init run.
+   * Used by rollback() to decide whether to delete the branch (we created it)
+   * or leave it alone (it preexisted).
+   */
+  private branchCreatedByThisInit: boolean = false;
+
+  constructor(
+    private readonly gitModule: IGitModule,
+    private readonly configStore: ConfigStore<unknown>,
+    options: GitHubProjectInitializerOptions,
+  ) {
+    // owner/repo are required options for caller-declared intent + future extensibility,
+    // but not stored internally — the injected gitModule and configStore already carry
+    // them. Re-storing would be dead state (TypeScript noUnusedLocals rejects unused private fields).
+    this.branch = options.branch ?? 'gitgov-state';
+    this.basePath = options.basePath ?? '.gitgov';
+    this.commitMessage = options.commitMessage ?? 'gitgov: remote init';
+    this.commitAuthor = options.commitAuthor ?? {
+      name: 'gitgov bot',
+      email: 'bot@gitgov.dev',
+    };
+  }
+
+  // GPI01/GPI02/GPI03 — IKS-T1: create branch (if needed) + stage policy.yml
+  async createProjectStructure(): Promise<void> {
+    const exists = await this.gitModule.branchExists(this.branch);
+    if (!exists) {
+      // startPoint undefined → create from default branch via GitHubGitModule semantics
+      await this.gitModule.createBranch(this.branch, undefined);
+      this.branchCreatedByThisInit = true;
+    }
+
+    // Stage policy.yml in the shared gitModule buffer. No .gitkeep —
+    // directories emerge naturally from the files written in the final commit.
+    const policyPath = `${this.basePath}/policy.yml`;
+    await this.gitModule.add([policyPath], {
+      contentMap: { [policyPath]: DEFAULT_POLICY_YML },
+    });
+  }
+
+  // GPI10 — project is initialized iff branch exists AND config.json is loadable
+  async isInitialized(): Promise<boolean> {
+    const branchExists = await this.gitModule.branchExists(this.branch);
+    if (!branchExists) return false;
+    const config = await this.configStore.loadConfig();
+    return config !== null;
+  }
+
+  // GPI05 — IKS-T4: stage config.json in the shared gitModule buffer.
+  // Does NOT delegate to configStore.saveConfig() — that makes an immediate
+  // Contents API PUT which would violate IKS-T6 "all in 1 commit".
+  async writeConfig(config: GitGovConfig): Promise<void> {
+    const configPath = `${this.basePath}/config.json`;
+    const content = JSON.stringify(config, null, 2);
+    await this.gitModule.add([configPath], {
+      contentMap: { [configPath]: content },
+    });
+  }
+
+  // GPI07 — no-op in remote backend
+  async initializeSession(_actorId: string): Promise<void> {
+    // intentional no-op: sessions tracked via JWE tokens in saas-api, not gitgov-state
+  }
+
+  // GPI04 — IKS-T5: cleanup on init failure. Delete branch if we created it.
+  async rollback(): Promise<void> {
+    if (this.branchCreatedByThisInit) {
+      await this.gitModule.deleteBranch(this.branch);
+      this.branchCreatedByThisInit = false;
+    }
+    // If the branch preexisted, rollback is a no-op — we do not touch state we did not create.
+  }
+
+  // GPI11 — environment validation for remote backend
+  async validateEnvironment(): Promise<EnvironmentValidation> {
+    const branchExists = await this.gitModule.branchExists(this.branch);
+    const config = branchExists ? await this.configStore.loadConfig() : null;
+    const isAlreadyInitialized = branchExists && config !== null;
+
+    return {
+      isValid: !isAlreadyInitialized,
+      isGitRepo: true, // semantically true for a remote GitHub repo
+      hasWritePermissions: true, // assumed post-OAuth; real probe would cost an API call
+      isAlreadyInitialized,
+      hasRemote: true,
+      hasCommits: true,
+      currentBranch: this.branch,
+      warnings: isAlreadyInitialized
+        ? [
+            `Project already initialized at ${this.basePath}/config.json in branch '${this.branch}'`,
+          ]
+        : [],
+      suggestions: [],
+    };
+  }
+
+  // GPI06 — read via gitModule Contents API
+  async readFile(filePath: string): Promise<string> {
+    return this.gitModule.getFileContent(this.branch, filePath);
+  }
+
+  // GPI08 — no-op in remote (no local agent prompt in remote init)
+  async copyAgentPrompt(): Promise<void> {
+    // intentional no-op
+  }
+
+  // GPI09 — no-op in remote (no local .gitignore in remote state)
+  async setupGitIntegration(): Promise<void> {
+    // intentional no-op
+  }
+
+  // GPI12 — canonical remote path for an actor record
+  getActorPath(actorId: string): string {
+    return `${this.basePath}/actors/${actorId}.json`;
+  }
+
+  // GPI13 — IKS-T6: transaction boundary. Materializes all staged writes in 1 commit.
+  async finalize(): Promise<void> {
+    await this.gitModule.commit(this.commitMessage, this.commitAuthor);
+  }
+}

--- a/packages/core/src/project_initializer/github/github_project_initializer.types.ts
+++ b/packages/core/src/project_initializer/github/github_project_initializer.types.ts
@@ -1,0 +1,31 @@
+import type { CommitAuthor } from '../../git';
+
+/**
+ * Options for GitHubProjectInitializer constructor.
+ *
+ * @example
+ *   new GitHubProjectInitializer(
+ *     gitModule,
+ *     configStore,
+ *     {
+ *       owner: 'myorg',
+ *       repo: 'myrepo',
+ *       branch: 'gitgov-state',
+ *       basePath: '.gitgov',
+ *       commitMessage: 'gitgov: remote init',
+ *       commitAuthor: { name: 'gitgov bot', email: 'bot@gitgov.dev' },
+ *     },
+ *   );
+ */
+export type GitHubProjectInitializerOptions = {
+  owner: string;
+  repo: string;
+  /** Branch to initialize (default 'gitgov-state') */
+  branch?: string;
+  /** Base path for all .gitgov files (default '.gitgov') */
+  basePath?: string;
+  /** Commit message used by finalize() (default 'gitgov: remote init') */
+  commitMessage?: string;
+  /** Commit author used by finalize() (default gitgov bot) */
+  commitAuthor?: CommitAuthor;
+};

--- a/packages/core/src/project_initializer/github/index.ts
+++ b/packages/core/src/project_initializer/github/index.ts
@@ -1,0 +1,2 @@
+export { GitHubProjectInitializer } from './github_project_initializer';
+export type { GitHubProjectInitializerOptions } from './github_project_initializer.types';

--- a/packages/core/src/project_initializer/project_initializer.ts
+++ b/packages/core/src/project_initializer/project_initializer.ts
@@ -120,8 +120,14 @@ export interface IProjectInitializer {
    *
    * Calling `finalize()` more than once in a single initialization sequence
    * is an error.
+   *
+   * **Return value (added in Cycle 5 Task 5.1b for identity_key_sync):**
+   * Transactional backends return the commit SHA of the atomic commit
+   * (useful for observability and state machine events — e.g.,
+   * `RepoStateMachineService.transition({type: 'INIT_COMPLETE', commitSha})`).
+   * Non-transactional backends (filesystem) return `undefined`.
    */
-  finalize(): Promise<void>;
+  finalize(): Promise<string | undefined>;
 }
 
 // EnvironmentValidation is defined in ./project_initializer.types.ts

--- a/packages/core/src/project_initializer/project_initializer.ts
+++ b/packages/core/src/project_initializer/project_initializer.ts
@@ -54,7 +54,17 @@ export interface IProjectInitializer {
   initializeSession(actorId: string): Promise<void>;
 
   /**
-   * Cleans up partial setup if initialization fails.
+   * Cleanup-on-failure for a failed initialization — NOT an uninstall command.
+   *
+   * Called in the failure path of the sequence `createProjectStructure →
+   * writeConfig → initializeSession → ...` to leave the backend in the state
+   * it was in before the failed init attempt. It is NOT a command to
+   * uninstall an already successfully-initialized project — that would be
+   * a distinct operation outside this contract.
+   *
+   * Implementations should be graceful: if called when there is nothing to
+   * roll back (e.g. no artifacts created yet), it SHALL complete without
+   * throwing.
    */
   rollback(): Promise<void>;
 
@@ -90,6 +100,28 @@ export interface IProjectInitializer {
    * @returns Path or identifier for the actor
    */
   getActorPath(actorId: string): string;
+
+  /**
+   * Finalize the initialization transaction — Unit of Work pattern
+   * (added in Cycle 5, IKS-A40 / EARS-PI11).
+   *
+   * Materializes pending writes on backends with transactional semantics.
+   * Must be called as the final step of an initialization sequence for writes
+   * to become durable on transactional backends.
+   *
+   * - **Filesystem backend (`FsProjectInitializer`):** no-op. All write methods
+   *   persist immediately via `fs.writeFile`/`fs.mkdir` — there is no
+   *   transaction buffer to commit.
+   *
+   * - **GitHub backend (`GitHubProjectInitializer`, Task 5.1a):** triggers the
+   *   commit (`gitModule.commit(message, author)`) that materializes all staged
+   *   writes (config.json, policy.yml, and orchestrator-staged records) into a
+   *   single atomic commit via the 6-step transaction of `GitHubGitModule`.
+   *
+   * Calling `finalize()` more than once in a single initialization sequence
+   * is an error.
+   */
+  finalize(): Promise<void>;
 }
 
 // EnvironmentValidation is defined in ./project_initializer.types.ts

--- a/packages/core/src/utils/id_generator.test.ts
+++ b/packages/core/src/utils/id_generator.test.ts
@@ -3,7 +3,8 @@ import {
   generateTaskId,
   generateCycleId,
   generateExecutionId,
-  generateFeedbackId
+  generateFeedbackId,
+  computeSuccessorActorId
 } from './id_generator';
 
 describe('ID Generators', () => {
@@ -38,6 +39,27 @@ describe('ID Generators', () => {
   describe('generateFeedbackId', () => {
     it('[EARS-6] should create a valid feedback ID', () => {
       expect(generateFeedbackId('Code Review Comments', 77777)).toBe('77777-feedback-code-review-comments');
+    });
+  });
+
+  describe('computeSuccessorActorId (RFC-02 §6.3)', () => {
+    it('[EARS-7] should append -v2 for first rotation', () => {
+      expect(computeSuccessorActorId('human:camilo')).toBe('human:camilo-v2');
+    });
+
+    it('[EARS-7] should increment version for subsequent rotations', () => {
+      expect(computeSuccessorActorId('human:camilo-v2')).toBe('human:camilo-v3');
+      expect(computeSuccessorActorId('human:camilo-v99')).toBe('human:camilo-v100');
+    });
+
+    it('[EARS-7] should handle agent IDs', () => {
+      expect(computeSuccessorActorId('agent:aion')).toBe('agent:aion-v2');
+      expect(computeSuccessorActorId('agent:camilo:cursor-v3')).toBe('agent:camilo:cursor-v4');
+    });
+
+    it('[EARS-7] should produce valid actor ID pattern', () => {
+      const result = computeSuccessorActorId('human:dev');
+      expect(result).toMatch(/^(human|agent)(:[a-z0-9-]+)+$/);
     });
   });
 });

--- a/packages/core/src/utils/id_generator.ts
+++ b/packages/core/src/utils/id_generator.ts
@@ -19,6 +19,23 @@ export function generateActorId(type: 'human' | 'agent', displayName: string): s
 }
 
 /**
+ * Computes the successor actor ID for key rotation (RFC-02 §6.3).
+ * Pattern: first rotation appends '-v2', subsequent increments version.
+ *
+ * @example
+ *   computeSuccessorActorId('human:camilo')     → 'human:camilo-v2'
+ *   computeSuccessorActorId('human:camilo-v2')  → 'human:camilo-v3'
+ *   computeSuccessorActorId('human:camilo-v99') → 'human:camilo-v100'
+ */
+export function computeSuccessorActorId(actorId: string): string {
+  const versionMatch = actorId.match(/^(.+)-v(\d+)$/);
+  if (versionMatch && versionMatch[1] && versionMatch[2]) {
+    return `${versionMatch[1]}-v${parseInt(versionMatch[2], 10) + 1}`;
+  }
+  return `${actorId}-v2`;
+}
+
+/**
  * Generates an Agent ID (e.g., 'agent:code-reviewer').
  * Convenience wrapper over generateActorId for agent-specific use cases.
  */

--- a/packages/core/src/utils/project_discovery.test.ts
+++ b/packages/core/src/utils/project_discovery.test.ts
@@ -22,9 +22,10 @@ jest.mock('fs', () => ({
   realpathSync: jest.fn((p: string) => p),
 }));
 
-import { existsSync } from 'fs';
+import { existsSync, realpathSync } from 'fs';
 
 const mockedExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
+const mockedRealpathSync = realpathSync as jest.MockedFunction<typeof realpathSync>;
 
 describe('Project Discovery', () => {
   beforeEach(() => {
@@ -106,6 +107,21 @@ describe('Project Discovery', () => {
       const result2 = getWorktreeBasePath('/test/project-b');
 
       expect(result1).not.toBe(result2);
+    });
+
+    it('[EARS-B4] WHEN getWorktreeBasePath is called with a symlinked path and its resolved path, THE SYSTEM SHALL return the same hash', () => {
+      mockedRealpathSync.mockImplementation((p) => {
+        const s = typeof p === 'string' ? p : p.toString();
+        if (s.startsWith('/tmp/')) return s.replace('/tmp/', '/private/tmp/') as never;
+        return s as never;
+      });
+
+      const viaSymlink = getWorktreeBasePath('/tmp/my-project');
+      const viaReal = getWorktreeBasePath('/private/tmp/my-project');
+
+      expect(viaSymlink).toBe(viaReal);
+
+      mockedRealpathSync.mockImplementation((p) => (typeof p === 'string' ? p : p.toString()) as never);
     });
   });
 

--- a/packages/core/src/watcher_state/fs/fs_watcher_state.test.ts
+++ b/packages/core/src/watcher_state/fs/fs_watcher_state.test.ts
@@ -22,7 +22,8 @@ import { FsWatcherStateModule } from "./fs_watcher_state";
 import { ProjectNotInitializedError } from "../watcher_state.errors";
 
 const TEST_DEBOUNCE = 50;
-const WAIT_MS = 600;
+// CI runners have slower filesystem — need extra margin for watcher debounce
+const WAIT_MS = process.env['CI'] ? 2000 : 600;
 
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/e2e/tests/helpers/cli.ts
+++ b/packages/e2e/tests/helpers/cli.ts
@@ -56,7 +56,8 @@ export function runGitgovCli(args: string, options: { cwd: string; expectError?:
 
 // [HLP-A2] Create a temp git repo with initial commit
 export function createTempGitRepo(): { tmpDir: string; repoDir: string } {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-'));
+  const rawTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-'));
+  const tmpDir = fs.realpathSync(rawTmpDir);
   const repoDir = path.join(tmpDir, 'repo');
   fs.mkdirSync(repoDir, { recursive: true });
   execSync('git init --initial-branch=main', { cwd: repoDir, stdio: 'pipe' });

--- a/packages/e2e/tests/helpers/cli.ts
+++ b/packages/e2e/tests/helpers/cli.ts
@@ -111,6 +111,10 @@ export function spawnGitgovCli(args: string, options: { cwd: string; timeout?: n
     },
     waitForExit(timeoutMs = 30000) {
       return new Promise((resolve) => {
+        if (child.exitCode !== null) {
+          resolve({ stdout: out, stderr: err, exitCode: child.exitCode });
+          return;
+        }
         const timer = setTimeout(() => {
           child.kill();
           resolve({ stdout: out, stderr: err, exitCode: null });

--- a/packages/e2e/tests/helpers/cli.ts
+++ b/packages/e2e/tests/helpers/cli.ts
@@ -1,8 +1,10 @@
 /**
  * CLI Helpers — Execute the globally installed gitgov CLI for E2E tests.
- * [HLP-A1] Real binary execution, [HLP-A2] Git repo creation, [HLP-A3] Worktree cleanup.
+ * [HLP-A1] Real binary execution (sync), [HLP-A4] Async spawn for interactive commands.
+ * [HLP-A2] Git repo creation, [HLP-A3] Worktree cleanup.
  */
-import { execSync } from 'child_process';
+import { execSync, spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -12,6 +14,15 @@ export type CliResult = {
   success: boolean;
   output: string;
   error: string | null;
+};
+
+export type SpawnedCli = {
+  process: ChildProcess;
+  stdout: () => string;
+  stderr: () => string;
+  waitForOutput: (match: string | RegExp, timeoutMs?: number) => Promise<string>;
+  waitForExit: (timeoutMs?: number) => Promise<{ stdout: string; stderr: string; exitCode: number | null }>;
+  kill: () => void;
 };
 
 // [HLP-A1] Execute the globally installed gitgov CLI
@@ -66,6 +77,52 @@ export function createBareRemote(): { remotePath: string } {
 
 export function addRemote(repoPath: string, remotePath: string): void {
   execSync(`git remote add origin "${remotePath}"`, { cwd: repoPath, stdio: 'pipe' });
+}
+
+// [HLP-A4] Spawn gitgov CLI as async child process (for interactive/long-running commands)
+export function spawnGitgovCli(args: string, options: { cwd: string; timeout?: number }): SpawnedCli {
+  const child = spawn('gitgov', args.split(/\s+/), {
+    cwd: options.cwd,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env },
+  });
+
+  let out = '';
+  let err = '';
+  child.stdout?.on('data', (d: Buffer) => { out += d.toString(); });
+  child.stderr?.on('data', (d: Buffer) => { err += d.toString(); });
+
+  return {
+    process: child,
+    stdout: () => out,
+    stderr: () => err,
+    waitForOutput(match, timeoutMs = 10000) {
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`Timed out waiting for output matching ${match}`)), timeoutMs);
+        const check = () => {
+          const combined = out + err;
+          const found = typeof match === 'string' ? combined.includes(match) : match.test(combined);
+          if (found) { clearTimeout(timer); resolve(combined); }
+        };
+        child.stdout?.on('data', check);
+        child.stderr?.on('data', check);
+        check();
+      });
+    },
+    waitForExit(timeoutMs = 30000) {
+      return new Promise((resolve) => {
+        const timer = setTimeout(() => {
+          child.kill();
+          resolve({ stdout: out, stderr: err, exitCode: null });
+        }, timeoutMs);
+        child.on('close', (code) => {
+          clearTimeout(timer);
+          resolve({ stdout: out, stderr: err, exitCode: code });
+        });
+      });
+    },
+    kill() { child.kill(); },
+  };
 }
 
 // [HLP-A3] Clean up worktree created by CLI init

--- a/packages/e2e/tests/helpers/github.ts
+++ b/packages/e2e/tests/helpers/github.ts
@@ -23,6 +23,7 @@ export function createGitHubCoreBackend(octokit: Octokit): unknown {
       new GitHubConfigStore({ owner: opts.owner, repo: opts.repo, ref: opts.ref }, octokit),
     verifyInstallation: async () => true,
     findInstallationForOrg: async () => null,
+    isRepoInInstallation: async () => false,
   };
 }
 

--- a/packages/e2e/tests/helpers/github.ts
+++ b/packages/e2e/tests/helpers/github.ts
@@ -21,6 +21,7 @@ export function createGitHubCoreBackend(octokit: Octokit): unknown {
       ),
     createConfigStore: async (opts: { owner: string; repo: string; ref?: string }) =>
       new GitHubConfigStore({ owner: opts.owner, repo: opts.repo, ref: opts.ref }, octokit),
+    verifyInstallation: async () => true,
   };
 }
 

--- a/packages/e2e/tests/helpers/github.ts
+++ b/packages/e2e/tests/helpers/github.ts
@@ -22,6 +22,7 @@ export function createGitHubCoreBackend(octokit: Octokit): unknown {
     createConfigStore: async (opts: { owner: string; repo: string; ref?: string }) =>
       new GitHubConfigStore({ owner: opts.owner, repo: opts.repo, ref: opts.ref }, octokit),
     verifyInstallation: async () => true,
+    findInstallationForOrg: async () => null,
   };
 }
 

--- a/packages/e2e/tests/helpers/helpers.test.ts
+++ b/packages/e2e/tests/helpers/helpers.test.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 
 import {
   runGitgovCli,
+  spawnGitgovCli,
   createTempGitRepo,
   cleanupWorktree,
   createProtocolPrisma,
@@ -39,7 +40,7 @@ afterAll(() => {
 
 describe('E2E Helpers', () => {
 
-  describe('4.1. CLI Helpers (HLP-A1 to HLP-A3)', () => {
+  describe('4.1. CLI Helpers (HLP-A1 to HLP-A4)', () => {
 
     it('[HLP-A1] should execute gitgov --version and return success', () => {
       const { tmpDir, repoDir } = createTempGitRepo();
@@ -73,6 +74,18 @@ describe('E2E Helpers', () => {
       cleanupWorktree(repoDir);
 
       expect(fs.existsSync(gitgovDir)).toBe(false);
+    });
+
+    it('[HLP-A4] should spawn gitgov CLI and resolve waitForOutput when output matches', async () => {
+      const { tmpDir, repoDir } = createTempGitRepo();
+      tempDirs.push(tmpDir);
+
+      const cli = spawnGitgovCli('--version', { cwd: repoDir });
+      const output = await cli.waitForOutput(/\d+\.\d+\.\d+/, 5000);
+      expect(output).toMatch(/\d+\.\d+\.\d+/);
+
+      const result = await cli.waitForExit(5000);
+      expect(result.exitCode).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- `IGitModule.deleteBranch()` added to interface + 3 backends (local, memory, github) with idempotent semantics
- `IProjectInitializer.finalize()` transaction boundary — Unit of Work pattern for backends with explicit commit semantics (FS = no-op)
- `GitHubProjectInitializer` — new `@gitgov/core/github` sibling implementing `IProjectInitializer` against GitHub REST API
- `GitHubGitModule` error handling refactor — migrated to `mapOctokitError` convention (41→4 manual throws)
- `GitHubGitModule.createBranch` fallback for missing activeRef + `deleteBranch` URL encoding fix
- Key succession: `revokeActor` + `rotateActorKey` sign per RFC-02 §6.3 (proof of ownership)
- `buildSignatureDigest` + `computeSuccessorActorId` exported from `@gitgov/core`
- `FsKeyProvider` colon sanitization in key filenames (consistency with `FsRecordStore`)
- CLI smart init: `gitgov init` checks remote for `gitgov-state` before generating keypair
- CLI login: `--force-local` / `--force-cloud` conflict resolution, key succession handling, post-sync push
- E2E helpers: `spawnGitgovCli` for interactive CLI testing, `createGitHubCoreBackend` extensions

## Test Results

| Suite | Count | Status |
|-------|-------|--------|
| core github_git_module | 46/46 | ✅ |
| core fs_key_provider | 19/19 | ✅ |
| core identity_adapter | passing | ✅ |
| cli login-command | 27/27 | ✅ |
| cli init-command | 35/35 | ✅ |
| tsc | 0 errors | ✅ |

## Stats

30 commits, 46 files changed, +2,559 / -335 lines