### PR TITLE
fix(core,cli): IKS Phase 2 Cycle 1 — buildMetaWhere + collab fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Agent:  "Sprint is 70% done, 3 tasks active, 1 blocked."
 | Package | Version | Tests | License | Purpose |
 |:--------|:--------|------:|:--------|:--------|
 | **Protocol** | — | — | ![Apache-2.0](https://img.shields.io/badge/Apache--2.0-brightgreen.svg) | The **Standard** — RFCs, schemas, specifications |
-| [`@gitgov/core`](packages/core/README.md) | 2.10.1 | 2,568 | ![MPL-2.0](https://img.shields.io/badge/MPL--2.0-brightgreen.svg) | The **Engine** — SDK for records, validation, storage, adapters |
-| [`@gitgov/cli`](packages/cli/README.md) | 2.1.0 | 475 | ![Apache-2.0](https://img.shields.io/badge/Apache--2.0-brightgreen.svg) | The **Tool** — CLI for humans and AI agents |
+| [`@gitgov/core`](packages/core/README.md) | 3.12.0 | 2,876 | ![MPL-2.0](https://img.shields.io/badge/MPL--2.0-brightgreen.svg) | The **Engine** — SDK for records, validation, storage, adapters |
+| [`@gitgov/cli`](packages/cli/README.md) | 3.0.0 | 547 | ![Apache-2.0](https://img.shields.io/badge/Apache--2.0-brightgreen.svg) | The **Tool** — CLI for humans and AI agents |
 | [`@gitgov/mcp-server`](packages/mcp-server/README.md) | — | 199 | ![Apache-2.0](https://img.shields.io/badge/Apache--2.0-brightgreen.svg) | The **Bridge** — 43 MCP tools for AI agents |
-| [`@gitgov/e2e`](packages/e2e/README.md) | — | 36 | ![Apache-2.0](https://img.shields.io/badge/Apache--2.0-brightgreen.svg) | The **Validation** — Cross-package E2E tests (CLI + core + GitHub) |
+| [`@gitgov/e2e`](packages/e2e/README.md) | — | 80 | ![Apache-2.0](https://img.shields.io/badge/Apache--2.0-brightgreen.svg) | The **Validation** — Cross-package E2E tests (CLI + core + GitHub) |
 
 ## Community
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -230,7 +230,7 @@ This package is licensed under the [Apache License 2.0](https://opensource.org/l
 
 > For development rules, conventions, and architecture see the [AGENTS.md](../../packages/blueprints/03_products/cli/AGENTS.md).
 
-**Last updated:** 2026-04-05 — 17 commands (login added). Adapters count fixed (10→7).
+**Last updated:** 2026-04-26 — 17 commands, 547 tests. Note: esbuild uses `--external:@gitgov/core` — core is resolved at runtime, not bundled. Rebuild core + re-link CLI after core changes.
 
 
 ## @gitgov/core — Type System

--- a/packages/cli/e2e/actor_command_e2e.test.ts
+++ b/packages/cli/e2e/actor_command_e2e.test.ts
@@ -272,10 +272,11 @@ describe('Actor CLI Command - E2E Tests', () => {
       expect(newActorActive).toBe(true);
 
       // 5. Verify new actor has a .key file
-      // FsKeyProvider uses actorId directly (colons preserved) as filename
+      // FsKeyProvider encodes actorId (: → _) for the filename
       const keysDir = path.join(worktreeBasePath, '.gitgov', 'keys');
       const keyFiles = fs.readdirSync(keysDir).filter(f => f.endsWith('.key'));
-      const hasNewKey = keyFiles.some(f => f.includes(newActorId));
+      const encodedNewActorId = newActorId.replace(/:/g, '_');
+      const hasNewKey = keyFiles.some(f => f.includes(encodedNewActorId));
       expect(hasNewKey).toBe(true);
     });
 

--- a/packages/cli/e2e/init_command_e2e.test.ts
+++ b/packages/cli/e2e/init_command_e2e.test.ts
@@ -248,16 +248,15 @@ describe('Init CLI Command - Edge Cases E2E Tests', () => {
       cleanupWorktree(testProjectRoot, worktreeBasePath);
     });
 
-    it('WHEN remote exists but gitgov-state does not THE SYSTEM SHALL init without creating gitgov-state (lazy)', () => {
+    it('WHEN remote exists but gitgov-state does not THE SYSTEM SHALL init and push gitgov-state to remote', () => {
       const result = runCliCommand(['init', '--name', 'New Remote Project', '--actor-name', 'Test User', '--quiet'], { cwd: testProjectRoot });
 
       expect(result.success).toBe(true);
       expect(fs.existsSync(path.join(worktreeBasePath, '.gitgov'))).toBe(true);
 
-      // With worktree mode, gitgov-state IS created locally for the worktree
-      // but it should NOT be pushed to remote until sync push
+      // With GitHubProjectInitializer, init now pushes gitgov-state to remote automatically
       const remoteBranches = execSync('git ls-remote --heads origin gitgov-state', { cwd: testProjectRoot, encoding: 'utf8' });
-      expect(remoteBranches.trim()).toBe('');
+      expect(remoteBranches.trim()).toContain('gitgov-state');
     });
 
     it('WHEN init completes THE SYSTEM SHALL allow sync push to create remote gitgov-state', () => {
@@ -386,7 +385,8 @@ describe('Init CLI Command - Edge Cases E2E Tests', () => {
     });
 
     it('[EARS-E8] WHEN gitgov-state exists but is empty THE SYSTEM SHALL bootstrap from it or init fresh', () => {
-      const result = runCliCommand(['init', '--name', 'Bootstrap Project', '--actor-name', 'Test User', '--quiet'], { cwd: testProjectRoot });
+      // --force-local bypasses Smart Init which aborts when remote has gitgov-state
+      const result = runCliCommand(['init', '--name', 'Bootstrap Project', '--actor-name', 'Test User', '--force-local', '--quiet'], { cwd: testProjectRoot });
 
       expect(result.success).toBe(true);
       expect(fs.existsSync(path.join(worktreeBasePath, '.gitgov'))).toBe(true);
@@ -394,7 +394,8 @@ describe('Init CLI Command - Edge Cases E2E Tests', () => {
     });
 
     it('[EARS-E9] WHEN bootstrapping from empty state THE SYSTEM SHALL update gitgov-state with new config', () => {
-      runCliCommand(['init', '--name', 'Bootstrap Project', '--actor-name', 'Test User', '--quiet'], { cwd: testProjectRoot });
+      // --force-local bypasses Smart Init which aborts when remote has gitgov-state
+      runCliCommand(['init', '--name', 'Bootstrap Project', '--actor-name', 'Test User', '--force-local', '--quiet'], { cwd: testProjectRoot });
 
       // Ensure we're on main branch (init may leave us on gitgov-state in some edge cases)
       execSync('git checkout main', { cwd: testProjectRoot, stdio: 'pipe' });

--- a/packages/cli/e2e/sync_command_e2e.test.ts
+++ b/packages/cli/e2e/sync_command_e2e.test.ts
@@ -295,9 +295,9 @@ describe('Sync CLI Commands - E2E Tests', () => {
         fs.writeFileSync(path.join(cloneGitgov, 'keys', keyFiles[0]), keyContent);
       }
 
-      // Create session in clone
+      // Create session in clone (decode _ → : to get real actorId)
       const sessionContent = JSON.stringify({
-        lastSession: { actorId: keyFiles[0]?.replace('.key', ''), timestamp: new Date().toISOString() }
+        lastSession: { actorId: (keyFiles[0]?.replace('.key', '') ?? '').replace(/_/g, ':'), timestamp: new Date().toISOString() }
       });
       fs.writeFileSync(path.join(cloneGitgov, '.session.json'), sessionContent);
 
@@ -352,7 +352,7 @@ describe('Sync CLI Commands - E2E Tests', () => {
         fs.writeFileSync(path.join(cloneGitgov, 'keys', keyFiles[0]), keyContent);
       }
       const sessionContent = JSON.stringify({
-        lastSession: { actorId: keyFiles[0]?.replace('.key', ''), timestamp: new Date().toISOString() }
+        lastSession: { actorId: (keyFiles[0]?.replace('.key', '') ?? '').replace(/_/g, ':'), timestamp: new Date().toISOString() }
       });
       fs.writeFileSync(path.join(cloneGitgov, '.session.json'), sessionContent);
 
@@ -439,7 +439,7 @@ describe('Sync CLI Commands - E2E Tests', () => {
       fs.mkdirSync(path.join(cloneGitgov, 'keys'), { recursive: true });
       fs.writeFileSync(path.join(cloneGitgov, 'keys', keyFileName), keyContentBefore);
       const sessionContent = JSON.stringify({
-        lastSession: { actorId: keyFileName.replace('.key', ''), timestamp: new Date().toISOString() }
+        lastSession: { actorId: keyFileName.replace('.key', '').replace(/_/g, ':'), timestamp: new Date().toISOString() }
       });
       fs.writeFileSync(path.join(cloneGitgov, '.session.json'), sessionContent);
 
@@ -518,7 +518,7 @@ describe('Sync CLI Commands - E2E Tests', () => {
         fs.writeFileSync(path.join(cloneGitgov, 'keys', keyFiles[0]), keyContent);
       }
       const sessionContent = JSON.stringify({
-        lastSession: { actorId: keyFiles[0]?.replace('.key', ''), timestamp: new Date().toISOString() }
+        lastSession: { actorId: (keyFiles[0]?.replace('.key', '') ?? '').replace(/_/g, ':'), timestamp: new Date().toISOString() }
       });
       fs.writeFileSync(path.join(cloneGitgov, '.session.json'), sessionContent);
 
@@ -730,9 +730,9 @@ describe('Sync CLI Commands - E2E Tests', () => {
         fs.readFileSync(path.join(originKeysDir, keyFileName), 'utf-8')
       );
 
-      // Create session for Agent B
+      // Create session for Agent B (decode _ → : to get real actorId)
       const sessionContent = JSON.stringify({
-        lastSession: { actorId: keyFileName.replace('.key', ''), timestamp: new Date().toISOString() }
+        lastSession: { actorId: keyFileName.replace('.key', '').replace(/_/g, ':'), timestamp: new Date().toISOString() }
       });
       fs.writeFileSync(path.join(cloneWorktree, '.gitgov', '.session.json'), sessionContent);
 
@@ -799,7 +799,7 @@ describe('Sync CLI Commands - E2E Tests', () => {
         );
       }
       const sessionContent = JSON.stringify({
-        lastSession: { actorId: keyFiles[0]?.replace('.key', ''), timestamp: new Date().toISOString() }
+        lastSession: { actorId: (keyFiles[0]?.replace('.key', '') ?? '').replace(/_/g, ':'), timestamp: new Date().toISOString() }
       });
       fs.writeFileSync(path.join(cloneWorktree, '.gitgov', '.session.json'), sessionContent);
 

--- a/packages/cli/src/commands/init/init-command.ts
+++ b/packages/cli/src/commands/init/init-command.ts
@@ -41,8 +41,8 @@ export class InitCommand {
    */
   async execute(options: InitCommandOptions): Promise<void> {
     try {
-      // 1. Environment validation (unless skipped)
-      if (!options.skipValidation) {
+      // 1. Environment validation (unless skipped or force-local)
+      if (!options.skipValidation && !options.forceLocal) {
         await this.validateEnvironment(options);
       }
 
@@ -94,7 +94,7 @@ export class InitCommand {
       if (completeOptions.actorEmail) projectInitOptions.actorEmail = completeOptions.actorEmail;
       // [EARS-A4] Configure methodology according to flag
       if (completeOptions.methodology) projectInitOptions.methodology = completeOptions.methodology;
-      if (completeOptions.skipValidation) projectInitOptions.skipValidation = completeOptions.skipValidation;
+      if (completeOptions.skipValidation || completeOptions.forceLocal) projectInitOptions.skipValidation = true;
       if (completeOptions.verbose) projectInitOptions.verbose = completeOptions.verbose;
       if (completeOptions.login) projectInitOptions.login = completeOptions.login;
       const saasUrl = completeOptions.saasUrl || process.env['GITGOV_SAAS_URL'] || 'https://app.gitgov.dev';

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -755,7 +755,7 @@ describe('LoginCommand v2', () => {
       );
     });
 
-    it('[LOGIN-J3] should use local actor actorId for key sync instead of github login', async () => {
+    it('[LOGIN-J3] should use local actor actorId when it matches the logged-in user', async () => {
       const { execSync } = await import('child_process');
       (execSync as jest.MockedFunction<typeof execSync>).mockImplementation((cmd: unknown) => {
         if (typeof cmd === 'string' && cmd.includes('fetch')) return '';
@@ -764,7 +764,7 @@ describe('LoginCommand v2', () => {
 
       mockGetConfig.mockResolvedValue({ saasUrl: 'https://app.gitgov.dev' });
       mockGetCurrentActor.mockResolvedValue({
-        id: 'human:camilo-acua-godoy',
+        id: 'human:camilo:v2',
         type: 'human',
         displayName: 'Camilo Acuña Godoy',
       });
@@ -777,9 +777,39 @@ describe('LoginCommand v2', () => {
       const cmd = new LoginCommand(deps);
       await cmd.executeLogin(defaultOptions);
 
-      // Should use local actorId, not human:camilo (github login)
+      // Versioned actorId starts with human:camilo: → matches login → use it
       expect(mockSetLastSession).toHaveBeenCalledWith(
-        'human:camilo-acua-godoy',
+        'human:camilo:v2',
+        expect.any(String),
+      );
+    });
+
+    it('[LOGIN-J3b] should fall back to human:{login} when local actor belongs to a different user', async () => {
+      const { execSync } = await import('child_process');
+      (execSync as jest.MockedFunction<typeof execSync>).mockImplementation((cmd: unknown) => {
+        if (typeof cmd === 'string' && cmd.includes('fetch')) return '';
+        return 'https://github.com/testorg/testrepo.git\n';
+      });
+
+      mockGetConfig.mockResolvedValue({ saasUrl: 'https://app.gitgov.dev' });
+      // Local worktree has the owner's actor, but we're logging in as a different user
+      mockGetCurrentActor.mockResolvedValue({
+        id: 'human:owner-user',
+        type: 'human',
+        displayName: 'Owner User',
+      });
+      mockHasPrivateKey.mockResolvedValue(false);
+
+      const deps = createMockDeps({
+        fetchSaas: createTrpcFetch({ 'keyStatus': noKeyStatus }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      // Local actor is human:owner-user but login is camilo → use human:camilo
+      expect(mockSetLastSession).toHaveBeenCalledWith(
+        'human:camilo',
         expect.any(String),
       );
     });

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -122,9 +122,16 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       const sessionManager = await this.dependencyService.getSessionManager();
       await sessionManager.setCloudToken(token);
 
-      // Discover local actor — use its actorId for key sync, not github login
+      // Use login from OAuth to derive actorId. Only use local actor if it
+      // belongs to the logged-in user (handles versioned IDs like human:login:v2).
+      // Without this check, a collaborator would incorrectly resolve to the owner's actor.
       const localActor = await this.findLocalHumanActor();
-      const actorId = localActor?.actorId ?? `human:${user.login}`;
+      const expectedBase = `human:${user.login}`;
+      const localMatchesUser = localActor != null && (
+        localActor.actorId === expectedBase ||
+        localActor.actorId.startsWith(`${expectedBase}:`)
+      );
+      const actorId = localMatchesUser ? localActor.actorId : expectedBase;
 
       await sessionManager.setLastSession(actorId, new Date().toISOString());
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -83,8 +83,8 @@ await batchStore.putMany([
 ```mermaid
 graph LR
     subgraph "@gitgov/core — Pure Logic"
-        Adapters["Adapters (10)"]
-        Modules["Modules (26)"]
+        Adapters["Adapters (7)"]
+        Modules["Modules (30+)"]
         Records["Record System"]
         Projection["RecordProjector + IRecordProjection"]
 
@@ -156,7 +156,7 @@ graph LR
 | `@gitgov/core` | Interfaces, types, pure logic, factories, validators + all audit types | No |
 | `@gitgov/core/audit` | Audit product types: Finding, Waiver, Scan, PolicyDecision, enums, metadata types | No |
 | `@gitgov/core/fs` | Filesystem implementations (FsRecordStore, FsRecordProjection, LocalGitModule, FsLintModule, ...) | Local |
-| `@gitgov/core/github` | GitHub API implementations (GitHubRecordStore, GitHubGitModule, GitHubConfigStore, GitHubFileLister, GithubSyncStateModule, GithubWebhookHandler) | Remote |
+| `@gitgov/core/github` | GitHub API implementations (GitHubRecordStore, GitHubGitModule, GitHubConfigStore, GitHubFileLister, GithubSyncStateModule) | Remote |
 | `@gitgov/core-gitlab` | GitLab API implementations — [separate package](https://gitlab.com/gitgovernance/core-gitlab) | Remote |
 | `@gitgov/core/memory` | In-memory implementations for testing (MemoryRecordStore, MemoryRecordProjection, MemoryGitModule, ...) | No |
 | `@gitgov/core/prisma` | Database-backed implementations via Prisma-compatible client (PrismaRecordProjection) | Remote |
@@ -309,10 +309,7 @@ Adapters are orchestrators that compose modules. All receive dependencies via co
 | `project_initializer/` | GitGovernance project setup |
 | `logger/` | Logging centralizado |
 | `utils/` | ID generation/parsing, array utils, signature utils |
-| `policy_evaluator/` | Pass/block evaluation by severity threshold (stub — Epic 5 formalizes) |
 | `diagram_generator/` | Mermaid diagram generation |
-| `logger/` | Centralized logging |
-| `utils/` | ID generation/parsing, array utils, signature utils |
 
 ## Development
 

--- a/packages/core/src/adapters/identity_adapter/identity_adapter.ts
+++ b/packages/core/src/adapters/identity_adapter/identity_adapter.ts
@@ -22,7 +22,7 @@ import { generateActorId, computeSuccessorActorId } from '../../utils/id_generat
 import type { ISessionManager } from '../../session_manager';
 
 export class IdentityAdapter implements IIdentityAdapter {
-  private stores: Required<Pick<RecordStores, 'actors'>>;
+  readonly stores: Required<Pick<RecordStores, 'actors'>>;
   private keyProvider: KeyProvider;
   // Optional as of IKS-A46 pre-P9 cleanup. Only `getCurrentActor()` and
   // `rotateActorKey()` consume it; callers that never use those methods
@@ -257,7 +257,6 @@ export class IdentityAdapter implements IIdentityAdapter {
     const session = await this.sessionManager.loadSession();
 
     if (session?.lastSession?.actorId) {
-      // Use resolveCurrentActorId to handle succession chain
       const currentActorId = await this.resolveCurrentActorId(session.lastSession.actorId);
       const actor = await this.getActor(currentActorId);
       if (actor) {

--- a/packages/core/src/adapters/project_adapter/project_adapter.ts
+++ b/packages/core/src/adapters/project_adapter/project_adapter.ts
@@ -66,7 +66,7 @@ export class ProjectAdapter implements IProjectAdapter {
     try {
       // 1. Environment Validation (delegates to IProjectInitializer)
       const envValidation = await this.validateEnvironment();
-      if (!envValidation.isValid) {
+      if (!options.skipValidation && !envValidation.isValid) {
         throw new Error(`Environment validation failed: ${envValidation.warnings.join(', ')}`);
       }
 

--- a/packages/core/src/record_projection/prisma/prisma_record_projection.test.ts
+++ b/packages/core/src/record_projection/prisma/prisma_record_projection.test.ts
@@ -531,6 +531,25 @@ describe('PrismaRecordProjection', () => {
       // Verify createMany is also in the same transaction
       expect(mockClient.gitgovTask.createMany).toHaveBeenCalled();
     });
+
+    it('[EARS-D5] should use metaUniqueFields for GitgovMeta upsert key when tenant fields differ from unique constraint', async () => {
+      const client = createMockClient();
+      const sinkWithMeta = new PrismaRecordProjection({
+        client,
+        tenantFields: { repoId: 'repo-1', orgId: 'org-1', projectionType: 'index' },
+        metaUniqueFields: ['repoId', 'projectionType'],
+      });
+
+      const data = createMockIndexData();
+      await sinkWithMeta.persist(data, {});
+
+      expect(client.gitgovMeta.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { repoId_projectionType: { repoId: 'repo-1', projectionType: 'index' } },
+          create: expect.objectContaining({ repoId: 'repo-1', orgId: 'org-1', projectionType: 'index' }),
+        }),
+      );
+    });
   });
 
   describe('4.5. Metadata Projection (EARS-E1 a E6)', () => {

--- a/packages/core/src/record_projection/prisma/prisma_record_projection.ts
+++ b/packages/core/src/record_projection/prisma/prisma_record_projection.ts
@@ -16,20 +16,31 @@ import type {
 export class PrismaRecordProjection implements IRecordProjection {
   private readonly client: ProjectionClient;
   private readonly tenantFields: Record<string, string>;
+  private readonly metaUniqueFields: string[];
 
   constructor(options: PrismaRecordProjectionOptions) {
     this.client = options.client;
     this.tenantFields = options.tenantFields ?? {};
+    // [EARS-D5] Meta unique fields may be a subset of tenant fields
+    this.metaUniqueFields = options.metaUniqueFields ?? Object.keys(this.tenantFields);
   }
 
   private buildWhere(): Record<string, string> {
     return { ...this.tenantFields };
   }
 
+  // [EARS-D5] Build the composite unique key for GitgovMeta upsert.
+  // Uses metaUniqueFields (not all tenantFields) to match the schema's @@unique constraint.
   private buildMetaWhere(): Record<string, unknown> {
-    const keys = Object.keys(this.tenantFields);
-    if (keys.length > 0) {
-      return { [keys.join('_')]: { ...this.tenantFields } };
+    if (this.metaUniqueFields.length > 0) {
+      const uniqueValues: Record<string, string> = {};
+      for (const key of this.metaUniqueFields) {
+        const value = this.tenantFields[key];
+        if (value !== undefined) {
+          uniqueValues[key] = value;
+        }
+      }
+      return { [this.metaUniqueFields.join('_')]: uniqueValues };
     }
     return {};
   }

--- a/packages/core/src/record_projection/prisma/prisma_record_projection.types.ts
+++ b/packages/core/src/record_projection/prisma/prisma_record_projection.types.ts
@@ -178,4 +178,9 @@ export type ProjectionClient = {
 export type PrismaRecordProjectionOptions = {
   client: ProjectionClient;
   tenantFields?: Record<string, string>;
+  // [EARS-D5] Subset of tenantFields keys that form the GitgovMeta @@unique constraint.
+  // Defaults to all tenantFields keys. Required when the meta unique constraint
+  // excludes fields that are in tenantFields (e.g., orgId is a tenant field but
+  // GitgovMeta's unique is only [repoId, projectionType]).
+  metaUniqueFields?: string[];
 };

--- a/packages/core/src/session_store/fs/fs_session_store.test.ts
+++ b/packages/core/src/session_store/fs/fs_session_store.test.ts
@@ -194,22 +194,24 @@ describe('FsSessionStore', () => {
   // ==================== §4.3 detectActorFromKeyFiles (EARS-C1 to C6) ====================
 
   describe('4.3. detectActorFromKeyFiles (EARS-C1 to C6)', () => {
-    it('[EARS-C1] WHEN detectActorFromKeyFiles is invoked with .key files, THE SYSTEM SHALL return actor ID', async () => {
+    it('[EARS-C1] WHEN detectActorFromKeyFiles is invoked with .key files, THE SYSTEM SHALL decode filename and return actor ID', async () => {
       const store = new FsSessionStore(projectRoot);
-      mockedFs.readdir.mockResolvedValue(['human:camilo-v2.key'] as any);
+      // FsKeyProvider encodes `:` → `_` in filenames (DEFAULT_ID_ENCODER)
+      mockedFs.readdir.mockResolvedValue(['human_camilo-v2.key'] as never);
 
       const result = await store.detectActorFromKeyFiles();
 
+      // Must decode `_` back to `:` to get the real actorId
       expect(result).toBe('human:camilo-v2');
       expect(mockedFs.readdir).toHaveBeenCalledWith('/test/project/.gitgov/keys');
     });
 
-    it('[EARS-C2] WHEN detectActorFromKeyFiles is invoked with multiple .key files, THE SYSTEM SHALL return first', async () => {
+    it('[EARS-C2] WHEN detectActorFromKeyFiles is invoked with multiple .key files, THE SYSTEM SHALL return first alphabetically (decoded)', async () => {
       const store = new FsSessionStore(projectRoot);
       mockedFs.readdir.mockResolvedValue([
-        'human:alice.key',
-        'human:bob.key',
-      ] as any);
+        'human_alice.key',
+        'human_bob.key',
+      ] as never);
 
       const result = await store.detectActorFromKeyFiles();
 
@@ -218,7 +220,7 @@ describe('FsSessionStore', () => {
 
     it('[EARS-C3] WHEN detectActorFromKeyFiles is invoked without .key files, THE SYSTEM SHALL return null', async () => {
       const store = new FsSessionStore(projectRoot);
-      mockedFs.readdir.mockResolvedValue(['other.txt', 'readme.md'] as any);
+      mockedFs.readdir.mockResolvedValue(['other.txt', 'readme.md'] as never);
 
       const result = await store.detectActorFromKeyFiles();
 
@@ -241,7 +243,7 @@ describe('FsSessionStore', () => {
         'human:bob.json',
         'human:charlie.key',
         'readme.md',
-      ] as any);
+      ] as never);
 
       const result = await store.detectActorFromKeyFiles();
 
@@ -250,7 +252,7 @@ describe('FsSessionStore', () => {
 
     it('[EARS-C6] WHEN detectActorFromKeyFiles is invoked with empty directory, THE SYSTEM SHALL return null', async () => {
       const store = new FsSessionStore(projectRoot);
-      mockedFs.readdir.mockResolvedValue([] as any);
+      mockedFs.readdir.mockResolvedValue([] as never);
 
       const result = await store.detectActorFromKeyFiles();
 

--- a/packages/core/src/session_store/fs/fs_session_store.ts
+++ b/packages/core/src/session_store/fs/fs_session_store.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import type { SessionStore } from '../session_store';
 import type { GitGovSession } from '../../session_manager/session_manager.types';
 import { SessionManager } from '../../session_manager/session_manager';
+import { DEFAULT_ID_ENCODER } from '../../record_store/record_store';
 
 /**
  * Filesystem-based SessionStore implementation.
@@ -69,8 +70,8 @@ export class FsSessionStore implements SessionStore {
   /**
    * Detect actor from .key files in .gitgov/keys/
    *
-   * [EARS-C1] Returns actor ID from first .key file
-   * [EARS-C2] Returns first .key file alphabetically if multiple exist
+   * [EARS-C1] Returns decoded actor ID from first .key file (filename uses DEFAULT_ID_ENCODER: `_` → `:`)
+   * [EARS-C2] Returns first .key file alphabetically if multiple exist (decoded)
    * [EARS-C3] Returns null if no .key files exist
    * [EARS-C4] Returns null if keys directory doesn't exist
    * [EARS-C5] Ignores non-.key files
@@ -91,10 +92,10 @@ export class FsSessionStore implements SessionStore {
         return null;
       }
 
-      // Extract actor ID from filename (remove .key extension)
-      // e.g., "human:camilo-v2.key" -> "human:camilo-v2"
-      const actorId = firstKeyFile.replace('.key', '');
-      return actorId;
+      // Extract actor ID from filename (remove .key extension, decode _ → :)
+      // e.g., "human_camilo-v2.key" -> "human:camilo-v2"
+      const encoded = firstKeyFile.replace('.key', '');
+      return DEFAULT_ID_ENCODER.decode(encoded);
     } catch {
       // Directory doesn't exist or can't be read
       return null;

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -2,129 +2,94 @@
 
 Cross-package E2E tests for the GitGovernance monorepo. Tests run against real infrastructure: CLI binary (`node gitgov.mjs`), PostgreSQL database, GitHub API, and filesystem.
 
+> Para reglas de desarrollo, blocks, tiempos, y arquitectura ver el [AGENTS.md del package](../../packages/blueprints/03_products/e2e/AGENTS.md).
+
 ## Core Dependency
 
-This package depends on `@gitgov/core` for all record types, audit types, and adapters. Never redefine types that exist in core — import them. See [core README](../core/README.md#rules-for-consumers) for the 5 rules.
-
-```typescript
-// Correct
-import type { Finding, Waiver, PolicyDecision } from '@gitgov/core';
-import type { GitGovExecutionRecord, GitGovFeedbackRecord } from '@gitgov/core';
-
-// Wrong — never redefine
-type Finding = { severity: string; ... };
-```
+This package depends on `@gitgov/core` for all record types, audit types, and adapters. Never redefine types — import from `@gitgov/core`.
 
 ## Prerequisites
 
 ```bash
-# 1. Build CLI (required for all tests)
+# 1. Build CLI (required for CLI-based tests)
 cd packages/cli && pnpm build
-# Produces build/dist/gitgov.mjs
 
-# 2. PostgreSQL (required for Blocks B, D, E, F)
-docker compose up -d
-# PostgreSQL at localhost:5432
+# 2. PostgreSQL (required for projection tests)
+docker run -d --name gitgov-pg -e POSTGRES_USER=gitgov -e POSTGRES_PASSWORD=gitgov -e POSTGRES_DB=gitgov_dev -p 5432:5432 postgres:16
 
-# 3. Prisma migrations
-cd packages/core && npx prisma migrate deploy
-
-# 4. GitHub token (required for Blocks C, D, F — others skip gracefully)
+# 3. GitHub token (required for T2 tests — T1 tests skip gracefully)
 export GITHUB_TOKEN=ghp_xxxxxxxxxxxx
 ```
 
+`globalSetup.ts` creates the 2 E2E databases (`gitgov_e2e_protocol`, `gitgov_e2e_audit`) and runs `prisma db push` automatically.
+
 ## Environment Variables
 
-| Variable                | Required       | Default                                                | Used by                                                |
-| ----------------------- | -------------- | ------------------------------------------------------ | ------------------------------------------------------ |
-| `DATABASE_URL`          | Blocks B,D,E,F | `postgresql://gitgov:gitgov@localhost:5432/gitgov_dev` | Prisma + projection                                    |
-| `GITHUB_TOKEN`          | Blocks C,D,F   | —                                                      | GitHub API auth                                        |
-| `GITHUB_TEST_OWNER`     | Blocks C,D,F   | —                                                      | `gitgovernance`                                        |
-| `GITHUB_TEST_REPO_NAME` | Blocks C,D,F   | —                                                      | `e2e-test-repo`                                        |
-| `GITHUB_TEST_REPO`      | Blocks C,D,F   | —                                                      | `git@github.com:gitgovernance/e2e-test-repo.git`       |
-| `SKIP_CLEANUP`          | Optional       | `0`                                                    | Set to `1` to keep temp dirs and DB rows for debugging |
+| Variable | Required for | Default |
+|---|---|---|
+| `DATABASE_URL_PROTOCOL` | Blocks B, D, E | `postgresql://gitgov:gitgov@localhost:5432/gitgov_e2e_protocol` |
+| `DATABASE_URL_AUDIT` | Block CBA | `postgresql://gitgov:gitgov@localhost:5432/gitgov_e2e_audit` |
+| `GITHUB_TOKEN` | Blocks C, D, E, F | — |
+| `GITHUB_TEST_OWNER` | Blocks C, D, E, F | `gitgovernance` |
+| `GITHUB_TEST_REPO_NAME` | Blocks C, D, E, F | `e2e-test-repo` |
+| `GITHUB_TEST_REPO` | Blocks C, D, E, F | `git@github.com:gitgovernance/e2e-test-repo.git` |
+| `GITLAB_TOKEN` | Block J | — |
+| `GITLAB_TEST_PROJECT_ID` | Block J | — |
+| `SKIP_CLEANUP` | Debug | `0` |
 
 A `.env` file in `packages/e2e/` is loaded automatically by vitest.
 
-## GitHub Test Repository
-
-Tests that interact with GitHub use a dedicated test repo:
-
-**https://github.com/gitgovernance/e2e-test-repo**
-
-This repo is used for:
-
-- Pushing/pulling `.gitgov/` state branches
-- Testing `GitHubRecordStore` reads/writes
-- Cross-path validation (CLI local vs GitHub remote)
-- Change detection and sync state
-
-Tests create isolated branches per run and clean up in `afterAll`.
-
 ## Running Tests
+
+All tests are **autonomous** — no human interaction required (unlike e2e-private which needs Playwright OAuth).
 
 ```bash
 cd packages/e2e
 
-# All tests (requires Docker + GitHub token)
+# T1: Fast, no GitHub (~30s)
+pnpm vitest run tests/cli_records.test.ts tests/projection_protocol.test.ts tests/projection_audit.test.ts tests/audit_orchestration.test.ts tests/policy_evaluation.test.ts tests/redaction.test.ts
+
+# T2: With GitHub (~2min, needs GITHUB_TOKEN)
+pnpm vitest run tests/github.test.ts tests/cross_path.test.ts tests/parity.test.ts tests/change_detection.test.ts
+
+# All tests
 pnpm test
 
-# Local-only tests (no GitHub, no external deps beyond PostgreSQL)
-pnpm test:local
+# GitLab only
+pnpm test:gitlab
 
-# With GitHub integration
-pnpm test:github
-
-# Single block
-pnpm vitest run tests/cli_records.test.ts
-pnpm vitest run tests/projection.test.ts
-pnpm vitest run tests/github.test.ts
+# Debug: keep temp dirs and DB rows
+SKIP_CLEANUP=1 pnpm test
 ```
 
 ## Test Blocks
 
-Each block is independent and self-contained. No block depends on another having run first.
+Each block is independent and self-contained. No block depends on another.
 
-| Block | File                       | EARS    | Requires                  | What it tests                                                  |
-| ----- | -------------------------- | ------- | ------------------------- | -------------------------------------------------------------- |
-| A     | `cli_records.test.ts`      | CA1-CA9 | CLI build                 | CLI creates 7 record types on disk                             |
-| B     | `projection.test.ts`       | CB1-CB8 | CLI + PostgreSQL          | Records projected to DB via RecordProjector                    |
-| C     | `github.test.ts`           | CC1-CC5 | GitHub token              | GitHubRecordStore against real GitHub API                      |
-| D     | `cross_path.test.ts`       | CD1-CD5 | CLI + PostgreSQL + GitHub | Records created by CLI readable via GitHub and vice versa      |
-| E     | `parity.test.ts`           | CE1-CE2 | CLI + PostgreSQL + GitHub | FS vs Prisma parity (CE1) + FS vs GitHub parity (CE2)         |
-| F     | `change_detection.test.ts` | CF1-CF7 | CLI + PostgreSQL + GitHub | GithubSyncStateModule: delta detection, pushState, concurrency, audit |
-
-## Architecture
-
-```
-packages/e2e/
-  tests/
-    helpers.ts              <- Shared utilities (runCliCommand, createGitRepo, DB, projection)
-    cli_records.test.ts     <- Block A
-    projection.test.ts      <- Block B
-    github.test.ts          <- Block C
-    cross_path.test.ts      <- Block D
-    parity.test.ts          <- Block E
-    change_detection.test.ts <- Block F
-  .env                      <- Environment variables (not committed)
-  vitest.config.ts          <- Sequential execution, 120s timeout
-  package.json
-```
-
-Each test file follows the same lifecycle:
-
-```
-beforeAll:  mkdtemp → git init → (optional: DB connect, GitHub auth)
-tests:      runCliCommand() → verify filesystem / DB / GitHub
-afterAll:   cleanup temp dir → cleanup DB rows → (optional: delete GitHub branch)
-```
+| Block | File | EARS | Tier | Requires | What it tests |
+|---|---|---|---|---|---|
+| A | `cli_records.test.ts` | CA1-CA9 | T1 | CLI build | CLI creates 7 record types on disk |
+| B | `projection_protocol.test.ts` | CB1-CB11 | T1 | CLI + PostgreSQL | Protocol records projected to DB |
+| CBA | `projection_audit.test.ts` | CBA1-CBA6 | T1 | PostgreSQL | SARIF → audit projection → DB |
+| C | `github.test.ts` | CC1-CC5 | T2 | GitHub token | GitHubRecordStore against real GitHub |
+| D | `cross_path.test.ts` | CD1-CD5 | T2 | CLI + PostgreSQL + GitHub | CLI ↔ GitHub cross-path |
+| E | `parity.test.ts` | CE1-CE3 | T2 | CLI + PostgreSQL + GitHub | FS vs Prisma vs GitHub parity |
+| F | `change_detection.test.ts` | CF1-CF4 | T2 | CLI + PostgreSQL + GitHub | Delta detection, pushState, concurrency |
+| G | `audit_orchestration.test.ts` | CG1-CG16 | T1 | — | Pipeline: orchestrator → agent → SARIF → policy |
+| H | `policy_evaluation.test.ts` | CH1-CH4 | T1 | — | PolicyEvaluator + ExecutionRecord decision |
+| I | `redaction.test.ts` | CI1-CI4 | T1 | — | Snippet redaction L1/L2 + fingerprint integrity |
+| J | `gitlab.test.ts` | CJ1-CJ8 | T2 | GitLab token | GitLabRecordStore against real GitLab |
 
 ## Troubleshooting
 
 **Tests hang on GitHub blocks:** Check `GITHUB_TOKEN` is valid. Expired tokens cause silent hangs.
 
-**CLI command fails with "not found":** Run `cd packages/cli && pnpm build` first. Tests use the built `gitgov.mjs`, not source.
+**CLI command fails:** Run `cd packages/cli && pnpm build` first. Tests use the built `gitgov.mjs`, not source.
 
-**DB connection refused:** Start Docker: `docker compose up -d`. Verify with `psql $DATABASE_URL -c '\l'`.
+**DB connection refused:** Start Docker. `globalSetup.ts` creates databases automatically.
 
-**Keep temp files for debugging:** Run with `SKIP_CLEANUP=1 pnpm test` to preserve temp dirs and DB rows.
+**GitHub rate limit:** Space out T2 runs. Multiple runs in quick succession can trigger secondary rate limits.
+
+## License
+
+MPL-2.0

--- a/packages/e2e/tests/helpers/cli.ts
+++ b/packages/e2e/tests/helpers/cli.ts
@@ -81,11 +81,11 @@ export function addRemote(repoPath: string, remotePath: string): void {
 }
 
 // [HLP-A4] Spawn gitgov CLI as async child process (for interactive/long-running commands)
-export function spawnGitgovCli(args: string, options: { cwd: string; timeout?: number }): SpawnedCli {
+export function spawnGitgovCli(args: string, options: { cwd: string; timeout?: number; env?: Record<string, string> }): SpawnedCli {
   const child = spawn('gitgov', args.split(/\s+/), {
     cwd: options.cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
-    env: { ...process.env },
+    env: { ...process.env, ...options.env },
   });
 
   let out = '';


### PR DESCRIPTION
## Summary
- **EARS-D5**: `PrismaRecordProjection.buildMetaWhere` now uses configurable `metaUniqueFields` to match GitgovMeta `@@unique([repoId, projectionType])` — fixes silent `$transaction` failure where protocol projection never persisted to DB
- **Collab onboarding fixes** (sessions 24-25): `detectActorFromKeyFiles` decode, `--force-local` skip validation, collaborator login actorId resolution
- Core: 2876 tests, CLI: 547 tests — all green

## Test plan
- [x] `pnpm --filter @gitgov/core test` — 2876 passed
- [x] `pnpm --filter @gitgov/cli test` — 547 passed
- [x] tsc --noEmit — 0 errors