### PR TITLE
feat(core): Gate Session 43 — ref in AuditOrchestrationOptions, ISP, clean_exports fix

### DIFF
--- a/packages/core/prisma/schema/audit.prisma
+++ b/packages/core/prisma/schema/audit.prisma
@@ -146,7 +146,10 @@ model Scan {
   status               String           @default("pending")
   prNumber             Int?
   prUrl                String?
-  checkRunId           Int?
+  // [SCAN-Q1] GitHub Check Run ID. BIGINT in DB (GitHub IDs can exceed
+  // Int32 range). Migration 20260506042653_index_status_enum_and_scan_updates
+  // set the column type to BIGINT — the schema must match for client codegen.
+  checkRunId           BigInt?
   branch               String?
   commitSha            String?
   commitAuthor         String?

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -36,6 +36,7 @@ export type {
   PolicyDecision,
   PolicyRuleResult,
   // Orchestration
+  AuditOrchestrationOptions,
   AuditOrchestrationResult,
   AuditSummary,
   AgentAuditResult,

--- a/packages/core/src/audit/types.ts
+++ b/packages/core/src/audit/types.ts
@@ -365,6 +365,31 @@ export type AuditOrchestrationResult = {
   reviewResults?: ReviewAgentResult[];
 };
 
+// ─── Orchestration Input ──────────────────────────────────────────────────────
+
+/**
+ * Options passed to AuditOrchestrator.run() — the public input contract.
+ *
+ * Consumers: CLI (audit-command.ts), SaaS (scan_orchestrator.service.ts).
+ * Counterpart of AuditOrchestrationResult (output).
+ */
+export type AuditOrchestrationOptions = {
+  /** Scan scope: diff (changed files), full (all files), baseline (full + save baseline) */
+  scope: "diff" | "full" | "baseline";
+  /** Optional: run only this specific agent */
+  agentId?: string;
+  /** Glob patterns to include in scan */
+  include?: string[];
+  /** Glob patterns to exclude from scan */
+  exclude?: string[];
+  /** TaskRecord ID for traceability */
+  taskId: string;
+  /** Minimum severity to block on (optional) */
+  failOn?: FindingSeverity;
+  /** Target commit/branch to scan. Passed to agents for SARIF versionControlProvenance. */
+  ref?: string;
+};
+
 // ─── Scan ─────────────────────────────────────────────────────────────────────
 
 /**

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.ts
@@ -1,10 +1,9 @@
 import type { SarifLog, SarifPhysicalLocation } from "../sarif/sarif.types";
 import type { IAgentRunner } from "../agent_runner/agent_runner";
-import type { RecordStore } from "../record_store/record_store";
-import type { GitGovAgentRecord } from "../record_types";
 import type { Waiver } from "../source_auditor/types";
 import type { RunOptions } from "../agent_runner/agent_runner.types";
 import type {
+  AgentRecordReader,
   AuditOrchestratorDeps,
   AuditOrchestrationOptions,
   AuditOrchestrationResult,
@@ -53,7 +52,7 @@ function levelToSeverity(level: string | undefined): FindingSeverity {
  * RecordStore.get(id) returns the full record with payload.metadata.
  */
 async function discoverAuditAgents(
-  agentStore: RecordStore<GitGovAgentRecord>,
+  agentStore: AgentRecordReader,
   agentId?: string,
 ): Promise<string[]> {
   const agentIds = await agentStore.list();
@@ -81,7 +80,7 @@ async function discoverAuditAgents(
  * [AORCH-F1] Discovers AgentRecords with metadata.purpose === "review".
  */
 async function discoverReviewAgents(
-  agentStore: RecordStore<GitGovAgentRecord>,
+  agentStore: AgentRecordReader,
 ): Promise<string[]> {
   const agentIds = await agentStore.list();
   const reviewAgentIds: string[] = [];

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.ts
@@ -160,6 +160,7 @@ async function executeAgent(
     ...(options.include !== undefined ? { include: options.include } : {}),
     ...(options.exclude !== undefined ? { exclude: options.exclude } : {}),
     taskId: options.taskId,
+    ...(options.ref !== undefined ? { ref: options.ref } : {}),
   };
 
   const runOpts: RunOptions = {

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.types.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.types.ts
@@ -21,6 +21,7 @@ export type {
   Waiver,
   PolicyDecision,
   AuditOrchestrationResult,
+  AuditOrchestrationOptions,
   AuditSummary,
   AgentAuditResult,
   ReviewAgentResult,
@@ -30,26 +31,8 @@ export type {
 export type { PolicyEvaluationResult } from "../policy_evaluator/policy_evaluator.types";
 
 // ============================================================================
-// ORCHESTRATOR-SPECIFIC TYPES (not in audit/types.ts)
+// ORCHESTRATOR-SPECIFIC TYPES (internal — not in audit/types.ts)
 // ============================================================================
-
-/**
- * Options passed to AuditOrchestrator.run().
- */
-export type AuditOrchestrationOptions = {
-  /** Scan scope: diff (changed files), full (all files), baseline (full + save baseline) */
-  scope: "diff" | "full" | "baseline";
-  /** Optional: run only this specific agent */
-  agentId?: string;
-  /** Glob patterns to include in scan */
-  include?: string[];
-  /** Glob patterns to exclude from scan */
-  exclude?: string[];
-  /** TaskRecord ID for traceability */
-  taskId: string;
-  /** Minimum severity to block on (optional) */
-  failOn?: import("../audit/types").FindingSeverity;
-};
 
 /**
  * Input passed to each audit agent via AgentRunner ctx.input.
@@ -65,6 +48,8 @@ export type AgentAuditInput = {
   taskId: string;
   /** Base directory for scanning (resolved by orchestrator from project root) */
   baseDir?: string;
+  /** Target commit/branch being scanned. Agents use this for SARIF versionControlProvenance. */
+  ref?: string;
 };
 
 /**

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.types.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.types.ts
@@ -6,7 +6,6 @@
  * This file re-exports them and defines orchestrator-specific types.
  */
 
-import type { RecordStore } from "../record_store/record_store";
 import type { GitGovAgentRecord } from "../record_types";
 import type { IAgentRunner } from "../agent_runner/agent_runner";
 import type { IWaiverReader } from "../source_auditor/types";
@@ -53,11 +52,19 @@ export type AgentAuditInput = {
 };
 
 /**
+ * Read-only contract for agent discovery. Any RecordStore backend satisfies this.
+ */
+export type AgentRecordReader = {
+  get(id: string): Promise<GitGovAgentRecord | null>;
+  list(): Promise<string[]>;
+};
+
+/**
  * Dependencies injected into createAuditOrchestrator().
  */
 export type AuditOrchestratorDeps = {
-  /** RecordStore for reading AgentRecords (typed for agent records) */
-  recordStore: RecordStore<GitGovAgentRecord>;
+  /** Reader for AgentRecords — only get/list needed for discovery */
+  recordStore: AgentRecordReader;
   /** AgentRunner interface for executing agents */
   agentRunner: IAgentRunner;
   /** WaiverReader for loading active waivers */

--- a/packages/core/src/audit_orchestrator/index.ts
+++ b/packages/core/src/audit_orchestrator/index.ts
@@ -1,5 +1,6 @@
 export { createAuditOrchestrator } from "./audit_orchestrator";
 export type {
+  AgentRecordReader,
   AuditOrchestratorDeps,
   AuditOrchestrationOptions,
   AuditOrchestrationResult,

--- a/packages/core/src/file_lister/file_lister.errors.ts
+++ b/packages/core/src/file_lister/file_lister.errors.ts
@@ -6,7 +6,22 @@ export type FileListerErrorCode =
   | 'READ_ERROR'
   | 'PERMISSION_DENIED'
   | 'INVALID_PATH'
-  | 'NETWORK_ERROR';
+  | 'NETWORK_ERROR'
+  | 'RATE_LIMITED';
+
+/**
+ * Optional structured metadata attached to FileListerError.
+ * Used by RATE_LIMITED to surface partial results and reset time
+ * (paths-not-fetched and x-ratelimit-reset header).
+ */
+export type FileListerErrorDetails = {
+  /** Paths not fetched before the stop (RATE_LIMITED) */
+  pathsNotFetched?: string[];
+  /** Unix timestamp from x-ratelimit-reset header (RATE_LIMITED) */
+  resetTime?: number;
+  /** Map of path → content fetched before the stop (RATE_LIMITED) */
+  partialResults?: Map<string, string>;
+};
 
 /**
  * Error thrown when file operations fail.
@@ -15,7 +30,8 @@ export class FileListerError extends Error {
   constructor(
     message: string,
     public readonly code: FileListerErrorCode,
-    public readonly filePath?: string
+    public readonly filePath?: string,
+    public readonly details?: FileListerErrorDetails,
   ) {
     super(message);
     this.name = 'FileListerError';

--- a/packages/core/src/file_lister/file_lister.ts
+++ b/packages/core/src/file_lister/file_lister.ts
@@ -13,7 +13,7 @@ import type { FileListOptions, FileStats } from './file_lister.types';
 // Re-export types and errors for barrel consumers
 export type { FileListOptions, FileStats, FsFileListerOptions, MemoryFileListerOptions } from './file_lister.types';
 export { FileListerError } from './file_lister.errors';
-export type { FileListerErrorCode } from './file_lister.errors';
+export type { FileListerErrorCode, FileListerErrorDetails } from './file_lister.errors';
 
 /**
  * Interface for listing and reading files.
@@ -65,4 +65,16 @@ export interface FileLister {
    * @throws FileListerError if file doesn't exist
    */
   stat(filePath: string): Promise<FileStats>;
+
+  /**
+   * Batch read multiple files in parallel.
+   * Optional — API-based backends (GitHub) benefit from parallel fetching.
+   * Filesystem backends can implement trivially or leave undefined.
+   * Consumers check `if (lister.readBatch)` and fall back to sequential read().
+   *
+   * @param paths - Array of file paths relative to cwd
+   * @returns Map of path → content
+   * @throws FileListerError if any path doesn't exist or rate limit hit
+   */
+  readBatch?(paths: string[]): Promise<Map<string, string>>;
 }

--- a/packages/core/src/file_lister/github/github_file_lister.test.ts
+++ b/packages/core/src/file_lister/github/github_file_lister.test.ts
@@ -45,10 +45,21 @@ function createMockOctokit(): MockOctokit {
   } as unknown as MockOctokit;
 }
 
-function createOctokitError(status: number, message = 'Error'): Error & { status: number } {
-  const error = new Error(message) as Error & { status: number };
-  error.status = status;
-  return error;
+function createOctokitError(status: number, message = 'Error') {
+  // Object.assign returns the merged type via inference — no cast required.
+  // Equivalent shape to Octokit RequestError for the fields we test against.
+  return Object.assign(new Error(message), { status });
+}
+
+/**
+ * Builds an Octokit-like 403 error with x-ratelimit-reset header.
+ * Used by EARS-D3 tests to simulate GitHub rate limit cascade.
+ */
+function createOctokitRateLimitError(resetTimestamp: string) {
+  return Object.assign(new Error('API rate limit exceeded'), {
+    status: 403,
+    response: { headers: { 'x-ratelimit-reset': resetTimestamp } },
+  });
 }
 
 const defaultOptions: GitHubFileListerOptions = {
@@ -466,6 +477,120 @@ describe('GitHubFileLister', () => {
       await expect(lister.list(['**/*'])).rejects.toMatchObject({
         code: 'FILE_NOT_FOUND',
       });
+    });
+  });
+
+  // ==================== 4.4. Batch Read via Blobs API (EARS-D1 to D3) ====================
+
+  describe('4.4. Batch Read via Blobs API (EARS-D1 to D3)', () => {
+    it('[EARS-D1] should fetch blobs in parallel using SHAs from tree cache', async () => {
+      mockOctokit.rest.git.getTree.mockResolvedValue(createTreeResponse([
+        { path: '.gitgov/tasks/task-1.json', type: 'blob', sha: 'sha-task-1' },
+        { path: '.gitgov/actors/camilo.json', type: 'blob', sha: 'sha-camilo' },
+        { path: '.gitgov/config.json', type: 'blob', sha: 'sha-config' },
+      ]));
+      mockOctokit.rest.git.getBlob
+        .mockResolvedValueOnce(createBlobResponse('task-content', 'sha-task-1'))
+        .mockResolvedValueOnce(createBlobResponse('actor-content', 'sha-camilo'))
+        .mockResolvedValueOnce(createBlobResponse('config-content', 'sha-config'));
+
+      const result = await lister.readBatch([
+        'tasks/task-1.json',
+        'actors/camilo.json',
+        'config.json',
+      ]);
+
+      expect(result.size).toBe(3);
+      expect(result.get('tasks/task-1.json')).toBe('task-content');
+      expect(result.get('actors/camilo.json')).toBe('actor-content');
+      expect(result.get('config.json')).toBe('config-content');
+      expect(mockOctokit.rest.git.getBlob).toHaveBeenCalledTimes(3);
+      expect(mockOctokit.rest.git.getBlob).toHaveBeenCalledWith({
+        owner: 'test-org',
+        repo: 'test-repo',
+        file_sha: 'sha-task-1',
+      });
+      // Tree fetched once via lazy fetchTree on first readBatch call
+      expect(mockOctokit.rest.git.getTree).toHaveBeenCalledTimes(1);
+      // Contents API not used at all
+      expect(mockOctokit.rest.repos.getContent).not.toHaveBeenCalled();
+    });
+
+    it('[EARS-D1] should throw FILE_NOT_FOUND when path is not in tree cache', async () => {
+      mockOctokit.rest.git.getTree.mockResolvedValue(createTreeResponse([
+        { path: '.gitgov/actors/camilo.json', type: 'blob', sha: 'sha-camilo' },
+      ]));
+
+      await expect(
+        lister.readBatch(['actors/camilo.json', 'actors/missing.json']),
+      ).rejects.toThrow(FileListerError);
+      await expect(
+        lister.readBatch(['actors/camilo.json', 'actors/missing.json']),
+      ).rejects.toMatchObject({
+        code: 'FILE_NOT_FOUND',
+        filePath: 'actors/missing.json',
+      });
+      // No blob fetches happen — validation fails upfront
+      expect(mockOctokit.rest.git.getBlob).not.toHaveBeenCalled();
+    });
+
+    it('[EARS-D2] should use blob SHA from tree cache instead of Contents API when cache populated', async () => {
+      mockOctokit.rest.git.getTree.mockResolvedValue(createTreeResponse([
+        { path: '.gitgov/config.json', type: 'blob', sha: 'cached-sha' },
+      ]));
+      mockOctokit.rest.git.getBlob.mockResolvedValue(createBlobResponse('cached content', 'cached-sha'));
+
+      // Populate tree cache via list()
+      await lister.list(['**/*']);
+      // read() should now use Blobs API via cached SHA
+      const content = await lister.read('config.json');
+
+      expect(content).toBe('cached content');
+      expect(mockOctokit.rest.git.getBlob).toHaveBeenCalledWith({
+        owner: 'test-org',
+        repo: 'test-repo',
+        file_sha: 'cached-sha',
+      });
+      // Contents API never called for the read — cache short-circuit hit
+      expect(mockOctokit.rest.repos.getContent).not.toHaveBeenCalled();
+    });
+
+    it('[EARS-D2] should fall back to Contents API when tree cache not populated', async () => {
+      mockOctokit.rest.repos.getContent.mockResolvedValue(createContentsResponse('contents-content'));
+
+      // No list() — tree cache is empty
+      const content = await lister.read('config.json');
+
+      expect(content).toBe('contents-content');
+      expect(mockOctokit.rest.repos.getContent).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.rest.git.getBlob).not.toHaveBeenCalled();
+    });
+
+    it('[EARS-D3] should stop fetching and return partial results on rate limit error', async () => {
+      mockOctokit.rest.git.getTree.mockResolvedValue(createTreeResponse([
+        { path: '.gitgov/tasks/task-1.json', type: 'blob', sha: 'sha-task-1' },
+        { path: '.gitgov/tasks/task-2.json', type: 'blob', sha: 'sha-task-2' },
+      ]));
+      mockOctokit.rest.git.getBlob
+        .mockResolvedValueOnce(createBlobResponse('task-1-content', 'sha-task-1'))
+        .mockRejectedValueOnce(createOctokitRateLimitError('1700000000'));
+
+      const err: unknown = await lister
+        .readBatch(['tasks/task-1.json', 'tasks/task-2.json'])
+        .then(
+          () => null,
+          (e: unknown) => e,
+        );
+
+      expect(err).toBeInstanceOf(FileListerError);
+      if (err instanceof FileListerError) {
+        expect(err.code).toBe('RATE_LIMITED');
+        expect(err.details).toBeDefined();
+        expect(err.details?.partialResults?.size).toBe(1);
+        expect(err.details?.partialResults?.get('tasks/task-1.json')).toBe('task-1-content');
+        expect(err.details?.pathsNotFetched).toEqual(['tasks/task-2.json']);
+        expect(err.details?.resetTime).toBe(1700000000);
+      }
     });
   });
 

--- a/packages/core/src/file_lister/github/github_file_lister.ts
+++ b/packages/core/src/file_lister/github/github_file_lister.ts
@@ -13,10 +13,13 @@
 
 import picomatch from 'picomatch';
 import type { Octokit } from '@octokit/rest';
-import type { FileLister, FileListOptions, FileStats } from '../file_lister';
+import type { FileLister, FileListOptions, FileListerErrorDetails, FileStats } from '../file_lister';
 import { FileListerError } from '../file_lister';
-import { isOctokitRequestError } from '../../shared/github/github';
+import { isOctokitRequestError, getOctokitRateLimitReset } from '../../shared/github/github';
 import type { GitHubFileListerOptions } from './github_file_lister.types';
+
+/** [EARS-D1] Max parallel Blob fetches in readBatch */
+const READ_BATCH_CONCURRENCY = 10;
 
 /** Tree entry shape from Octokit git.getTree response */
 type TreeEntry = {
@@ -165,9 +168,24 @@ export class GitHubFileLister implements FileLister {
    * [EARS-A3] Reads file content as string.
    * [EARS-B2] Decodes base64 content from Contents API.
    * [EARS-B7] Falls back to Blobs API for files >1MB (null content).
+   * [EARS-D2] When tree cache is populated AND the path resolves to a blob SHA,
+   *           uses Blobs API directly (no path resolution overhead, no 1MB limit).
+   *           Otherwise falls back to the Contents API path below.
    */
   async read(filePath: string): Promise<string> {
     const fullPath = this.buildFullPath(filePath);
+
+    // [EARS-D2] Tree cache populated → use Blobs API via SHA from cache
+    if (this.treeCache !== null) {
+      const entry = this.treeCache.find(
+        e => e.type === 'blob' && e.path === fullPath && typeof e.sha === 'string',
+      );
+      if (entry?.sha) {
+        return this.readViaBlobs(entry.sha, filePath);
+      }
+      // Tree populated but path not in cache → fall through to Contents API
+      // (preserves backwards compat for files added between list() and read())
+    }
 
     try {
       const { data } = await this.octokit.rest.repos.getContent({
@@ -294,6 +312,104 @@ export class GitHubFileLister implements FileLister {
         filePath,
       );
     }
+  }
+
+  /**
+   * [EARS-D1] Reads multiple files in parallel via the Blobs API.
+   *
+   * Resolves each path's blob SHA from the tree cache (lazily fetched if not
+   * populated by a prior list() call), then fetches blobs in parallel with a
+   * concurrency cap of READ_BATCH_CONCURRENCY. Decodes each from base64 and
+   * returns a Map of path → content.
+   *
+   * - Throws FILE_NOT_FOUND if any input path is not present as a blob in the tree.
+   * - [EARS-D3] On HTTP 403 (rate limit) mid-batch, stops remaining fetches and
+   *   throws RATE_LIMITED with details.partialResults / pathsNotFetched / resetTime.
+   * - Other errors propagate as-is.
+   */
+  async readBatch(paths: string[]): Promise<Map<string, string>> {
+    // [EARS-D1] Lazy fetchTree: idempotent (cache hit if list() was called)
+    const tree = await this.fetchTree();
+
+    // Build path → SHA lookup (only blobs, only entries with both path and sha)
+    const blobShaByFullPath = new Map<string, string>();
+    for (const entry of tree) {
+      if (entry.type === 'blob' && entry.path && entry.sha) {
+        blobShaByFullPath.set(entry.path, entry.sha);
+      }
+    }
+
+    // [EARS-D1] Resolve all paths upfront — throw FILE_NOT_FOUND on any miss
+    const resolved: Array<{ path: string; sha: string }> = [];
+    for (const p of paths) {
+      const fullPath = this.buildFullPath(p);
+      const sha = blobShaByFullPath.get(fullPath);
+      if (!sha) {
+        throw new FileListerError(
+          `File not found in tree: ${p}`,
+          'FILE_NOT_FOUND',
+          p,
+        );
+      }
+      resolved.push({ path: p, sha });
+    }
+
+    // [EARS-D1] Parallel fetch via Blobs API with concurrency cap
+    const results = new Map<string, string>();
+    let stopped = false;
+    let resetTime: number | undefined;
+    let nextIndex = 0;
+
+    const worker = async (): Promise<void> => {
+      while (!stopped) {
+        const i = nextIndex++;
+        if (i >= resolved.length) return;
+        const item = resolved[i];
+        if (!item) return;
+        try {
+          const { data } = await this.octokit.rest.git.getBlob({
+            owner: this.owner,
+            repo: this.repo,
+            file_sha: item.sha,
+          });
+          if (!stopped) {
+            results.set(item.path, Buffer.from(data.content, 'base64').toString('utf-8'));
+          }
+        } catch (error: unknown) {
+          // [EARS-D3] Rate limit (403): stop remaining workers, capture reset time
+          if (isOctokitRequestError(error) && error.status === 403) {
+            stopped = true;
+            resetTime = getOctokitRateLimitReset(error);
+            return;
+          }
+          throw error;
+        }
+      }
+    };
+
+    const workerCount = Math.min(READ_BATCH_CONCURRENCY, resolved.length);
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+    // [EARS-D3] Rate limit triggered → throw with partial results + details
+    if (stopped) {
+      const fetched = new Set(results.keys());
+      const pathsNotFetched = paths.filter(p => !fetched.has(p));
+      const details: FileListerErrorDetails = {
+        pathsNotFetched,
+        partialResults: results,
+      };
+      if (resetTime !== undefined) {
+        details.resetTime = resetTime;
+      }
+      throw new FileListerError(
+        `Rate limit hit during batch read; ${results.size}/${paths.length} fetched`,
+        'RATE_LIMITED',
+        undefined,
+        details,
+      );
+    }
+
+    return results;
   }
 
   // ═══════════════════════════════════════════════════════════════════════

--- a/packages/core/src/integration/guardrails/clean_exports.test.ts
+++ b/packages/core/src/integration/guardrails/clean_exports.test.ts
@@ -88,7 +88,7 @@ describe('CI Guardrail: Clean Exports', () => {
 
   describe('Subpath: @gitgov/core/memory', () => {
     it('[EARS-CI04] should NOT import fs, path, child_process, or chokidar', () => {
-      const memoryPath = path.join(distPath, 'memory.js');
+      const memoryPath = path.join(distPath, 'shared/memory/memory.js');
 
       if (!fs.existsSync(memoryPath)) {
         throw new Error(`Build output not found: ${memoryPath}. Run 'pnpm build' first.`);
@@ -112,7 +112,7 @@ describe('CI Guardrail: Clean Exports', () => {
 
   describe('Subpath: @gitgov/core/fs', () => {
     it('[EARS-CI05] should import fs and path (expected for filesystem implementations)', () => {
-      const fsPath = path.join(distPath, 'fs.js');
+      const fsPath = path.join(distPath, 'shared/fs/fs.js');
 
       if (!fs.existsSync(fsPath)) {
         throw new Error(`Build output not found: ${fsPath}. Run 'pnpm build' first.`);

--- a/packages/core/src/shared/github/github.test.ts
+++ b/packages/core/src/shared/github/github.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for shared GitHub utilities.
+ *
+ * Covers:
+ * - isOctokitRequestError    (EARS-B1, B2) — type guard (duck-typing).
+ * - getOctokitRateLimitReset (EARS-D1 to D3) — rate limit header extractor.
+ * - isOctokitRateLimitError  (EARS-D4)        — rate limit error detector.
+ *
+ * EARS A1-A7 (mapOctokitError) and C1-C2 (GitHubApiError) remain verified
+ * indirectly via consumer tests (ConfigStore, RecordStore, PolicyConfigLoader)
+ * — see github_shared_module §4.
+ */
+
+import {
+  getOctokitRateLimitReset,
+  isOctokitRateLimitError,
+  isOctokitRequestError,
+} from './github';
+
+describe('shared/github', () => {
+  describe('4.2. isOctokitRequestError (EARS-B1 to B2)', () => {
+    it('[EARS-B1] should return true for errors with numeric status', () => {
+      const err = Object.assign(new Error('http error'), { status: 404 });
+      expect(isOctokitRequestError(err)).toBe(true);
+
+      const err500 = Object.assign(new Error('server'), { status: 500 });
+      expect(isOctokitRequestError(err500)).toBe(true);
+
+      // Status 0 is still numeric (rare but valid)
+      const err0 = Object.assign(new Error('abort'), { status: 0 });
+      expect(isOctokitRequestError(err0)).toBe(true);
+    });
+
+    it('[EARS-B2] should return false for plain Error or non-Error inputs', () => {
+      // Plain Error (no status)
+      expect(isOctokitRequestError(new Error('plain'))).toBe(false);
+
+      // Non-numeric status
+      expect(isOctokitRequestError(Object.assign(new Error(), { status: '404' }))).toBe(false);
+      expect(isOctokitRequestError(Object.assign(new Error(), { status: null }))).toBe(false);
+
+      // Plain object with status (not Error instance)
+      expect(isOctokitRequestError({ status: 404, message: 'fake' })).toBe(false);
+
+      // Primitive inputs
+      expect(isOctokitRequestError(undefined)).toBe(false);
+      expect(isOctokitRequestError(null)).toBe(false);
+      expect(isOctokitRequestError('error string')).toBe(false);
+      expect(isOctokitRequestError(404)).toBe(false);
+    });
+  });
+
+  describe('4.4. getOctokitRateLimitReset (EARS-D1 to D3)', () => {
+    it('[EARS-D1] should parse numeric string x-ratelimit-reset header', () => {
+      const error = Object.assign(new Error('Rate limited'), {
+        status: 403,
+        response: { headers: { 'x-ratelimit-reset': '1700000000' } },
+      });
+
+      expect(getOctokitRateLimitReset(error)).toBe(1700000000);
+    });
+
+    it('[EARS-D2] should pass through numeric x-ratelimit-reset header', () => {
+      const error = Object.assign(new Error('Rate limited'), {
+        status: 403,
+        response: { headers: { 'x-ratelimit-reset': 1700000000 } },
+      });
+
+      expect(getOctokitRateLimitReset(error)).toBe(1700000000);
+    });
+
+    it('[EARS-D4] should detect rate limit errors via status (403 or 429) and x-ratelimit-remaining=0', () => {
+      // Positive: 403 + remaining=0 (string)
+      expect(isOctokitRateLimitError(Object.assign(new Error('Rate limited'), {
+        status: 403,
+        response: { headers: { 'x-ratelimit-remaining': '0' } },
+      }))).toBe(true);
+
+      // Positive: 429 + remaining=0 (string)
+      expect(isOctokitRateLimitError(Object.assign(new Error('Too many requests'), {
+        status: 429,
+        response: { headers: { 'x-ratelimit-remaining': '0' } },
+      }))).toBe(true);
+
+      // Positive: remaining as number 0
+      expect(isOctokitRateLimitError(Object.assign(new Error(), {
+        status: 403,
+        response: { headers: { 'x-ratelimit-remaining': 0 } },
+      }))).toBe(true);
+
+      // Negative: 403 with remaining > 0 (permission denial, not rate limit)
+      expect(isOctokitRateLimitError(Object.assign(new Error('Resource not accessible'), {
+        status: 403,
+        response: { headers: { 'x-ratelimit-remaining': '4999' } },
+      }))).toBe(false);
+
+      // Negative: 401 (unauthorized — not rate limit)
+      expect(isOctokitRateLimitError(Object.assign(new Error('Unauthorized'), {
+        status: 401,
+        response: { headers: { 'x-ratelimit-remaining': '0' } },
+      }))).toBe(false);
+
+      // Negative: 500 (server error — not rate limit)
+      expect(isOctokitRateLimitError(Object.assign(new Error('Server error'), {
+        status: 500,
+      }))).toBe(false);
+
+      // Negative: missing response.headers
+      expect(isOctokitRateLimitError(Object.assign(new Error(), {
+        status: 403,
+        response: {},
+      }))).toBe(false);
+
+      // Negative: missing x-ratelimit-remaining header
+      expect(isOctokitRateLimitError(Object.assign(new Error(), {
+        status: 403,
+        response: { headers: {} },
+      }))).toBe(false);
+
+      // Negative: not an Error
+      expect(isOctokitRateLimitError(undefined)).toBe(false);
+      expect(isOctokitRateLimitError(null)).toBe(false);
+      expect(isOctokitRateLimitError({ status: 403 })).toBe(false);
+
+      // Negative: plain Error without status
+      expect(isOctokitRateLimitError(new Error('plain'))).toBe(false);
+
+      // Negative: header is non-numeric string
+      expect(isOctokitRateLimitError(Object.assign(new Error(), {
+        status: 403,
+        response: { headers: { 'x-ratelimit-remaining': 'unknown' } },
+      }))).toBe(false);
+    });
+
+    it('[EARS-D3] should return undefined when header is missing or invalid', () => {
+      // Not an Error
+      expect(getOctokitRateLimitReset(undefined)).toBeUndefined();
+      expect(getOctokitRateLimitReset(null)).toBeUndefined();
+      expect(getOctokitRateLimitReset('string')).toBeUndefined();
+      expect(getOctokitRateLimitReset(403)).toBeUndefined();
+
+      // Error without response
+      expect(getOctokitRateLimitReset(new Error('plain'))).toBeUndefined();
+
+      // Error with non-object response
+      expect(getOctokitRateLimitReset(Object.assign(new Error(), { response: null }))).toBeUndefined();
+      expect(getOctokitRateLimitReset(Object.assign(new Error(), { response: 'oops' }))).toBeUndefined();
+
+      // Error with response but no headers
+      expect(getOctokitRateLimitReset(Object.assign(new Error(), { response: {} }))).toBeUndefined();
+
+      // Error with headers but no x-ratelimit-reset
+      expect(getOctokitRateLimitReset(Object.assign(new Error(), {
+        response: { headers: { 'x-ratelimit-limit': '5000' } },
+      }))).toBeUndefined();
+
+      // Header is a non-numeric string
+      expect(getOctokitRateLimitReset(Object.assign(new Error(), {
+        response: { headers: { 'x-ratelimit-reset': 'not-a-number' } },
+      }))).toBeUndefined();
+
+      // Header is null
+      expect(getOctokitRateLimitReset(Object.assign(new Error(), {
+        response: { headers: { 'x-ratelimit-reset': null } },
+      }))).toBeUndefined();
+
+      // Header is an object (not string or number)
+      expect(getOctokitRateLimitReset(Object.assign(new Error(), {
+        response: { headers: { 'x-ratelimit-reset': { nested: true } } },
+      }))).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/shared/github/github.ts
+++ b/packages/core/src/shared/github/github.ts
@@ -60,12 +60,71 @@ export class GitHubApiError extends GitError {
 /**
  * Type guard: checks if an error is an Octokit RequestError (duck-typing).
  * Avoids runtime import of ESM-only @octokit/request-error.
+ *
+ * Uses TypeScript 4.9+ structural narrowing (`'status' in error`) — no casts.
  */
 export function isOctokitRequestError(error: unknown): error is { status: number; message: string } {
-  return (
-    error instanceof Error &&
-    typeof (error as unknown as Record<string, unknown>)['status'] === 'number'
-  );
+  if (!(error instanceof Error)) return false;
+  if (!('status' in error)) return false;
+  return typeof error.status === 'number';
+}
+
+/**
+ * [EARS-D4] Detects whether an unknown error is a GitHub rate-limit failure
+ * (primary or secondary), using the canonical detection pattern documented at
+ * https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+ *
+ * Returns `true` only when ALL of the following hold:
+ *   - error is an Error with numeric `status` of 403 OR 429 (both are valid
+ *     rate-limit codes per GitHub docs — primary uses 403/429, secondary same)
+ *   - error.response.headers['x-ratelimit-remaining'] is present AND equals 0
+ *     (true for both primary AND secondary rate limit per docs)
+ *
+ * Used to distinguish rate-limit failures from permission-denial 403s (which
+ * carry the same status but no `x-ratelimit-remaining: 0` header).
+ *
+ * Never throws — graceful `false` on any structural mismatch.
+ */
+export function isOctokitRateLimitError(error: unknown): boolean {
+  if (!isOctokitRequestError(error)) return false;
+  if (error.status !== 403 && error.status !== 429) return false;
+  if (!('response' in error)) return false;
+  const response = error.response;
+  if (typeof response !== 'object' || response === null) return false;
+  if (!('headers' in response)) return false;
+  const headers = response.headers;
+  if (typeof headers !== 'object' || headers === null) return false;
+  if (!('x-ratelimit-remaining' in headers)) return false;
+  const remaining = headers['x-ratelimit-remaining'];
+  if (typeof remaining === 'string') return parseInt(remaining, 10) === 0;
+  if (typeof remaining === 'number') return remaining === 0;
+  return false;
+}
+
+/**
+ * [EARS-D1][EARS-D2][EARS-D3] Extracts the `x-ratelimit-reset` Unix timestamp from an
+ * Octokit error's response headers. Returns `undefined` if the input is not an Error,
+ * lacks `response.headers`, or the header is missing/invalid. Never throws.
+ *
+ * Used by GitHubFileLister.readBatch to populate FileListerError.details.resetTime
+ * when a 403 rate limit is hit mid-batch (see github_file_lister §4.4 EARS-D3).
+ */
+export function getOctokitRateLimitReset(error: unknown): number | undefined {
+  if (!(error instanceof Error)) return undefined;
+  if (!('response' in error)) return undefined;
+  const response = error.response;
+  if (typeof response !== 'object' || response === null) return undefined;
+  if (!('headers' in response)) return undefined;
+  const headers = response.headers;
+  if (typeof headers !== 'object' || headers === null) return undefined;
+  if (!('x-ratelimit-reset' in headers)) return undefined;
+  const reset = headers['x-ratelimit-reset'];
+  if (typeof reset === 'string') {
+    const n = parseInt(reset, 10);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  if (typeof reset === 'number') return reset;
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **AuditOrchestrationOptions** moved to `audit/types.ts` (canonical) with `ref?: string` for PR-scoped scanning
- **AgentRecordReader** ISP interface replaces full RecordStore in orchestrator deps — removes cast
- **clean_exports.test.ts** paths updated after shared/ refactor

## Test plan
- [x] Core tsc: 0 errors
- [x] Core tests: 2939/2939
- [x] CLI tsc: 0 errors
- [x] CLI unit tests: 452/452
- [x] Audit triada: 5 agents COHERENT