### PR TITLE
feat(core,cli): Gate Session 45 — ICiReporter externalId, postOrUpdateComment re-throw, Gate→Audit rename

### DIFF
--- a/packages/cli/src/commands/audit/audit-command.test.ts
+++ b/packages/cli/src/commands/audit/audit-command.test.ts
@@ -558,7 +558,7 @@ describe('AuditCommand', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       mockOrchestrator.run.mockResolvedValue(mockResultWithFindings);
-      mockFormatAuditResult.mockReturnValue('## 🔴 GitGov Gate: 2 findings');
+      mockFormatAuditResult.mockReturnValue('## 🔴 GitGov Audit: 2 findings');
       mockPostOrUpdateComment.mockResolvedValue(undefined);
       // Reset env
       delete process.env['GITHUB_ACTIONS'];
@@ -584,7 +584,7 @@ describe('AuditCommand', () => {
 
       expect(mockFormatAuditResult).toHaveBeenCalledWith(mockResultWithFindings);
       expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
-        '## 🔴 GitGov Gate: 2 findings',
+        '## 🔴 GitGov Audit: 2 findings',
         { owner: 'myorg', repo: 'myrepo', prNumber: 42 },
       );
       await fs.unlink(tmpEvent).catch(() => {});

--- a/packages/core/src/audit/formatter.test.ts
+++ b/packages/core/src/audit/formatter.test.ts
@@ -108,7 +108,7 @@ describe('AuditFormatter', () => {
       const result = makeResult({ decision: 'block' });
       const md = formatAuditResult(result)!;
 
-      expect(md).toContain('## 🔴 GitGov Gate: 1 findings — blocked');
+      expect(md).toContain('## 🔴 GitGov Audit: 1 findings — blocked');
     });
   });
 

--- a/packages/core/src/audit/formatter.ts
+++ b/packages/core/src/audit/formatter.ts
@@ -31,7 +31,7 @@ export function formatAuditResult(result: AuditOrchestrationResult): string | nu
   const headerBadge = decision === 'block' ? '🔴' : '✅';
 
   // [AFMT-A4]
-  let md = `## ${headerBadge} GitGov Gate: ${active.length} findings — ${statusLabel}\n\n`;
+  let md = `## ${headerBadge} GitGov Audit: ${active.length} findings — ${statusLabel}\n\n`;
 
   // [AFMT-A1]
   md += '| # | Severity | Category | File | Line | Message |\n';
@@ -53,7 +53,7 @@ export function formatAuditResult(result: AuditOrchestrationResult): string | nu
   // [AFMT-B3]
   md += '\n> 💡 To waive: `gitgov audit waive <fingerprint> -j "reason"`\n';
 
-  md += '\n---\n*GitGov Gate v1*\n';
+  md += '\n---\n*GitGov Audit v1*\n';
 
   return md;
 }

