### PR TITLE
feat(core): createUnsignedRecord factory for pre-signing records

### DIFF
--- a/packages/core/src/record_factories/embedded_metadata_factory.test.ts
+++ b/packages/core/src/record_factories/embedded_metadata_factory.test.ts
@@ -1,4 +1,4 @@
-import { createEmbeddedMetadataRecord, createTestSignature } from './embedded_metadata_factory';
+import { createEmbeddedMetadataRecord, createTestSignature, createUnsignedRecord } from './embedded_metadata_factory';
 import type { ActorRecord, TaskRecord } from '../record_types';
 import { DetailedValidationError } from '../record_validations/common';
 
@@ -174,6 +174,42 @@ describe('EmbeddedMetadata Factory', () => {
       const result = createEmbeddedMetadataRecord(complexPayload);
 
       expect(result.payload).toEqual(complexPayload);
+    });
+  });
+
+  // ── createUnsignedRecord (EARS-UR-1 to UR-4) ───────────────────────────
+  // UR-1..3: unit tests below. UR-4: integration (verified by identity_key_exchange.e2e.test.ts PI-A2)
+
+  describe('createUnsignedRecord', () => {
+    const sampleTaskPayload: TaskRecord = {
+      id: '1700000000-task-test',
+      title: 'Test task',
+      status: 'draft',
+      priority: 'medium',
+      description: 'A test task',
+      tags: [],
+    };
+
+    // [EARS-UR-1]
+    it('[EARS-UR-1] should return record with empty signatures, valid checksum, and version 1.0', () => {
+      const result = createUnsignedRecord(sampleTaskPayload);
+
+      expect(result.header.signatures).toEqual([]);
+      expect(result.header.version).toBe('1.0');
+      expect(result.header.payloadChecksum).toMatch(/^[a-f0-9]{64}$/);
+      expect(result.payload).toEqual(sampleTaskPayload);
+    });
+
+    // [EARS-UR-2]
+    it('[EARS-UR-2] should infer type task from TaskRecord payload', () => {
+      const result = createUnsignedRecord(sampleTaskPayload);
+      expect(result.header.type).toBe('task');
+    });
+
+    // [EARS-UR-3]
+    it('[EARS-UR-3] should use options.type override when provided', () => {
+      const result = createUnsignedRecord(sampleTaskPayload, { type: 'feedback' });
+      expect(result.header.type).toBe('feedback');
     });
   });
 });

--- a/packages/core/src/record_factories/embedded_metadata_factory.ts
+++ b/packages/core/src/record_factories/embedded_metadata_factory.ts
@@ -140,3 +140,39 @@ export function createEmbeddedMetadataRecord<T extends GitGovRecordPayload>(
   return embeddedRecord;
 }
 
+/**
+ * Pre-signing record: header with checksum but no signatures yet.
+ * Designed for production code paths where signRecord() will add the first signature.
+ */
+export type UnsignedRecord<T extends GitGovRecordPayload> = {
+  header: Omit<EmbeddedMetadataHeader, 'signatures'> & { signatures: Signature[] };
+  payload: T;
+};
+
+/**
+ * Creates an unsigned record ready to be signed by IdentityAdapter.signRecord().
+ *
+ * Unlike createEmbeddedMetadataRecord (which generates a test signature),
+ * this creates a record with an empty signatures array — no dummy data.
+ * signRecord() handles empty signatures by adding the first real signature.
+ *
+ * Usage: production code that delegates signing to IdentityService/IdentityAdapter.
+ */
+export function createUnsignedRecord<T extends GitGovRecordPayload>(
+  payload: T,
+  options?: { type?: GitGovRecordType },
+): UnsignedRecord<T> {
+  const type = options?.type ?? inferTypeFromPayload(payload);
+  const payloadChecksum = calculatePayloadChecksum(payload);
+
+  return {
+    header: {
+      version: '1.0',
+      type,
+      payloadChecksum,
+      signatures: [],
+    },
+    payload,
+  };
+}
+


### PR DESCRIPTION
## Summary
- Add `createUnsignedRecord(payload)` to `embedded_metadata_factory.ts` — creates records with `signatures: []` for production code that delegates signing to `IdentityAdapter.signRecord()`
- Add `UnsignedRecord<T>` type for pre-signing records
- 3 unit tests (EARS-UR-1..3), 15/15 green

## Context
Discovered during identity_key_exchange E2E flow (IKS Phase 2 Cycle 2). `createEmbeddedMetadataRecord()` without a private key generates a dummy test signature that `signRecord()` does not replace — leaving records with 2 signatures (dummy + real). `createUnsignedRecord` solves this by producing a record with empty signatures that `signRecord` populates with the first real Ed25519 signature.

## Test plan
- [ ] `npx jest --testPathPattern="embedded_metadata_factory"` → 15/15
- [ ] Private PR merges after this (saas-api uses the new factory)