--- a/packages/core/src/ci_reporter/ci_reporter.ts
+++ b/packages/core/src/ci_reporter/ci_reporter.ts
@@ -25,7 +25,7 @@ export interface ICiReporter {
   // [CIREP-A1] POST new comment / [CIREP-A2] PATCH existing / [CIREP-A3] default marker / [CIREP-A4] skip empty
   postOrUpdateComment(markdown: string, context: PrContext, marker?: string): Promise<void>;
   // [CIREP-D1] Create Check Run in_progress — first step of two-step lifecycle
-  startCheckRun?(sha: string, name: string, context: RepoContext): Promise<CheckInfo>;
+  startCheckRun?(sha: string, name: string, context: RepoContext, externalId?: string): Promise<CheckInfo>;
   // [CIREP-C1] API errors non-blocking
   createCheckStatus?(sha: string, conclusion: 'pass' | 'fail', summary: string, context: RepoContext): Promise<CheckInfo>;
   postInlineSuggestion?(file: string, line: number, suggestion: string, context: PrContext): Promise<void>;

--- a/packages/core/src/ci_reporter/github/github_ci_reporter.test.ts
+++ b/packages/core/src/ci_reporter/github/github_ci_reporter.test.ts
@@ -139,13 +139,13 @@ describe('GitHubCiReporter', () => {
   });
 
   describe('4.3. Error Handling (CIREP-C1 to C2)', () => {
-    it('[CIREP-C1] should warn on API error without throwing', async () => {
+    it('[CIREP-C1] should warn and re-throw on API error', async () => {
       const octokit = createMockOctokit([]);
       octokit.rest.issues.createComment.mockRejectedValueOnce(new Error('403 Forbidden'));
       const reporter = new GitHubCiReporter(octokit as unknown as Octokit);
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-      await reporter.postOrUpdateComment('test', PR_CONTEXT);
+      await expect(reporter.postOrUpdateComment('test', PR_CONTEXT)).rejects.toThrow('403 Forbidden');
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('403 Forbidden'));
       warnSpy.mockRestore();

--- a/packages/core/src/ci_reporter/github/github_ci_reporter.test.ts
+++ b/packages/core/src/ci_reporter/github/github_ci_reporter.test.ts
@@ -179,5 +179,31 @@ describe('GitHubCiReporter', () => {
       expect(result.id).toBe(1);
       expect(result.url).toBe('https://github.com/check/1');
     });
+
+    it('[CIREP-D1] should pass external_id to checks.create when externalId provided', async () => {
+      const octokit = createMockOctokit();
+      const reporter = new GitHubCiReporter(octokit as unknown as Octokit);
+
+      await reporter.startCheckRun('abc123', 'GitGov Audit', { owner: 'myorg', repo: 'myrepo' }, 'scan-42');
+
+      expect(octokit.rest.checks.create).toHaveBeenCalledWith({
+        owner: 'myorg',
+        repo: 'myrepo',
+        name: 'GitGov Audit',
+        head_sha: 'abc123',
+        status: 'in_progress',
+        external_id: 'scan-42',
+      });
+    });
+
+    it('[CIREP-D1] should not include external_id when externalId is undefined', async () => {
+      const octokit = createMockOctokit();
+      const reporter = new GitHubCiReporter(octokit as unknown as Octokit);
+
+      await reporter.startCheckRun('abc123', 'GitGov Audit', { owner: 'myorg', repo: 'myrepo' });
+
+      const call = (octokit.rest.checks.create as jest.Mock).mock.calls[0][0];
+      expect(call).not.toHaveProperty('external_id');
+    });
   });
 });

--- a/packages/core/src/ci_reporter/github/github_ci_reporter.ts
+++ b/packages/core/src/ci_reporter/github/github_ci_reporter.ts
@@ -95,11 +95,11 @@ export class GitHubCiReporter implements ICiReporter {
     const { data } = await this.octokit.rest.checks.create({
       owner: context.owner,
       repo: context.repo,
-      name: 'GitGov Gate',
+      name: 'GitGov Audit',
       head_sha: sha,
       status: 'completed',
       conclusion: conclusion === 'pass' ? 'success' : 'failure',
-      output: { title: 'GitGov Gate', summary },
+      output: { title: 'GitGov Audit', summary },
     });
     const result: CheckInfo = { id: data.id, conclusion };
     if (data.html_url) result.url = data.html_url;

--- a/packages/core/src/ci_reporter/github/github_ci_reporter.ts
+++ b/packages/core/src/ci_reporter/github/github_ci_reporter.ts
@@ -59,9 +59,10 @@ export class GitHubCiReporter implements ICiReporter {
         });
       }
     } catch (error) {
-      // [CIREP-C1]
+      // [CIREP-C1] Log then re-throw — callers handle (CLI warns, SaaS surfaces via errorCode)
       const msg = error instanceof Error ? error.message : String(error);
       console.warn(`⚠ Failed to post PR comment: ${msg}`);
+      throw error;
     }
   }
 
@@ -70,6 +71,7 @@ export class GitHubCiReporter implements ICiReporter {
     sha: string,
     name: string,
     context: RepoContext,
+    externalId?: string,
   ): Promise<CheckInfo> {
     const { data } = await this.octokit.rest.checks.create({
       owner: context.owner,
@@ -77,6 +79,7 @@ export class GitHubCiReporter implements ICiReporter {
       name,
       head_sha: sha,
       status: 'in_progress',
+      ...(externalId ? { external_id: externalId } : {}),
     });
     const result: CheckInfo = { id: data.id, conclusion: 'pass' };
     if (data.html_url) result.url = data.html_url;


### PR DESCRIPTION
## Summary
- ICiReporter `startCheckRun` accepts `externalId` param (passed as `external_id` to GitHub Checks API)
- `postOrUpdateComment` now re-throws after `console.warn` (CIREP-C1 behavior change — callers handle)
- Renamed "GitGov Gate" → "GitGov Audit" in Check Runs, PR comments, and formatter output
- CIREP-D1 test coverage: externalId present/absent paths

## Test plan
- [x] 13/13 ci_reporter tests green
- [x] formatter tests green
- [x] CLI audit-command tests green (Gate→Audit string update)
- [x] PAF E2E 17/17 green validates end-to-end