### PR TITLE
refactor: actor initialization — ensureActorInProject → addActor + --token seam

### DIFF
--- a/packages/cli/e2e/audit_command_e2e.test.ts
+++ b/packages/cli/e2e/audit_command_e2e.test.ts
@@ -1,0 +1,69 @@
+/**
+ * E2E Tests for Audit CLI Command
+ *
+ * Blueprint: audit_command.md §4.11 (AORCH-P5), §4.12 (AORCH-P6)
+ *
+ * Tests the `gitgov audit` command in edge cases:
+ * - AORCH-P5: Repo without .gitgov → clear error message
+ * - AORCH-P6: Repo without commits → clear error message
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { runCliCommand, createGitRepo, getWorktreeBasePath, cleanupWorktree } from './helpers';
+
+describe('Audit CLI Command E2E', () => {
+  describe('4.11. Project Guard (AORCH-P5)', () => {
+    it('[AORCH-P5] should exit with error when project not initialized', () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitgov-audit-e2e-'));
+      const repoPath = path.join(tempDir, 'repo');
+      fs.mkdirSync(repoPath, { recursive: true });
+
+      // Create repo WITH commits but WITHOUT gitgov init
+      createGitRepo(repoPath, true);
+
+      // Audit should fail — no .gitgov/
+      const auditResult = runCliCommand(
+        ['audit', '--scope', 'full'],
+        { cwd: repoPath, expectError: true },
+      );
+      expect(auditResult.success).toBe(false);
+      const output = `${auditResult.output} ${auditResult.error ?? ''}`;
+      expect(output).toContain('not initialized');
+
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+  });
+
+  describe('4.12. Working Repo Guard (AORCH-P6)', () => {
+    it('[AORCH-P6] should exit with error when repo has no commits', () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitgov-audit-e2e-'));
+      const repoPath = path.join(tempDir, 'repo');
+      fs.mkdirSync(repoPath, { recursive: true });
+
+      // Create repo WITHOUT commits
+      createGitRepo(repoPath, false);
+
+      // Init succeeds without commits
+      const initResult = runCliCommand(
+        ['init', '--name', 'NoCommit', '--actor-name', 'Test', '--quiet'],
+        { cwd: repoPath },
+      );
+      expect(initResult.success).toBe(true);
+
+      // Audit should fail with clear message
+      const auditResult = runCliCommand(
+        ['audit', '--scope', 'full'],
+        { cwd: repoPath, expectError: true },
+      );
+      expect(auditResult.success).toBe(false);
+      const output = `${auditResult.output} ${auditResult.error ?? ''}`;
+      expect(output).toContain('No commits found');
+
+      // Cleanup
+      const wtPath = getWorktreeBasePath(repoPath);
+      cleanupWorktree(repoPath, wtPath);
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+  });
+});

--- a/packages/cli/e2e/init_command_e2e.test.ts
+++ b/packages/cli/e2e/init_command_e2e.test.ts
@@ -712,4 +712,29 @@ describe('Init CLI Command - Edge Cases E2E Tests', () => {
       cleanupWorktree(projRoot, wtPath);
     });
   });
+
+  describe('4.9. Security .gitignore (EARS-FPI20)', () => {
+    it('[EARS-FPI20] should create .gitgov/.gitignore with security exclusions after init', () => {
+      const projRoot = path.join(tempDir, 'gitignore-test');
+      fs.mkdirSync(projRoot, { recursive: true });
+      createGitRepo(projRoot);
+
+      const initResult = runCliCommand(
+        ['init', '--name', 'GitignoreTest', '--actor-name', 'Test'],
+        { cwd: projRoot },
+      );
+      expect(initResult.success).toBe(true);
+
+      const wtPath = getWorktreeBasePath(projRoot);
+      const gitignorePath = path.join(wtPath, '.gitgov', '.gitignore');
+      expect(fs.existsSync(gitignorePath)).toBe(true);
+
+      const content = fs.readFileSync(gitignorePath, 'utf-8');
+      expect(content).toContain('*.key');
+      expect(content).toContain('.session.json');
+      expect(content).toContain('index.json');
+
+      cleanupWorktree(projRoot, wtPath);
+    });
+  });
 });

--- a/packages/cli/src/base/base-command.ts
+++ b/packages/cli/src/base/base-command.ts
@@ -83,6 +83,26 @@ export abstract class BaseCommand<TOptions extends BaseCommandOptions = BaseComm
   }
 
   /**
+   * Guard: require .gitgov/ directory exists (project initialized).
+   * Exits with user-friendly error if not initialized.
+   */
+  protected async requireProject(options: TOptions): Promise<void> {
+    const { existsSync } = await import('fs');
+    const path = await import('path');
+    const { getWorktreeBasePath } = await import('@gitgov/core/fs');
+    try {
+      const gitModule = await this.container.getGitModule();
+      const repoRoot = await gitModule.getRepoRoot();
+      const worktreePath = getWorktreeBasePath(repoRoot);
+      if (!existsSync(path.join(worktreePath, '.gitgov'))) {
+        this.handleError('Project not initialized. Run `gitgov init` first.', options);
+      }
+    } catch {
+      this.handleError('Project not initialized. Run `gitgov init` first.', options);
+    }
+  }
+
+  /**
    * Guard: require active actor identity for write operations.
    * Returns actor ID or exits with user-friendly error message.
    */

--- a/packages/cli/src/base/base-command.ts
+++ b/packages/cli/src/base/base-command.ts
@@ -103,6 +103,22 @@ export abstract class BaseCommand<TOptions extends BaseCommandOptions = BaseComm
   }
 
   /**
+   * Guard: require at least one commit in the repo.
+   * A repo without commits cannot run audit, sync, or status.
+   */
+  protected async requireWorkingRepo(options: TOptions): Promise<void> {
+    try {
+      const gitModule = await this.container.getGitModule();
+      await gitModule.getCommitHash('HEAD');
+    } catch {
+      this.handleError(
+        'No commits found. Commit your code first before running gitgov commands.',
+        options,
+      );
+    }
+  }
+
+  /**
    * Guard: require active actor identity for write operations.
    * Returns actor ID or exits with user-friendly error message.
    */

--- a/packages/cli/src/commands/agent/agent-command.test.ts
+++ b/packages/cli/src/commands/agent/agent-command.test.ts
@@ -610,12 +610,31 @@ describe('AgentCommand', () => {
         gitgov: { agent: { purpose: 'audit', function: 'runAgent' } },
       });
 
-      mockAgentStore.list.mockResolvedValue(['agent_security-audit']);
+      mockAgentStore.list.mockResolvedValue(['agent:security-audit']);
 
       await agentCommand.executeNew(tmpAgentDir, {});
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining('Agent updated: agent:security-audit'),
+      );
+    });
+
+    it('[EARS-E8] should show updated message with engine type transition', async () => {
+      tmpAgentDir = createFakeAgent({
+        name: '@gitgov/agent-security-audit',
+        main: 'dist/index.mjs',
+        gitgov: { agent: { purpose: 'audit', function: 'runAgent' } },
+      });
+
+      mockAgentStore.list.mockResolvedValue(['agent:security-audit']);
+      mockAgentStore.get.mockResolvedValue({
+        payload: { engine: { type: 'npm' } },
+      });
+
+      await agentCommand.executeNew(tmpAgentDir, {});
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('[npm → local]'),
       );
     });
   });

--- a/packages/cli/src/commands/agent/agent-command.ts
+++ b/packages/cli/src/commands/agent/agent-command.ts
@@ -220,14 +220,20 @@ export class AgentCommand extends BaseCommand<RunCommandOptions> {
 
       // [EARS-E5, E6] Create or update
       const agentStore = await this.container.getAgentStore();
+      // list() returns decoded IDs (e.g. 'agent:security-audit'), not encoded filenames
       const existingIds = await agentStore.list();
-      const alreadyExists = existingIds.includes(DEFAULT_ID_ENCODER.encode(actorId));
+      const alreadyExists = existingIds.includes(actorId);
 
       let agent: AgentRecord;
+      // [EARS-E8] Read previous engine type before overwrite
+      let previousEngineType: string | null = null;
       if (alreadyExists) {
+        try {
+          const prev = await agentStore.get(actorId);
+          if (prev) previousEngineType = (prev.payload as { engine?: { type?: string } })?.engine?.type ?? null;
+        } catch { /* read failure is non-fatal */ }
         // [EARS-E6] Update existing
         agent = await agentAdapter.createAgentRecord(payload);
-        if (!options.quiet) console.log(`✅ Agent updated: ${actorId}`);
       } else {
         // [EARS-E5] Create new — auto-create ActorRecord if needed
         try {
@@ -248,15 +254,18 @@ export class AgentCommand extends BaseCommand<RunCommandOptions> {
         }
       }
 
-      // [EARS-E7] Output
+      // [EARS-E7] [EARS-E8] Output — distinguish register vs update
       if (options.json) {
         console.log(JSON.stringify({
           success: true,
           action: alreadyExists ? 'updated' : 'created',
-          data: { id: agent.id, actorId, engine: agent.engine },
+          data: { id: agent.id, actorId, engine: agent.engine, previousEngineType },
         }, null, 2));
       } else if (!options.quiet) {
-        console.log(`✅ Agent ${alreadyExists ? 'updated' : 'registered'}: ${actorId} [${engine.type}]`);
+        const typeLabel = alreadyExists && previousEngineType
+          ? `[${previousEngineType} → ${engine.type}]`
+          : `[${engine.type}]`;
+        console.log(`✅ Agent ${alreadyExists ? 'updated' : 'registered'}: ${actorId} ${typeLabel}`);
         console.log(`   Package: ${pkgName}`);
         console.log(`   Function: ${fnName}`);
       }

--- a/packages/cli/src/commands/audit/audit-command.test.ts
+++ b/packages/cli/src/commands/audit/audit-command.test.ts
@@ -7,15 +7,34 @@
  */
 
 // vi.hoisted ensures variables exist when vi.mock factory runs (hoisted to top)
-const { mockFormatAuditResult, mockPostOrUpdateComment } = vi.hoisted(() => ({
+const { mockFormatAuditResult, mockPostOrUpdateComment, mockAuditFsProjectionPersist } = vi.hoisted(() => ({
   mockFormatAuditResult: vi.fn(),
   mockPostOrUpdateComment: vi.fn().mockResolvedValue(undefined),
+  mockAuditFsProjectionPersist: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@gitgov/core/audit', () => ({
   formatAuditResult: (...args: unknown[]) => mockFormatAuditResult(...args),
   severityBadge: vi.fn((s: string) => ({ critical: '🔴', high: '🟠', medium: '🟡', low: '🔵' })[s] ?? '⚪'),
 }));
+
+// Mock @gitgov/core/fs for AORCH-P4 (AuditFsProjection)
+vi.mock('@gitgov/core/fs', () => ({
+  AuditFsProjection: class MockAuditFsProjection {
+    persist = mockAuditFsProjectionPersist;
+  },
+  findProjectRoot: vi.fn().mockReturnValue('/mock/project/root'),
+}));
+
+// Mock child_process for AORCH-C8 (branch + commit resolution)
+vi.mock('child_process', () => ({
+  execSync: vi.fn().mockImplementation((cmd: string) => {
+    if (cmd === 'git branch --show-current') return 'main\n';
+    if (cmd === 'git rev-parse HEAD') return 'abc123def456\n';
+    return '';
+  }),
+}));
+
 // GitHubCiReporter mock: spy on fromToken after import (vi.mock doesn't intercept this subpath export)
 import { GitHubCiReporter } from '@gitgov/core/github';
 
@@ -448,6 +467,20 @@ describe('AuditCommand', () => {
       expect(callArg.taskId).toBe('1774524476-task-audit-full-scan');
     });
 
+    it('[AORCH-C8] should include branch and commit references in TaskRecord', async () => {
+      await auditCommand.execute(createDefaultOptions({ scope: 'full' }));
+
+      const diInstance = mockDI.getInstance();
+      const backlogAdapter = await diInstance.getBacklogAdapter();
+      const createTaskArgs = (backlogAdapter.createTask as vi.Mock).mock.calls[0];
+      expect(createTaskArgs[0].references).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^branch:/),
+          expect.stringMatching(/^commit:/),
+        ]),
+      );
+    });
+
     it('should handle initialization errors gracefully', async () => {
       mockDI.getInstance.mockReturnValue({
         getAuditOrchestrator: vi.fn().mockRejectedValue(new Error('Init failed')),
@@ -762,6 +795,33 @@ describe('AuditCommand', () => {
       await auditCommand.execute({ scope: 'full', output: 'text', failOn: 'critical' } as AuditCommandOptions);
 
       expect(mockExecCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  // 4.11. Project Guard (AORCH-P5)
+  describe('4.11. Project Guard (AORCH-P5)', () => {
+    it('[AORCH-P5] should exit with error when project not initialized', async () => {
+      const coreFsMock = await import('@gitgov/core/fs');
+      vi.mocked(coreFsMock.findProjectRoot).mockReturnValueOnce(null);
+
+      await auditCommand.execute(createDefaultOptions());
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Project not initialized'),
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  // 4.10. FS Audit Projection (AORCH-P4)
+  describe('4.10. FS Audit Projection (AORCH-P4)', () => {
+    it('[AORCH-P4] should persist audit result to .gitgov/audit-index.json after orchestrator.run', async () => {
+      mockOrchestrator.run.mockResolvedValueOnce(mockResultWithFindings);
+
+      await auditCommand.execute(createDefaultOptions({ scope: 'full' }));
+
+      expect(mockAuditFsProjectionPersist).toHaveBeenCalledTimes(1);
+      expect(mockAuditFsProjectionPersist).toHaveBeenCalledWith(mockResultWithFindings);
     });
   });
 });

--- a/packages/cli/src/commands/audit/audit-command.test.ts
+++ b/packages/cli/src/commands/audit/audit-command.test.ts
@@ -24,6 +24,7 @@ vi.mock('@gitgov/core/fs', () => ({
     persist = mockAuditFsProjectionPersist;
   },
   findProjectRoot: vi.fn().mockReturnValue('/mock/project/root'),
+  getWorktreeBasePath: vi.fn().mockReturnValue('/mock/worktree'),
 }));
 
 // Mock child_process for AORCH-C8 (branch + commit resolution)
@@ -283,6 +284,7 @@ describe('AuditCommand', () => {
       getIdentityAdapter: vi.fn().mockResolvedValue(mockIdentityAdapter),
       getCurrentActor: vi.fn().mockResolvedValue({ id: 'human:developer' }),
       getProjectRoot: vi.fn().mockResolvedValue('/mock/project/root'),
+      getGitModule: vi.fn().mockResolvedValue({ getCommitHash: vi.fn().mockResolvedValue('abc123'), getRepoRoot: vi.fn().mockResolvedValue('/mock/repo') }),
       getSessionManager: vi.fn().mockResolvedValue({
         getState: vi.fn().mockReturnValue({ actorId: 'human:developer' }),
       }),
@@ -801,15 +803,51 @@ describe('AuditCommand', () => {
   // 4.11. Project Guard (AORCH-P5)
   describe('4.11. Project Guard (AORCH-P5)', () => {
     it('[AORCH-P5] should exit with error when project not initialized', async () => {
-      const coreFsMock = await import('@gitgov/core/fs');
-      vi.mocked(coreFsMock.findProjectRoot).mockReturnValueOnce(null);
-
+      // getWorktreeBasePath returns /mock/worktree, existsSync('/mock/worktree/.gitgov') = false
+      // → requireProject detects no .gitgov/ and exits
       await auditCommand.execute(createDefaultOptions());
 
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining('Project not initialized'),
       );
       expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  // 4.12. Working Repo Guard (AORCH-P6)
+  describe('4.12. Working Repo Guard (AORCH-P6)', () => {
+    it('[AORCH-P6] should exit with error when repo has no commits', async () => {
+      // Bypass requireProject so we reach requireWorkingRepo
+      vi.spyOn(auditCommand as any, 'requireProject').mockResolvedValue(undefined);
+      mockDIInstance.getGitModule = vi.fn().mockResolvedValue({
+        getCommitHash: vi.fn().mockRejectedValue(new Error('fatal: ambiguous argument HEAD')),
+      });
+
+      await auditCommand.execute(createDefaultOptions());
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('No commits found'),
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  // 4.13. Orchestrator Warnings Display (AORCH-P7)
+  describe('4.13. Orchestrator Warnings Display (AORCH-P7)', () => {
+    it('[AORCH-P7] should display orchestrator warnings before summary', async () => {
+      const resultWithWarning = {
+        ...mockResultWithFindings,
+        warning: 'All audit agents failed to load:\n  agent:security-audit: entrypoint not found',
+      };
+      mockOrchestrator.run.mockResolvedValueOnce(resultWithWarning);
+      const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation();
+
+      await auditCommand.execute(createDefaultOptions());
+
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('All audit agents failed'),
+      );
+      mockConsoleWarn.mockRestore();
     });
   });
 

--- a/packages/cli/src/commands/audit/audit-command.ts
+++ b/packages/cli/src/commands/audit/audit-command.ts
@@ -5,6 +5,7 @@ import { readFile } from 'node:fs/promises';
 import { Sarif as SarifModule, generateExecutionId } from '@gitgov/core';
 import { formatAuditResult } from '@gitgov/core/audit';
 import type { Finding, FindingCategory, DetectorName } from '@gitgov/core/audit';
+import { AuditFsProjection, findProjectRoot } from '@gitgov/core/fs';
 import type {
   AuditOrchestrationOptions,
   AuditOrchestrationResult,
@@ -110,6 +111,9 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
    */
   async execute(options: AuditCommandOptions): Promise<void> {
     try {
+      // [AORCH-P5] Guard: project must be initialized
+      await this.requireProject(options);
+
       // [AORCH-D6] [AORCH-D7] Set LLM env vars before running agents
       if (options.llmModel) process.env['LLM_MODEL'] = options.llmModel;
       if (options.llmKey) process.env['LLM_API_KEY'] = options.llmKey;
@@ -118,18 +122,32 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
       const backlogAdapter = await this.container.getBacklogAdapter();
       const { actorId } = await this.requireActor(options);
 
-      if (!options.quiet && options.output !== 'json') {
+      if (!options.quiet && options.output !== 'json' && options.output !== 'sarif') {
         this.logger.log(`Scanning repository (scope: ${options.scope})...`);
       }
 
+      // [AORCH-C8] Resolve git context for traceability (branch + commit in TaskRecord.references)
+      let branch = '';
+      let commitSha = '';
+      try {
+        const { execSync } = await import('child_process');
+        branch = execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
+        commitSha = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
+      } catch { /* git not available — leave empty */ }
+
       // Create a real TaskRecord for the audit run — serves as correlation
       // node linking ExecutionRecords (scan, policy) and FeedbackRecords (review)
+      const references: string[] = [];
+      if (branch) references.push(`branch:${branch}`);
+      if (commitSha) references.push(`commit:${commitSha}`);
+
       const auditTask = await backlogAdapter.createTask({
         title: `Audit: ${options.scope} scan`,
         status: 'active',
         priority: 'high',
         description: `Automated audit scan (scope: ${options.scope})`,
         tags: ['audit', 'automated'],
+        references,
       }, actorId);
 
       // Invoke orchestrator - ALL logic lives here
@@ -148,6 +166,17 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
         orchestrationOptions.exclude = options.exclude.split(',').map(g => g.trim());
       }
       const result = await orchestrator.run(orchestrationOptions);
+
+      // [AORCH-P4] Persist AuditOrchestrationResult to .gitgov/audit-index.json
+      try {
+        const projectRoot = findProjectRoot() ?? process.cwd();
+        const auditProjection = new AuditFsProjection({
+          basePath: `${projectRoot}/.gitgov`,
+        });
+        await auditProjection.persist(result);
+      } catch {
+        // FS persistence errors are non-fatal
+      }
 
       // [AORCH-P1] Write L1 ExecutionRecords to .gitgov/executions/ (redacted SARIF)
       if (result.l1AgentResults) {
@@ -463,8 +492,8 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
           content: options.justification,
           metadata: {
             fingerprint,
-            ruleId: 'CLI-WAIVER',
-            file: 'unknown',
+            ruleId: 'CLI-WAIVER', // TODO: Resolve ruleId from local ExecutionRecord SARIF by fingerprint lookup (Bug 15)
+            file: 'unknown', // TODO: Resolve file/line from local SARIF by fingerprint lookup (Bug 7/EARS-E1)
             line: 0,
           },
         },

--- a/packages/cli/src/commands/audit/audit-command.ts
+++ b/packages/cli/src/commands/audit/audit-command.ts
@@ -113,6 +113,8 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
     try {
       // [AORCH-P5] Guard: project must be initialized
       await this.requireProject(options);
+      // [AORCH-P6] Guard: repo must have at least one commit
+      await this.requireWorkingRepo(options);
 
       // [AORCH-D6] [AORCH-D7] Set LLM env vars before running agents
       if (options.llmModel) process.env['LLM_MODEL'] = options.llmModel;
@@ -215,6 +217,11 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
         } catch {
           // Review persistence errors are non-fatal
         }
+      }
+
+      // [AORCH-P7] Display orchestrator warnings before output
+      if (result.warning) {
+        console.warn(`\n⚠️  ${result.warning}\n`);
       }
 
       // Format and display output
@@ -356,10 +363,6 @@ export class AuditCommand extends BaseCommand<AuditCommandOptions> {
       console.log(`Exit code:  \x1b[31m1 (${options.failOn} findings detected)\x1b[0m`);
     } else {
       console.log(`Exit code:  \x1b[32m0 (no ${options.failOn} findings)\x1b[0m`);
-    }
-
-    if (result.warning) {
-      console.log(`\n⚠️  ${result.warning}`);
     }
 
     if (summary.total > 0) {

--- a/packages/cli/src/commands/init/init-command.test.ts
+++ b/packages/cli/src/commands/init/init-command.test.ts
@@ -338,7 +338,7 @@ describe('InitCommand', () => {
       expect(mockProcessExit).not.toHaveBeenCalled();
     });
 
-    it('[INIT-J1] should call ensureActorInProject when alreadyInitialized and actor missing', async () => {
+    it('[INIT-J1] should call addActor when alreadyInitialized and actor missing', async () => {
       mockProjectModule.initializeProject.mockResolvedValue({
         alreadyInitialized: true,
         actorId: 'human:test-user',

--- a/packages/cli/src/commands/init/init-command.test.ts
+++ b/packages/cli/src/commands/init/init-command.test.ts
@@ -361,6 +361,21 @@ describe('InitCommand', () => {
 
       expect(mockConsoleLog).toHaveBeenCalledWith('Already a member of this project as human:test-user');
     });
+
+    it('[INIT-J2b] should not run postInitConcerns when already a member', async () => {
+      mockProjectModule.initializeProject.mockResolvedValue({
+        alreadyInitialized: true,
+        actorId: 'human:test-user',
+        created: false,
+      } as any);
+      (execSync as Mock<typeof execSync>).mockClear();
+
+      await initCommand.execute({ name: 'Test Project' });
+
+      const pushCalls = (execSync as Mock<typeof execSync>).mock.calls
+        .filter(([cmd]) => typeof cmd === 'string' && cmd.includes('git push'));
+      expect(pushCalls).toHaveLength(0);
+    });
   });
 
   // ============================================================================

--- a/packages/cli/src/commands/init/init-command.ts
+++ b/packages/cli/src/commands/init/init-command.ts
@@ -86,9 +86,6 @@ export class InitCommand {
       // [EARS-B1] Get ProjectModule from dependency injection
       const projectModule = await this.getProjectModule(stateBranch);
 
-      // [EARS-B1] Delegate ALL business logic to ProjectModule
-      progressTracker.start("🚀 Initializing GitGovernance Project...\n");
-
       // [EARS-D1] Build ProjectInitOptions — filter undefined for exactOptionalPropertyTypes
       const saasUrl = completeOptions.saasUrl || process.env['GITGOV_SAAS_URL'] || 'https://app.gitgov.dev';
       const initOptions: import('@gitgov/core').ProjectModuleInitOptions = { name: completeOptions.name!, saasUrl, stateBranch };
@@ -97,25 +94,31 @@ export class InitCommand {
       if (completeOptions.type) initOptions.type = completeOptions.type;
       const result = await projectModule.initializeProject(initOptions);
 
-      progressTracker.complete();
+      // [EARS-B1] Show progress only for actual initialization (not re-runs)
+      if (!result.alreadyInitialized) {
+        progressTracker.start("🚀 Initializing GitGovernance Project...\n");
+        progressTracker.complete();
+      }
 
       // [EARS-B4] Format success output
       if (result.alreadyInitialized) {
         if (result.actorId && result.created) {
-          // [INIT-J1] Joined as new member
+          // [INIT-J1] Joined as new member — run postInitConcerns for push + DX
           console.log(`Joined existing project as ${result.actorId}`);
+          await this.postInitConcerns(options);
         } else if (result.actorId) {
-          // [INIT-J2] Already a member
+          // [INIT-J2] [INIT-J2b] Already a member — skip postInitConcerns
           console.log(`Already a member of this project as ${result.actorId}`);
+          return;
         } else {
           console.log("ℹ️  Project already initialized.");
+          return;
         }
       } else {
         this.showSuccessOutput(result, options);
+        // [EARS-G1] Post-init: best-effort push + DX concerns
+        await this.postInitConcerns(options);
       }
-
-      // [EARS-G1] Post-init: best-effort push + DX concerns
-      await this.postInitConcerns(options);
 
     } catch (error) {
       // 7. Format errors for user-friendly display

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -79,7 +79,7 @@ const {
   mockSetCloudToken, mockSetLastSession, mockClearCloudToken, mockLoadSession,
   mockDetectActorFromKeyFiles, mockGetPrivateKey, mockSetPrivateKey,
   mockHasPrivateKey, mockGetPublicKey, mockGetConfig, mockGetCurrentActor,
-  mockEnsureActorInProject,
+  mockAddActor,
 } = vi.hoisted(() => ({
   mockSetCloudToken: vi.fn(),
   mockSetLastSession: vi.fn(),
@@ -92,7 +92,7 @@ const {
   mockGetPublicKey: vi.fn(),
   mockGetConfig: vi.fn(),
   mockGetCurrentActor: vi.fn(),
-  mockEnsureActorInProject: vi.fn().mockResolvedValue({ actorId: 'human:testuser', created: true }),
+  mockAddActor: vi.fn().mockResolvedValue({ actorId: 'human:testuser', created: true }),
 }));
 
 vi.mock('../../services/dependency-injection', () => ({
@@ -117,7 +117,7 @@ vi.mock('../../services/dependency-injection', () => ({
       }),
       getCurrentActor: mockGetCurrentActor,
       getProjectModule: vi.fn().mockResolvedValue({
-        ensureActorInProject: mockEnsureActorInProject,
+        addActor: mockAddActor,
       }),
       getConfigManager: vi.fn().mockResolvedValue({
         loadConfig: mockGetConfig,
@@ -878,7 +878,7 @@ describe('LoginCommand v2', () => {
   // §4.14. Actor Materialization on Login (LOGIN-O1 to O2)
   // ==========================================================================
   describe('4.14. Actor Materialization on Login (LOGIN-O1 to O2)', () => {
-    it('[LOGIN-O1] should call ensureActorInProject before key sync', async () => {
+    it('[LOGIN-O1] should call addActor before key sync', async () => {
       mockGetCurrentActor.mockResolvedValue(null);
       mockGetConfig.mockResolvedValue({ saasUrl: 'https://app.gitgov.dev' });
       mockHasPrivateKey.mockResolvedValue(true);
@@ -893,7 +893,7 @@ describe('LoginCommand v2', () => {
       const cmd = new LoginCommand(deps);
       await cmd.executeLogin(defaultOptions);
 
-      expect(mockEnsureActorInProject).toHaveBeenCalledWith(
+      expect(mockAddActor).toHaveBeenCalledWith(
         expect.objectContaining({
           login: 'camilo',
           type: 'human',
@@ -902,11 +902,11 @@ describe('LoginCommand v2', () => {
       );
     });
 
-    it('[LOGIN-O2] should warn and continue when ensureActorInProject fails', async () => {
+    it('[LOGIN-O2] should warn and continue when addActor fails', async () => {
       mockGetCurrentActor.mockResolvedValue(null);
       mockGetConfig.mockResolvedValue({ saasUrl: 'https://app.gitgov.dev' });
       mockHasPrivateKey.mockResolvedValue(false);
-      mockEnsureActorInProject.mockRejectedValueOnce(new Error('GitHub API unavailable'));
+      mockAddActor.mockRejectedValueOnce(new Error('GitHub API unavailable'));
 
       const deps = createMockDeps({
         fetchSaas: createTrpcFetch({

--- a/packages/cli/src/commands/login/login-command.test.ts
+++ b/packages/cli/src/commands/login/login-command.test.ts
@@ -18,7 +18,10 @@ import type { IKeyProvider } from '@gitgov/core';
 // Mock child_process for resolveOrgId
 vi.mock('child_process', () => ({
   exec: vi.fn(),
-  execSync: vi.fn().mockReturnValue('https://github.com/testorg/testrepo.git\n'),
+  execSync: vi.fn().mockImplementation((cmd: string) => {
+    if (cmd.startsWith('ssh -G')) return 'hostname github.com\n';
+    return 'https://github.com/testorg/testrepo.git\n';
+  }),
 }));
 
 // Mock @gitgov/core/fs for FsKeyProvider (dynamic import in login-command)
@@ -637,9 +640,9 @@ describe('LoginCommand v2', () => {
     });
   });
 
-  // ==================== §4.8 Config Requirements (LOGIN-H1 to H3) ====================
+  // ==================== §4.8 Config Requirements (LOGIN-H1 to H4) ====================
 
-  describe('4.8. Config Requirements (LOGIN-H1 to H3)', () => {
+  describe('4.8. Config Requirements (LOGIN-H1 to H4)', () => {
     it('[LOGIN-H1] should exit with error when saasUrl is not configured', async () => {
       mockGetConfig.mockResolvedValue({ projectId: 'test' }); // no saasUrl
 
@@ -672,6 +675,35 @@ describe('LoginCommand v2', () => {
       // keyStatus should have been called with repoFullName from git remote
       expect(deps.fetchSaas).toHaveBeenCalledWith(
         expect.stringContaining('testorg'),
+        expect.any(Object)
+      );
+    });
+
+    it('[LOGIN-H4] should resolve SSH alias to real hostname via ssh -G', async () => {
+      const { execSync } = await import('child_process');
+      const mockExecSync = execSync as Mock<typeof execSync>;
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'git remote get-url origin') return 'git@github-triad:testorg/testrepo.git\n';
+        if (cmd === 'ssh -G github-triad') return 'hostname github.com\n';
+        return '';
+      });
+      mockHasPrivateKey.mockResolvedValue(false);
+
+      const deps = createMockDeps({
+        fetchSaas: vi.fn().mockImplementation(async (url: string) => {
+          if (url.includes('identity.keyStatus')) {
+            expect(url).toContain('github.com');
+            return { ok: true, json: async () => trpcWrap(noKeyStatus) };
+          }
+          return { ok: false, json: async () => ({}) };
+        }),
+      });
+
+      const cmd = new LoginCommand(deps);
+      await cmd.executeLogin(defaultOptions);
+
+      expect(deps.fetchSaas).toHaveBeenCalledWith(
+        expect.stringContaining('github.com'),
         expect.any(Object)
       );
     });

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -3,7 +3,7 @@
  *
  * Spec: cli/specs/login_command.md (v2)
  * EARS: LOGIN-A1..A4, LOGIN-B1..B3, LOGIN-C1..C2, LOGIN-D1..D2,
- *       LOGIN-E1..E4 (E2E), LOGIN-F1..F4, LOGIN-G1..G3, LOGIN-H1..H3
+ *       LOGIN-E1..E4 (E2E), LOGIN-F1..F4, LOGIN-G1..G3, LOGIN-H1..H4
  *
  * v2 changes (Cycle 4, identity_key_sync):
  *   - REST → tRPC wire format (IKS-A27)
@@ -56,7 +56,7 @@ function createDefaultDeps(): LoginDeps {
               clearTimeout(timeoutHandle);
               // [LOGIN-M1] Connection: close prevents socket hang
               res.writeHead(200, { 'Content-Type': 'text/html', 'Connection': 'close' });
-              res.end('<html><body><h1>Login successful!</h1><p>You can close this window.</p></body></html>');
+              res.end(`<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>GitGovernance</title><style>*{margin:0;padding:0;box-sizing:border-box}body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#0a0a0a;color:#fafafa;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}.card{text-align:center;max-width:400px;padding:2rem}h1{font-size:1.5rem;margin-bottom:.75rem}p{color:#888;font-size:.9rem;line-height:1.5}.check{font-size:2.5rem;margin-bottom:1rem}</style></head><body><div class="card"><div class="check">✓</div><h1>Authentication received</h1><p>Check your terminal for login status.</p></div></body></html>`);
               server.close();
               resolve({ token, user: { login, id: Number(id) } });
             } else {
@@ -502,7 +502,14 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       const { execSync } = await import('child_process');
       const remoteUrl = execSync('git remote get-url origin', { encoding: 'utf-8' }).trim();
       const ref = parseRemoteUrl(remoteUrl);
-      if (ref) return ref;
+      if (ref) {
+        // [LOGIN-H4] Resolve SSH alias to real hostname via ssh -G
+        // Handles multi-account SSH configs (e.g. Host github-work → HostName github.com)
+        const resolved = execSync(`ssh -G ${ref.providerHost}`, { encoding: 'utf-8' });
+        const hostMatch = resolved.match(/^hostname\s+(.+)$/m);
+        if (hostMatch?.[1]) ref.providerHost = hostMatch[1];
+        return ref;
+      }
     } catch {
       // Git not available or no remote
     }

--- a/packages/cli/src/commands/login/login-command.ts
+++ b/packages/cli/src/commands/login/login-command.ts
@@ -176,7 +176,7 @@ export class LoginCommand extends BaseCommand<LoginCommandOptions> {
       // [LOGIN-O1] Materialize actor BEFORE key sync — generates keypair if collaborator is new
       try {
         const projectModule = await this.dependencyService.getProjectModule();
-        await projectModule.ensureActorInProject({
+        await projectModule.addActor({
           login: user.login,
           type: actorType,
           repoId: '',

--- a/packages/cli/src/commands/login/login-command.types.ts
+++ b/packages/cli/src/commands/login/login-command.types.ts
@@ -27,6 +27,10 @@ export interface LoginCommandOptions extends BaseCommandOptions {
   forceCloud?: boolean;
   /** State branch name for pre-DI fetch (LOGIN-P1). Overrides resolveStateBranchPreDI() */
   stateBranch?: string;
+  /** Pre-minted session token (JWE). Bypasses OAuth browser flow. Test-only. */
+  token?: string;
+  /** GitHub login for --token mode (required with --token). */
+  login?: string;
 }
 
 // ============================================================================

--- a/packages/cli/src/commands/login/login.ts
+++ b/packages/cli/src/commands/login/login.ts
@@ -14,6 +14,8 @@ export function registerLoginCommands(program: Command): void {
     .option('--force-local', 'On key conflict: keep local key, upload to cloud')
     .option('--force-cloud', 'On key conflict: keep cloud key, download to local')
     .option('--state-branch <name>', 'State branch name (overrides config for pre-DI fetch)')
+    .option('--token <jwe>', 'Pre-minted session token (bypasses OAuth). Test-only')
+    .option('--login <name>', 'GitHub login (required with --token)')
     .option('--json', 'Output as JSON')
     .option('-v, --verbose', 'Verbose output')
     .option('-q, --quiet', 'Quiet output')

--- a/packages/cli/src/services/dependency-injection.test.ts
+++ b/packages/cli/src/services/dependency-injection.test.ts
@@ -510,6 +510,7 @@ vi.mock('@gitgov/core', () => {
         run: vi.fn().mockResolvedValue({
           findings: [],
           agentResults: [],
+          l1AgentResults: [],
           policyDecision: { decision: 'pass', reason: 'No findings', blockingFindings: [], waivedFindings: [], summary: { critical: 0, high: 0, medium: 0, low: 0 }, rulesEvaluated: [], evaluatedAt: new Date().toISOString() },
           summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, suppressed: 0, agentsRun: 0, agentsFailed: 0 },
           executionIds: { scans: [], policy: 'exec-policy-1' },
@@ -522,6 +523,15 @@ vi.mock('@gitgov/core', () => {
       createPolicyEvaluator: vi.fn().mockImplementation(function() { return {
         evaluate: vi.fn().mockReturnValue({ decision: 'pass', reason: 'No findings' }),
       }; }),
+    },
+
+    // 🎭 MOCK REDACTION: FindingRedactor for L1/L2 separation
+    Redaction: {
+      FindingRedactor: vi.fn().mockImplementation(function() { return {
+        redact: vi.fn().mockImplementation((f: unknown) => f),
+        redactSarif: vi.fn().mockImplementation((s: unknown) => s),
+      }; }),
+      DEFAULT_REDACTION_CONFIG: { sensitiveCategories: [], safeCategories: [], defaultBehavior: 'redact' },
     },
 
     // 🎭 MOCK SOURCE AUDITOR: Mock source auditor (for WaiverReader/WaiverWriter)
@@ -781,8 +791,8 @@ describe('DependencyInjectionService', () => {
   // ============================================================================
   // §4.3. Adapter Factories (EARS-C1 to C12)
   // ============================================================================
-  describe('4.3. Adapter Factories (EARS-C1 to C14)', () => {
-    it('[EARS-C1] should create RecordProjector with all dependencies', async () => {
+  describe('4.3. Adapter Factories (EARS-C1 to C15)', () => {
+    it('[EARS-C1] should create IndexerAdapter with all dependencies', async () => {
       const projector = await diService.getRecordProjector();
       expect(projector).toBeDefined();
       expect(projector.generateIndex).toBeDefined();
@@ -794,7 +804,7 @@ describe('DependencyInjectionService', () => {
       expect(backlogAdapter.createTask).toBeDefined();
     });
 
-    it('[EARS-C3] should create RecordMetrics with stores', async () => {
+    it('[EARS-C3] should create MetricsAdapter with stores', async () => {
       const recordMetrics = await diService.getRecordMetrics();
 
       expect(recordMetrics).toBeDefined();
@@ -814,7 +824,7 @@ describe('DependencyInjectionService', () => {
       expect(EventBus.EventBus).toHaveBeenCalled();
     });
 
-    it('[EARS-C5] should create FeedbackAdapter with signer and eventBus', async () => {
+    it('[EARS-C5] should create FeedbackAdapter with IdentityAdapter', async () => {
       const feedbackAdapter = await diService.getFeedbackAdapter();
 
       expect(feedbackAdapter).toBeDefined();
@@ -830,7 +840,7 @@ describe('DependencyInjectionService', () => {
       expect(lintModule).toBeDefined();
     });
 
-    it('[EARS-C7] should create FsWorktreeSyncStateModule with repoRoot and worktreePath', async () => {
+    it('[EARS-C7] should create SyncStateModule with all dependencies', async () => {
       const syncModule = await diService.getSyncStateModule();
 
       expect(syncModule).toBeDefined();
@@ -863,7 +873,7 @@ describe('DependencyInjectionService', () => {
       expect(sync1).toBe(sync2);
     });
 
-    it('[EARS-C9] should create ConfigManager with worktree base path', async () => {
+    it('[EARS-C9] should create ConfigManager with projectRoot', async () => {
       const configManager = await diService.getConfigManager();
 
       expect(configManager).toBeDefined();
@@ -873,7 +883,7 @@ describe('DependencyInjectionService', () => {
       expect(corefs.createConfigManager).toHaveBeenCalledWith(mockWorktreeBasePath);
     });
 
-    it('[EARS-C10] should create SessionManager with worktree base path', async () => {
+    it('[EARS-C10] should create SessionManager with projectRoot', async () => {
       const sessionManager = await diService.getSessionManager();
 
       expect(sessionManager).toBeDefined();
@@ -882,14 +892,21 @@ describe('DependencyInjectionService', () => {
       expect(corefs.createSessionManager).toHaveBeenCalledWith(mockWorktreeBasePath);
     });
 
-    it('[EARS-C11] should create AuditOrchestrator with all dependencies', async () => {
+    it('[EARS-C11] should create AuditOrchestrator with all dependencies including FindingRedactor', async () => {
       const orchestrator = await diService.getAuditOrchestrator();
 
       expect(orchestrator).toBeDefined();
       expect(orchestrator.run).toBeDefined();
 
-      // Verify AuditOrchestrator factory was called
+      // Verify AuditOrchestrator factory was called with redactor
       expect(AuditOrchestratorMock.createAuditOrchestrator).toHaveBeenCalled();
+      const depsArg = (AuditOrchestratorMock.createAuditOrchestrator as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(depsArg).toBeDefined();
+      expect(depsArg.redactor).toBeDefined();
+      expect(depsArg.redactor.redactSarif).toBeDefined();
+      expect(depsArg.agentRunner).toBeDefined();
+      expect(depsArg.waiverReader).toBeDefined();
+      expect(depsArg.recordStore).toBeDefined();
 
       // Verify PolicyEvaluator was created as dependency
       expect(PolicyEvaluatorMock.createPolicyEvaluator).toHaveBeenCalled();
@@ -923,7 +940,7 @@ describe('DependencyInjectionService', () => {
   // §4.4. Bootstrap Reindex (EARS-D1 to D2)
   // ============================================================================
   describe('4.4. Bootstrap Reindex (EARS-D1 to D2)', () => {
-    it('[EARS-D1] should call generateIndex() after successful worktree bootstrap', async () => {
+    it('[EARS-D1] should call generateIndex() after successful bootstrap from gitgov-state', async () => {
       // Mock fs.access to reject (no worktree .gitgov directory exists)
       mockFs.promises.access.mockRejectedValue(new Error('.gitgov directory not found'));
 
@@ -951,7 +968,7 @@ describe('DependencyInjectionService', () => {
       expect(projector.generateIndex).toHaveBeenCalledTimes(1);
     });
 
-    it('[EARS-D2] should NOT call generateIndex() when worktree .gitgov/ already exists', async () => {
+    it('[EARS-D2] should NOT call generateIndex() when .gitgov/ already exists (no bootstrap)', async () => {
       // Mock fs.access to succeed (worktree .gitgov exists)
       mockFs.promises.access.mockResolvedValue(undefined);
 
@@ -967,7 +984,7 @@ describe('DependencyInjectionService', () => {
   // §4.5. Error Handling (EARS-E1 to E4)
   // ============================================================================
   describe('4.5. Error Handling (EARS-E1 to E4)', () => {
-    it('[EARS-E1] should throw error when worktree bootstrap fails (RecordProjector)', async () => {
+    it('[EARS-E1] should throw error when project root not found (IndexerAdapter)', async () => {
       // Mock fs.access to reject (no worktree .gitgov directory)
       mockFs.promises.access.mockRejectedValue(new Error('Directory not found'));
 
@@ -986,7 +1003,7 @@ describe('DependencyInjectionService', () => {
         .rejects.toThrow("❌ GitGovernance not initialized. Run 'gitgov init' first.");
     });
 
-    it('[EARS-E1] should throw error when worktree bootstrap fails (BacklogAdapter)', async () => {
+    it('[EARS-E1] should throw error when project root not found (BacklogAdapter)', async () => {
       // Mock fs.access to reject (no worktree .gitgov directory)
       mockFs.promises.access.mockRejectedValue(new Error('Directory not found'));
 

--- a/packages/cli/src/services/dependency-injection.test.ts
+++ b/packages/cli/src/services/dependency-injection.test.ts
@@ -697,7 +697,7 @@ import { DependencyInjectionService } from './dependency-injection';
 // Mocked module references — vitest hoists vi.mock, so imports resolve to mocks
 import * as mockFsModule from 'fs';
 import * as corefs from '@gitgov/core/fs';
-import { Git, Adapters, KeyProvider, EventBus, RecordProjection, RecordMetrics, AuditOrchestrator as AuditOrchestratorMock, PolicyEvaluator as PolicyEvaluatorMock, SyncState } from '@gitgov/core';
+import { Git, Adapters, KeyProvider, EventBus, RecordProjection, RecordMetrics, AuditOrchestrator as AuditOrchestratorMock, PolicyEvaluator as PolicyEvaluatorMock, SyncState, Redaction as RedactionMock } from '@gitgov/core';
 const mockFs = vi.mocked(mockFsModule);
 
 describe('DependencyInjectionService', () => {
@@ -907,8 +907,10 @@ describe('DependencyInjectionService', () => {
       expect(depsArg.agentRunner).toBeDefined();
       expect(depsArg.waiverReader).toBeDefined();
       expect(depsArg.recordStore).toBeDefined();
+      expect(depsArg.policyEvaluator).toBeDefined();
 
-      // Verify PolicyEvaluator was created as dependency
+      // Verify FindingRedactor constructor was called
+      expect(RedactionMock.FindingRedactor).toHaveBeenCalled();
       expect(PolicyEvaluatorMock.createPolicyEvaluator).toHaveBeenCalled();
     });
 

--- a/packages/cli/src/services/dependency-injection.ts
+++ b/packages/cli/src/services/dependency-injection.ts
@@ -760,6 +760,7 @@ export class DependencyInjectionService {
   /**
    * Creates and returns AuditOrchestrator with all required dependencies
    */
+  // [EARS-C11] AuditOrchestrator with AgentRunner, WaiverReader, RecordStore, PolicyEvaluator, FindingRedactor
   async getAuditOrchestrator(): Promise<ReturnType<typeof AuditOrchestrator.createAuditOrchestrator>> {
     if (this.auditOrchestrator) {
       return this.auditOrchestrator;

--- a/packages/cli/src/services/dependency-injection.ts
+++ b/packages/cli/src/services/dependency-injection.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as os from 'os';
-import { Adapters, Config, Session, EventBus, Lint, Git, SourceAuditor, FindingDetector, KeyProvider, RecordProjection, RecordMetrics, AuditOrchestrator, PolicyEvaluator, IdentityModule, RecordSigner, getCurrentActor, ActorSelectionRequiredError, ProjectModule, DEFAULT_AGENTS } from '@gitgov/core';
+import { Adapters, Config, Session, EventBus, Lint, Git, SourceAuditor, FindingDetector, KeyProvider, RecordProjection, RecordMetrics, AuditOrchestrator, PolicyEvaluator, IdentityModule, RecordSigner, getCurrentActor, ActorSelectionRequiredError, ProjectModule, DEFAULT_AGENTS, Redaction } from '@gitgov/core';
 import { FsRecordStore, DEFAULT_ID_ENCODER, FsFileLister, FsProjectInitializer, FsLintModule, FsWorktreeSyncStateModule, GitModule, createAgentRunner, createConfigManager, findProjectRoot, createSessionManager, FsRecordProjection, getWorktreeBasePath, getKeysDir } from '@gitgov/core/fs';
 import type { IFsLintModule } from '@gitgov/core/fs';
 import type {
@@ -776,11 +776,14 @@ export class DependencyInjectionService {
       const recordStore = this.stores.agents;
       const policyEvaluator = PolicyEvaluator.createPolicyEvaluator({});
 
+      const redactor = new Redaction.FindingRedactor(Redaction.DEFAULT_REDACTION_CONFIG);
+
       this.auditOrchestrator = AuditOrchestrator.createAuditOrchestrator({
         recordStore,
         agentRunner,
         waiverReader,
         policyEvaluator,
+        redactor,
       });
 
       return this.auditOrchestrator;

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -264,7 +264,7 @@ Adapters are orchestrators that compose modules. All receive dependencies via co
 
 | Adapter | Purpose |
 |---------|---------|
-| `ProjectAdapter` | Project initialization, environment validation |
+| `ProjectModule` | Project initialization, addActor, environment validation |
 | `IdentityAdapter` | Actor and agent identity management |
 | `BacklogAdapter` | Task and cycle lifecycle, workflow validation |
 | `ExecutionAdapter` | Execution audit log tracking |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,11 @@
       "import": "./dist/src/sarif/index.js",
       "default": "./dist/src/sarif/index.js"
     },
+    "./redaction": {
+      "types": "./dist/src/redaction/index.d.ts",
+      "import": "./dist/src/redaction/index.js",
+      "default": "./dist/src/redaction/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/core/src/adapters/agent_adapter/agent_adapter.test.ts
+++ b/packages/core/src/adapters/agent_adapter/agent_adapter.test.ts
@@ -104,6 +104,7 @@ describe('AgentAdapter', () => {
     mockKeyProvider = {
       sign: jest.fn().mockResolvedValue(new Uint8Array(64)),
       getPrivateKey: jest.fn().mockResolvedValue('mock-private-key'),
+      getPublicKey: jest.fn().mockResolvedValue('mock-public-key'),
       setPrivateKey: jest.fn().mockResolvedValue(undefined),
       deletePrivateKey: jest.fn().mockResolvedValue(undefined),
       listKeys: jest.fn().mockResolvedValue([]),
@@ -349,6 +350,41 @@ describe('AgentAdapter', () => {
 
       expect(mockAgentStore.put).toHaveBeenCalledTimes(1);
       expect(mockAgentStore.putDeferred).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('4.7. buildSignedAgentRecord (EARS-G1)', () => {
+    const agentPayload = {
+      id: 'agent:test-agent',
+      engine: { type: 'local' as const, entrypoint: 'index.ts', function: 'run' },
+    };
+
+    it('[EARS-G1] should build and sign AgentRecord using keyProvider without reading the store', async () => {
+      // Make validate invoke the public-key resolver so we can assert its source
+      mockValidateFullAgentRecord.mockImplementation(
+        async (_record: GitGovAgentRecord, getPublicKey: (keyId: string) => Promise<string | null>) => {
+          await getPublicKey('agent:test-agent');
+        }
+      );
+
+      const result = await agentAdapter.buildSignedAgentRecord(agentPayload);
+
+      // Returns a signed record
+      expect(result.header.signatures.length).toBeGreaterThan(0);
+      expect(result.payload.id).toBe('agent:test-agent');
+      // Public key resolved from the KeyProvider — NOT identity.getActor / the store (no committed-read)
+      expect(mockKeyProvider.getPublicKey).toHaveBeenCalledWith('agent:test-agent');
+      expect(mockIdentityAdapter.getActor).not.toHaveBeenCalled();
+      // NOT persisted — the caller persists via initializer.addAgent (EARS-PI14)
+      expect(mockAgentStore.put).not.toHaveBeenCalled();
+      expect(mockAgentStore.putDeferred).not.toHaveBeenCalled();
+    });
+
+    it('[EARS-G1] should throw when private key is not available', async () => {
+      mockKeyProvider.getPrivateKey.mockResolvedValue(null);
+
+      await expect(agentAdapter.buildSignedAgentRecord(agentPayload))
+        .rejects.toThrow('Private key not found');
     });
   });
 });

--- a/packages/core/src/adapters/agent_adapter/agent_adapter.ts
+++ b/packages/core/src/adapters/agent_adapter/agent_adapter.ts
@@ -237,4 +237,66 @@ export class AgentAdapter implements IAgentAdapter {
   async archiveAgentRecord(agentId: string): Promise<AgentRecord> {
     return this.updateAgentRecord(agentId, { status: 'archived' });
   }
+
+  /**
+   * [EARS-G1] Builds + signs an AgentRecord WITHOUT a committed-read and WITHOUT
+   * persisting. Mirrors createAgentRecord's build+sign, but resolves the public
+   * key from the KeyProvider (not identity.getActor / the record store) — so it
+   * works during atomic init where the corresponding ActorRecord is staged but
+   * not yet committed. The caller persists the result via initializer.addAgent.
+   */
+  async buildSignedAgentRecord(payload: Partial<AgentPayload>): Promise<GitGovAgentRecord> {
+    // [EARS-G1] Validate required fields (same guard as EARS-A2)
+    if (!payload.id || !payload.engine) {
+      throw new Error('AgentRecord requires id and engine');
+    }
+
+    // [EARS-G1] Build the complete AgentRecord payload (same shape as createAgentRecord)
+    const completePayload: AgentRecord = {
+      id: payload.id,
+      engine: payload.engine,
+      status: payload.status || 'active',
+      triggers: payload.triggers || [],
+      knowledge_dependencies: payload.knowledge_dependencies || [],
+      prompt_engine_requirements: payload.prompt_engine_requirements || {},
+      ...payload
+    };
+    const validatedPayload = createAgentRecord(completePayload);
+    const payloadChecksum = calculatePayloadChecksum(validatedPayload);
+
+    // [EARS-G1] Load private key from KeyProvider — NO record store read (same guard as EARS-A6)
+    let privateKey: string;
+    try {
+      const key = await this.keyProvider.getPrivateKey(payload.id);
+      if (!key) {
+        throw new Error(`Private key not found for ${payload.id}`);
+      }
+      privateKey = key;
+    } catch (error) {
+      throw new Error(
+        `Private key not found for actor ${payload.id}. ` +
+        `AgentRecord requires a valid private key for cryptographic signing. ` +
+        `Original error: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+
+    // [EARS-G1] Self-sign with the agent's key
+    const signature = signPayload(validatedPayload, privateKey, payload.id, 'author', 'Agent registration');
+
+    const record: GitGovAgentRecord = {
+      header: {
+        version: '1.0',
+        type: 'agent',
+        payloadChecksum,
+        signatures: [signature]
+      },
+      payload: validatedPayload
+    };
+
+    // [EARS-G1] Validate resolving the public key via the KeyProvider — NOT identity.getActor (no committed-read)
+    await validateFullAgentRecord(record, (keyId) => this.keyProvider.getPublicKey(keyId));
+
+    // [EARS-G1] Return the signed record WITHOUT persisting — caller persists via initializer.addAgent (EARS-PI14)
+    return record;
+  }
 }

--- a/packages/core/src/adapters/agent_adapter/agent_adapter.types.ts
+++ b/packages/core/src/adapters/agent_adapter/agent_adapter.types.ts
@@ -1,6 +1,6 @@
 import type { RecordStores } from '../../record_store';
 import type { IIdentityModule } from '../../identity/identity_module.types';
-import type { AgentRecord, AgentPayload } from '../../record_types';
+import type { AgentRecord, AgentPayload, GitGovAgentRecord } from '../../record_types';
 import type { IEventStream } from '../../event_bus';
 import type { KeyProvider } from '../../key_provider/key_provider';
 
@@ -78,4 +78,17 @@ export interface IAgentAdapter {
    * @throws Error if AgentRecord not found
    */
   archiveAgentRecord(agentId: string): Promise<AgentRecord>;
+
+  /**
+   * [EARS-G1] Builds and signs a complete AgentRecord WITHOUT persisting it and
+   * WITHOUT a committed-read. Resolves the signing public key from the KeyProvider
+   * (persisted in the DB at actor creation), not from the record store — so it works
+   * during atomic init where the corresponding ActorRecord is staged but not yet
+   * committed. The caller persists the returned record via `initializer.addAgent`.
+   *
+   * @param payload - Partial AgentPayload (id and engine required)
+   * @returns Promise<GitGovAgentRecord> - The signed, unpersisted record
+   * @throws Error if id or engine missing, or private key unavailable in the KeyProvider
+   */
+  buildSignedAgentRecord(payload: Partial<AgentPayload>): Promise<GitGovAgentRecord>;
 }

--- a/packages/core/src/audit/formatter.test.ts
+++ b/packages/core/src/audit/formatter.test.ts
@@ -34,6 +34,7 @@ function makeResult(overrides: {
   return {
     findings,
     agentResults: [],
+    l1AgentResults: [],
     policyDecision: {
       decision,
       reason: overrides.reason ?? 'critical findings present',

--- a/packages/core/src/audit/fs/audit_fs_projection.test.ts
+++ b/packages/core/src/audit/fs/audit_fs_projection.test.ts
@@ -1,0 +1,179 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { AuditFsProjection } from './audit_fs_projection';
+import type { AuditOrchestrationResult, Finding, AuditSummary } from '../types';
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    fingerprint: 'sha256:abc123',
+    ruleId: 'SEC-001',
+    file: 'src/config.ts',
+    line: 3,
+    message: 'Hardcoded secret detected',
+    category: 'hardcoded-secret',
+    severity: 'critical',
+    detector: 'regex',
+    confidence: 1.0,
+    executionId: 'exec-001',
+    reportedBy: ['agent:security-audit'],
+    isWaived: false,
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: {
+  findings?: Finding[];
+  decision?: 'pass' | 'block';
+  summary?: Partial<AuditSummary>;
+} = {}): AuditOrchestrationResult {
+  const findings = overrides.findings ?? [makeFinding()];
+  const decision = overrides.decision ?? 'block';
+  return {
+    findings,
+    agentResults: [],
+    l1AgentResults: [],
+    policyDecision: {
+      decision,
+      reason: 'critical findings present',
+      executionId: 'exec-policy-001',
+      blockingFindings: decision === 'block' ? findings.filter(f => !f.isWaived) : [],
+      waivedFindings: findings.filter(f => f.isWaived),
+      summary: { critical: 0, high: 0, medium: 0, low: 0 },
+      rulesEvaluated: [],
+      evaluatedAt: '2026-04-26T00:00:00.000Z',
+    },
+    summary: {
+      total: findings.length,
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      suppressed: 0,
+      agentsRun: 1,
+      agentsFailed: 0,
+      ...overrides.summary,
+    },
+    executionIds: { scans: ['exec-scan-001'], policy: 'exec-policy-001' },
+  };
+}
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await fs.mkdtemp(path.join(tmpdir(), 'afrp-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+describe('AuditFsProjection', () => {
+  describe('4.1. Persist & Read (AFRP-A1 to A4)', () => {
+    it('[AFRP-A1] should serialize AuditOrchestrationResult to audit-index.json', async () => {
+      const projection = new AuditFsProjection({ basePath: testDir });
+      const result = makeResult();
+
+      await projection.persist(result);
+
+      const raw = await fs.readFile(path.join(testDir, 'audit-index.json'), 'utf-8');
+      const parsed = JSON.parse(raw);
+      expect(parsed.findings).toHaveLength(1);
+      expect(parsed.findings[0].fingerprint).toBe('sha256:abc123');
+      expect(parsed.policyDecision.decision).toBe('block');
+      expect(parsed.summary.total).toBe(1);
+    });
+
+    it('[AFRP-A2] should read and return AuditOrchestrationResult from audit-index.json', async () => {
+      const projection = new AuditFsProjection({ basePath: testDir });
+      const original = makeResult({ findings: [makeFinding(), makeFinding({ fingerprint: 'sha256:def456', ruleId: 'SEC-002' })] });
+
+      await projection.persist(original);
+      const loaded = await projection.readLatest();
+
+      expect(loaded).not.toBeNull();
+      const loadedResult = loaded!;
+      expect(loadedResult.findings).toHaveLength(2);
+      expect(loadedResult.findings[0]!.fingerprint).toBe('sha256:abc123');
+      expect(loadedResult.findings[1]!.fingerprint).toBe('sha256:def456');
+      expect(loadedResult.policyDecision.decision).toBe('block');
+    });
+
+    it('[AFRP-A3] should return null when audit-index.json does not exist', async () => {
+      const projection = new AuditFsProjection({ basePath: testDir });
+
+      const result = await projection.readLatest();
+
+      expect(result).toBeNull();
+    });
+
+    it('[AFRP-A4] should write to audit/scans/{timestamp}.json when keepHistory is true', async () => {
+      const projection = new AuditFsProjection({ basePath: testDir, keepHistory: true });
+      const result = makeResult();
+
+      await projection.persist(result);
+
+      const indexExists = await fs.stat(path.join(testDir, 'audit-index.json')).then(() => true).catch(() => false);
+      expect(indexExists).toBe(true);
+
+      const scansDir = path.join(testDir, 'audit', 'scans');
+      const entries = await fs.readdir(scansDir);
+      expect(entries).toHaveLength(1);
+      const firstEntry = entries[0]!;
+      expect(firstEntry).toMatch(/^\d+\.json$/);
+
+      const scanContent = await fs.readFile(path.join(scansDir, firstEntry), 'utf-8');
+      const parsed = JSON.parse(scanContent);
+      expect(parsed.findings).toHaveLength(1);
+    });
+  });
+
+  describe('4.2. History & List (AFRP-B1 to B4)', () => {
+    it('[AFRP-B1] should return scan timestamps sorted descending', async () => {
+      const scansDir = path.join(testDir, 'audit', 'scans');
+      await fs.mkdir(scansDir, { recursive: true });
+
+      const result = makeResult();
+      const timestamps = ['1752276000', '1752278000', '1752277000'];
+      for (const ts of timestamps) {
+        await fs.writeFile(path.join(scansDir, `${ts}.json`), JSON.stringify(result));
+      }
+
+      const projection = new AuditFsProjection({ basePath: testDir });
+      const ids = await projection.list();
+
+      expect(ids).toEqual(['1752278000', '1752277000', '1752276000']);
+    });
+
+    it('[AFRP-B2] should return empty array when no scan history exists', async () => {
+      const projection = new AuditFsProjection({ basePath: testDir });
+
+      const ids = await projection.list();
+
+      expect(ids).toEqual([]);
+    });
+
+    it('[AFRP-B3] should read specific scan by timestamp ID', async () => {
+      const scansDir = path.join(testDir, 'audit', 'scans');
+      await fs.mkdir(scansDir, { recursive: true });
+
+      const result = makeResult({ decision: 'pass' });
+      await fs.writeFile(path.join(scansDir, '1752276000.json'), JSON.stringify(result));
+
+      const projection = new AuditFsProjection({ basePath: testDir });
+      const scan = await projection.read('1752276000');
+
+      expect(scan).not.toBeNull();
+      expect(scan!.policyDecision.decision).toBe('pass');
+      expect(scan!.findings).toHaveLength(1);
+    });
+
+    it('[AFRP-B4] should return null for non-existent scan ID', async () => {
+      const projection = new AuditFsProjection({ basePath: testDir });
+
+      const scan = await projection.read('9999999999');
+
+      expect(scan).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/audit/fs/audit_fs_projection.ts
+++ b/packages/core/src/audit/fs/audit_fs_projection.ts
@@ -1,0 +1,82 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { AuditOrchestrationResult } from '../types';
+import type { IAuditFsProjection, AuditFsProjectionOptions } from './audit_fs_projection.types';
+
+export class AuditFsProjection implements IAuditFsProjection {
+  private readonly basePath: string;
+  private readonly keepHistory: boolean;
+  private readonly indexPath: string;
+  private readonly scansDir: string;
+
+  constructor(options: AuditFsProjectionOptions) {
+    this.basePath = options.basePath;
+    this.keepHistory = options.keepHistory ?? false;
+    this.indexPath = path.join(this.basePath, 'audit-index.json');
+    this.scansDir = path.join(this.basePath, 'audit', 'scans');
+  }
+
+  // [AFRP-A1] persist writes audit-index.json
+  async persist(result: AuditOrchestrationResult): Promise<void> {
+    await fs.mkdir(path.dirname(this.indexPath), { recursive: true });
+
+    const tmpPath = `${this.indexPath}.tmp`;
+    const content = JSON.stringify(result, null, 2);
+    await fs.writeFile(tmpPath, content, 'utf-8');
+    await fs.rename(tmpPath, this.indexPath);
+
+    // [AFRP-A4] persist with keepHistory writes timestamped file
+    if (this.keepHistory) {
+      await fs.mkdir(this.scansDir, { recursive: true });
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const scanPath = path.join(this.scansDir, `${timestamp}.json`);
+      await fs.writeFile(scanPath, content, 'utf-8');
+    }
+  }
+
+  // [AFRP-A2] readLatest reads and parses audit-index.json
+  // [AFRP-A3] readLatest returns null when missing
+  async readLatest(): Promise<AuditOrchestrationResult | null> {
+    try {
+      const content = await fs.readFile(this.indexPath, 'utf-8');
+      return JSON.parse(content) as AuditOrchestrationResult;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null;
+      }
+      return null;
+    }
+  }
+
+  // [AFRP-B3] read specific scan by ID
+  // [AFRP-B4] read non-existent returns null
+  async read(scanId: string): Promise<AuditOrchestrationResult | null> {
+    try {
+      const scanPath = path.join(this.scansDir, `${scanId}.json`);
+      const content = await fs.readFile(scanPath, 'utf-8');
+      return JSON.parse(content) as AuditOrchestrationResult;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null;
+      }
+      return null;
+    }
+  }
+
+  // [AFRP-B1] list returns sorted scan IDs
+  // [AFRP-B2] list returns empty when no scans
+  async list(): Promise<string[]> {
+    try {
+      const entries = await fs.readdir(this.scansDir);
+      return entries
+        .filter(e => e.endsWith('.json'))
+        .map(e => e.replace('.json', ''))
+        .sort((a, b) => Number(b) - Number(a));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return [];
+      }
+      return [];
+    }
+  }
+}

--- a/packages/core/src/audit/fs/audit_fs_projection.types.ts
+++ b/packages/core/src/audit/fs/audit_fs_projection.types.ts
@@ -1,0 +1,13 @@
+import type { AuditOrchestrationResult } from '../types';
+
+export type AuditFsProjectionOptions = {
+  basePath: string;
+  keepHistory?: boolean;
+};
+
+export interface IAuditFsProjection {
+  persist(result: AuditOrchestrationResult): Promise<void>;
+  readLatest(): Promise<AuditOrchestrationResult | null>;
+  read(scanId: string): Promise<AuditOrchestrationResult | null>;
+  list(): Promise<string[]>;
+}

--- a/packages/core/src/audit/fs/index.ts
+++ b/packages/core/src/audit/fs/index.ts
@@ -1,0 +1,2 @@
+export { AuditFsProjection } from './audit_fs_projection';
+export type { IAuditFsProjection, AuditFsProjectionOptions } from './audit_fs_projection.types';

--- a/packages/core/src/audit/types.ts
+++ b/packages/core/src/audit/types.ts
@@ -346,8 +346,8 @@ export type AuditOrchestrationResult = {
   findings: Finding[];
   /** Per-agent execution results (original, unredacted — for L2 persistence) */
   agentResults: AgentAuditResult[];
-  /** Per-agent results with redacted SARIF for L1 (Git) persistence */
-  l1AgentResults?: AgentAuditResult[];
+  /** Per-agent results with redacted SARIF for L1 (Git) persistence — always present (redactor required) */
+  l1AgentResults: AgentAuditResult[];
   /** Policy evaluation decision */
   policyDecision: PolicyDecision;
   /** Aggregated summary */

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.test.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.test.ts
@@ -332,6 +332,7 @@ describe("AuditOrchestrator", () => {
 
       expect(result.findings).toHaveLength(0);
       expect(result.agentResults).toHaveLength(0);
+      expect(result.l1AgentResults).toEqual([]);
       expect(result.summary.total).toBe(0);
       expect(result.summary.agentsRun).toBe(0);
       expect(deps.agentRunner.runOnce).not.toHaveBeenCalled();
@@ -1036,7 +1037,7 @@ describe("AuditOrchestrator", () => {
       expect(result.l1AgentResults).toHaveLength(1);
 
       // L1 SARIF should have redacted snippet for pii-email (sensitive)
-      const l1Sarif = result.l1AgentResults![0]!.sarif;
+      const l1Sarif = result.l1AgentResults[0]!.sarif;
       const l1Snippet =
         l1Sarif.runs[0]!.results[0]!.locations[0]!.physicalLocation.region.snippet;
       expect(l1Snippet).toBeDefined();
@@ -1045,6 +1046,9 @@ describe("AuditOrchestrator", () => {
       // snippetHash should be present
       const l1Props = l1Sarif.runs[0]!.results[0]!.properties;
       expect(l1Props?.["gitgov/snippetHash"]).toBeDefined();
+
+      // L1 SARIF must be a distinct object from L2 (copy, not mutation)
+      expect(result.l1AgentResults[0]!.sarif).not.toBe(result.agentResults[0]!.sarif);
     });
 
     it("[AORCH-E2] should preserve original unredacted agent results for L2", async () => {
@@ -1113,7 +1117,7 @@ describe("AuditOrchestrator", () => {
 
       // L1 should be redacted
       const l1Snippet =
-        result.l1AgentResults![0]!.sarif.runs[0]!.results[0]!.locations[0]!
+        result.l1AgentResults[0]!.sarif.runs[0]!.results[0]!.locations[0]!
           .physicalLocation.region.snippet;
       expect(l1Snippet!.text).toBe("[REDACTED]");
     });

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.test.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.test.ts
@@ -1356,4 +1356,40 @@ describe("AuditOrchestrator", () => {
       expect(result.reviewResults![0]!.errorMessage).toBe("Claude API unavailable");
     });
   });
+
+  describe("4.9. Agent Entrypoint Validation (AORCH-G1 to G2)", () => {
+    it("[AORCH-G1] should add warning when agent entrypoint is unresolvable", async () => {
+      const agentRecord = makeAgentRecord("agent:security-audit", "audit");
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue(["agent:security-audit"]);
+      (deps.recordStore.get as jest.Mock).mockResolvedValue(agentRecord);
+      (deps.agentRunner.runOnce as jest.Mock).mockRejectedValue(
+        new Error("Cannot find module '@gitgov/agent-security-audit'"),
+      );
+
+      const orchestrator = createAuditOrchestrator(deps);
+      const result = await orchestrator.run(defaultOptions);
+
+      expect(result.warning).toBeDefined();
+      expect(result.warning).toContain("failed to load");
+      expect(result.warning).toContain("gitgov agent new");
+    });
+
+    it("[AORCH-G2] should warn when all audit agents failed with entrypoint errors", async () => {
+      const agentRecord = makeAgentRecord("agent:security-audit", "audit");
+      const deps = createMockDeps();
+      (deps.recordStore.list as jest.Mock).mockResolvedValue(["agent:security-audit"]);
+      (deps.recordStore.get as jest.Mock).mockResolvedValue(agentRecord);
+      (deps.agentRunner.runOnce as jest.Mock).mockRejectedValue(
+        new Error("Cannot find module '@gitgov/agent-security-audit'"),
+      );
+
+      const orchestrator = createAuditOrchestrator(deps);
+      const result = await orchestrator.run(defaultOptions);
+
+      expect(result.warning).toContain("All audit agents failed");
+      expect(result.agentResults[0]!.status).toBe("error");
+      expect(result.findings).toHaveLength(0);
+    });
+  });
 });

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.test.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.test.ts
@@ -159,11 +159,14 @@ function createMockDeps(overrides?: Partial<AuditOrchestratorDeps>): AuditOrches
     evaluate: jest.fn().mockResolvedValue(makePolicyResult()),
   };
 
+  const redactor = new FindingRedactor(DEFAULT_REDACTION_CONFIG);
+
   return {
     recordStore,
     agentRunner,
     waiverReader,
     policyEvaluator,
+    redactor,
     ...overrides,
   };
 }
@@ -459,8 +462,10 @@ describe("AuditOrchestrator", () => {
       const orchestrator = createAuditOrchestrator(deps);
       const result = await orchestrator.run(defaultOptions);
 
-      // AgentRunner was called once per agent
+      // AgentRunner was called once per agent with type context
       expect(deps.agentRunner.runOnce).toHaveBeenCalledTimes(2);
+      const firstCall = (deps.agentRunner.runOnce as jest.Mock).mock.calls[0]![0];
+      expect(firstCall.input.taskId).toBe(defaultOptions.taskId);
 
       // ExecutionRecord IDs are captured from AgentRunner responses
       expect(result.executionIds.scans).toEqual(["exec-scan-001", "exec-scan-002"]);
@@ -573,8 +578,8 @@ describe("AuditOrchestrator", () => {
     });
   });
 
-  describe("4.3b. Snippet Extraction (AORCH-B13)", () => {
-    it("[AORCH-B13] should extract snippet from SARIF region.snippet.text into Finding", async () => {
+  describe("4.3. Consolidation and Dedup — Snippet Extraction (AORCH-B13)", () => {
+    it("[AORCH-B13] should include snippet text in Finding when SARIF result has region.snippet.text", async () => {
       const agentRecord = makeAgentRecord("agent:security-audit", "audit");
       const sarifResultWithSnippet = {
         ruleId: "SEC-001",
@@ -856,6 +861,8 @@ describe("AuditOrchestrator", () => {
       const evaluateCall = (deps.policyEvaluator.evaluate as jest.Mock).mock.calls[0][0];
       expect(evaluateCall.findings).toHaveLength(1);
       expect(evaluateCall.findings[0].fingerprint).toBe("hash-sec-001");
+      expect(evaluateCall.activeWaivers).toBeDefined();
+      expect(Array.isArray(evaluateCall.activeWaivers)).toBe(true);
       expect(evaluateCall.scanExecutionIds).toContain("exec-scan-g1");
       expect(evaluateCall.taskId).toBe(defaultOptions.taskId);
     });
@@ -968,7 +975,7 @@ describe("AuditOrchestrator", () => {
   });
 
   describe("4.7. Redaction Integration (AORCH-E1 to E3)", () => {
-    it("[AORCH-E1] should apply redactSarif to agent results for L1 when redactor is provided", async () => {
+    it("[AORCH-E1] should always apply redactSarif to agent results for L1", async () => {
       const agentRecord = makeAgentRecord("agent:security-audit", "audit");
       const sarifWithSnippet: SarifLog = {
         $schema:
@@ -1136,7 +1143,7 @@ describe("AuditOrchestrator", () => {
     });
   });
 
-  describe("4.5. Review Agent Execution (AORCH-F1 to AORCH-F4)", () => {
+  describe("4.8. Review Agent Execution (AORCH-F1 to AORCH-F4)", () => {
     it("[AORCH-F1] should discover and execute review agents after policy evaluation", async () => {
       // Setup: 1 audit agent + 1 review agent
       const auditRecord = makeAgentRecord("agent:scanner", "audit");
@@ -1266,11 +1273,15 @@ describe("AuditOrchestrator", () => {
 
       await orchestrator.run(defaultOptions);
 
-      // Verify review agent received findings + policyDecision + taskId
+      // Verify review agent received findings + policyDecision + taskId with content
       expect(reviewInput).toBeDefined();
-      expect(reviewInput!["findings"]).toBeDefined();
-      expect(Array.isArray(reviewInput!["findings"])).toBe(true);
-      expect(reviewInput!["policyDecision"]).toBeDefined();
+      const findings = reviewInput!["findings"] as Array<Record<string, unknown>>;
+      expect(Array.isArray(findings)).toBe(true);
+      expect(findings.length).toBeGreaterThan(0);
+      expect(findings[0]!["ruleId"]).toBe("PII-001");
+      const pd = reviewInput!["policyDecision"] as Record<string, unknown>;
+      expect(pd).toBeDefined();
+      expect(pd["decision"]).toBeDefined();
       expect(reviewInput!["taskId"]).toBe(defaultOptions.taskId);
     });
 

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.ts
@@ -426,6 +426,20 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
         return f;
       });
 
+      // [AORCH-G1] [AORCH-G2] Detect agents that failed due to unresolvable entrypoint
+      const failedAgents = agentResults.filter(
+        r => r.status === 'error' && r.errorMessage &&
+          (r.errorMessage.includes('MODULE_NOT_FOUND') || r.errorMessage.includes('ERR_MODULE_NOT_FOUND') || r.errorMessage.includes('Cannot find module')),
+      );
+      let entrypointWarning: string | undefined;
+      if (failedAgents.length > 0) {
+        const details = failedAgents.map(a => `  ${a.agentId}: entrypoint not found`).join('\n');
+        const successCount = agentResults.filter(r => r.status === 'success').length;
+        entrypointWarning = successCount === 0
+          ? `All audit agents failed to load:\n${details}\n\nRegister with a local path: gitgov agent new <path-to-agent>`
+          : `Some audit agents failed to load:\n${details}`;
+      }
+
       const result: AuditOrchestrationResult = {
         findings: findingsWithWaivers,
         agentResults,
@@ -436,6 +450,7 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
           scans: scanExecutionIds,
           policy: policyResult.executionRecord.id,
         },
+        ...(entrypointWarning ? { warning: entrypointWarning } : {}),
       };
 
       // [AORCH-F1] Discover and execute review agents post-policy

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.ts
@@ -313,7 +313,7 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
     async run(
       options: AuditOrchestrationOptions,
     ): Promise<AuditOrchestrationResult> {
-      // 1. Discover audit agents
+      // [AORCH-B1, B2] Discover audit agents (filter by purpose + optional agentId)
       const auditAgents = await discoverAuditAgents(
         deps.recordStore,
         options.agentId,
@@ -341,6 +341,7 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
         return {
           findings: [],
           agentResults: [],
+          l1AgentResults: [],
           policyDecision: policyResult.decision,
           summary: {
             total: 0,
@@ -360,7 +361,7 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
         };
       }
 
-      // 3. Execute each agent (allSettled: one failure doesn't abort batch -- AORCH-B5)
+      // [AORCH-A1, B4, B5, B8] Execute each agent (allSettled: one failure doesn't abort batch)
       const settled = await Promise.allSettled(
         auditAgents.map((agentId) =>
           executeAgent(deps.agentRunner, agentId, options),
@@ -383,22 +384,18 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
             },
       );
 
-      // 4. Produce L1-redacted SARIF copies when redactor is provided (AORCH-E1)
-      // The redactor applies redactSarif(sarif, 'l1') to each agent's SarifLog.
-      // Original agentResults remain unredacted for L2 (AORCH-E2).
-      // Agents do not need knowledge of RedactionLevel (AORCH-E3).
-      let l1AgentResults: AgentAuditResult[] | undefined;
-      if (deps.redactor) {
-        l1AgentResults = agentResults.map((r) => ({
-          ...r,
-          sarif: deps.redactor!.redactSarif(r.sarif, "l1"),
-        }));
-      }
+      // [AORCH-E1] Produce L1-redacted SARIF copies (redactor is required)
+      // [AORCH-E2] Original agentResults remain unredacted for L2
+      // [AORCH-E3] Agents do not need knowledge of RedactionLevel
+      const l1AgentResults: AgentAuditResult[] = agentResults.map((r) => ({
+        ...r,
+        sarif: deps.redactor.redactSarif(r.sarif, "l1"),
+      }));
 
-      // 5. Consolidate findings with dedup by fingerprint
+      // [AORCH-B6, B12, B13] Consolidate findings with dedup by fingerprint
       const rawFindings = consolidateFindings(agentResults);
 
-      // 5-6. Pass raw findings + waivers to PolicyEvaluator (it handles waiver application internally)
+      // [AORCH-B7, D1, D4] Pass raw findings + waivers to PolicyEvaluator
       const scanExecutionIds = agentResults.map((r) => r.executionId);
       const policyInput: PolicyEvaluationInput = {
         findings: rawFindings,
@@ -432,6 +429,7 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
       const result: AuditOrchestrationResult = {
         findings: findingsWithWaivers,
         agentResults,
+        l1AgentResults,
         policyDecision: policyResult.decision,
         summary: buildSummary(findingsWithWaivers, agentResults),
         executionIds: {
@@ -439,10 +437,6 @@ export function createAuditOrchestrator(deps: AuditOrchestratorDeps) {
           policy: policyResult.executionRecord.id,
         },
       };
-
-      if (l1AgentResults) {
-        result.l1AgentResults = l1AgentResults;
-      }
 
       // [AORCH-F1] Discover and execute review agents post-policy
       // [AORCH-F3] If no review agents found, skip silently (no warning, no error)

--- a/packages/core/src/audit_orchestrator/audit_orchestrator.types.ts
+++ b/packages/core/src/audit_orchestrator/audit_orchestrator.types.ts
@@ -72,9 +72,8 @@ export type AuditOrchestratorDeps = {
   /** PolicyEvaluator for pass/block decision */
   policyEvaluator: PolicyEvaluator;
   /**
-   * Optional FindingRedactor for L1/L2 separation (RLDX-E1..E3).
-   * When provided, the orchestrator produces redacted SARIF copies for L1 persistence.
-   * Agents do not need to know about RedactionLevel — the orchestrator applies the policy.
+   * FindingRedactor for L1/L2 separation (AORCH-E1..E3).
+   * Required — the orchestrator always produces redacted SARIF copies for L1 persistence.
    */
-  redactor?: FindingRedactor;
+  redactor: FindingRedactor;
 };

--- a/packages/core/src/git/github/github_git_module.test.ts
+++ b/packages/core/src/git/github/github_git_module.test.ts
@@ -352,6 +352,9 @@ describe('GitHubGitModule', () => {
       const branches = await git.listRemoteBranches('origin');
 
       expect(branches).toEqual(['main', 'develop', 'feature/test']);
+      expect(mockOctokit.rest.repos.listBranches).toHaveBeenCalledWith(
+        expect.objectContaining({ per_page: 100 }),
+      );
     });
 
     it('[EARS-B3] should return CommitInfo array from compare endpoint', async () => {

--- a/packages/core/src/git/github/github_git_module.ts
+++ b/packages/core/src/git/github/github_git_module.ts
@@ -280,6 +280,7 @@ export class GitHubGitModule implements IGitModule {
       const { data } = await this.octokit.rest.repos.listBranches({
         owner: this.owner,
         repo: this.repo,
+        per_page: 100,
       });
       return data.map(b => b.name);
     } catch (error: unknown) {

--- a/packages/core/src/project_initializer/fs/fs_project_initializer.test.ts
+++ b/packages/core/src/project_initializer/fs/fs_project_initializer.test.ts
@@ -14,6 +14,7 @@
 
 import * as path from 'path';
 import type { GitGovConfig } from '../../config_manager';
+import type { GitGovAgentRecord } from '../../record_types';
 
 // Mock ESM helper to avoid import.meta issues in Jest
 jest.mock('../../utils/esm_helper', () => ({
@@ -582,7 +583,8 @@ describe('FsProjectInitializer', () => {
     });
 
     it('[EARS-FPI14] should create policy.yml with default configuration', async () => {
-      // policy.yml does not exist — fs.access rejects
+      // policy.yml does not exist, .gitignore does not exist
+      mockFs.access.mockRejectedValueOnce(new Error('ENOENT'));
       mockFs.access.mockRejectedValueOnce(new Error('ENOENT'));
 
       await initializer.createProjectStructure();
@@ -597,8 +599,9 @@ describe('FsProjectInitializer', () => {
     });
 
     it('[EARS-FPI14] should not overwrite existing policy.yml on re-initialization', async () => {
-      // policy.yml exists — fs.access resolves
+      // policy.yml exists, .gitignore does not exist
       mockFs.access.mockResolvedValueOnce(undefined);
+      mockFs.access.mockRejectedValueOnce(new Error('ENOENT'));
 
       await initializer.createProjectStructure();
 
@@ -606,6 +609,50 @@ describe('FsProjectInitializer', () => {
         (call) => String(call[0]).includes('policy.yml'),
       );
       expect(policyWrite).toBeUndefined();
+    });
+  });
+
+  // ==========================================================================
+  // 4.9. Security .gitignore (EARS-FPI20) — flow_verification sesión 63
+  // ==========================================================================
+
+  describe('4.9. Security .gitignore (EARS-FPI20)', () => {
+    let initializer: FsProjectInitializer;
+
+    beforeEach(() => {
+      initializer = new FsProjectInitializer(testRoot);
+      mockFs.mkdir.mockResolvedValue(undefined);
+      mockFs.writeFile.mockResolvedValue(undefined);
+    });
+
+    it('[EARS-FPI20] should create .gitgov/.gitignore with security exclusions', async () => {
+      // policy.yml does not exist, .gitignore does not exist
+      mockFs.access.mockRejectedValueOnce(new Error('ENOENT'));
+      mockFs.access.mockRejectedValueOnce(new Error('ENOENT'));
+
+      await initializer.createProjectStructure();
+
+      const gitignoreWrite = mockFs.writeFile.mock.calls.find(
+        (call) => String(call[0]).includes('.gitignore'),
+      );
+      expect(gitignoreWrite).toBeDefined();
+      const content = String(gitignoreWrite![1]);
+      expect(content).toContain('*.key');
+      expect(content).toContain('.session.json');
+      expect(content).toContain('index.json');
+    });
+
+    it('[EARS-FPI20] should not overwrite existing .gitgov/.gitignore on re-initialization', async () => {
+      // policy.yml does not exist, .gitignore exists
+      mockFs.access.mockRejectedValueOnce(new Error('ENOENT'));
+      mockFs.access.mockResolvedValueOnce(undefined);
+
+      await initializer.createProjectStructure();
+
+      const gitignoreWrite = mockFs.writeFile.mock.calls.find(
+        (call) => String(call[0]).includes('.gitignore'),
+      );
+      expect(gitignoreWrite).toBeUndefined();
     });
   });
 
@@ -654,6 +701,44 @@ describe('FsProjectInitializer', () => {
       expect(mockFs.unlink).not.toHaveBeenCalled();
       expect(mockFs.copyFile).not.toHaveBeenCalled();
       expect(mockFs.appendFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('4.10. Agent Persistence (EARS-FPI21)', () => {
+    const signedAgent: GitGovAgentRecord = {
+      header: {
+        version: '1.0',
+        type: 'agent',
+        payloadChecksum: 'checksum',
+        signatures: [{ keyId: 'agent:security-audit', role: 'author', notes: '', signature: 'sig', timestamp: 1 }],
+      },
+      payload: {
+        id: 'agent:security-audit',
+        engine: { type: 'local', entrypoint: '@gitgov/agent-security-audit', function: 'runAgent' },
+        status: 'active',
+        triggers: [],
+        knowledge_dependencies: [],
+        prompt_engine_requirements: {},
+      },
+    };
+
+    it('[EARS-FPI21] should write signed agent JSON to .gitgov/agents/{id}.json', async () => {
+      const initializer = new FsProjectInitializer(testRoot);
+      mockFs.mkdir.mockResolvedValue(undefined);
+      mockFs.writeFile.mockResolvedValue(undefined);
+
+      await initializer.addAgent(signedAgent);
+
+      // agent:security-audit → agent_security-audit.json (DEFAULT_ID_ENCODER)
+      expect(mockFs.mkdir).toHaveBeenCalledWith(
+        path.join(testRoot, '.gitgov', 'agents'),
+        { recursive: true },
+      );
+      expect(mockFs.writeFile).toHaveBeenCalledWith(
+        path.join(testRoot, '.gitgov', 'agents', 'agent_security-audit.json'),
+        JSON.stringify(signedAgent, null, 2),
+        'utf-8',
+      );
     });
   });
 });

--- a/packages/core/src/project_initializer/fs/fs_project_initializer.ts
+++ b/packages/core/src/project_initializer/fs/fs_project_initializer.ts
@@ -2,6 +2,8 @@ import { promises as fs, existsSync } from 'node:fs';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import type { GitGovConfig } from '../../config_manager';
+import type { GitGovAgentRecord } from '../../record_types';
+import { DEFAULT_ID_ENCODER } from '../../record_store';
 import type { IProjectInitializer, EnvironmentValidation } from '../project_initializer';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
@@ -74,11 +76,18 @@ export class FsProjectInitializer implements IProjectInitializer {
     const policyPath = path.join(gitgovPath, 'policy.yml');
     try {
       await fs.access(policyPath);
-      // policy.yml exists — do not overwrite
     } catch {
-      // policy.yml does not exist — create with defaults
       const defaultPolicy = 'version: "1.0"\nfailOn: critical\n';
       await fs.writeFile(policyPath, defaultPolicy, 'utf-8');
+    }
+
+    // [EARS-FPI20] Create security .gitignore to prevent keys from being committed
+    const gitignorePath = path.join(gitgovPath, '.gitignore');
+    try {
+      await fs.access(gitignorePath);
+    } catch {
+      const securityGitignore = '# Security: prevent private keys and local files from being committed\n*.key\n.session.json\nindex.json\n';
+      await fs.writeFile(gitignorePath, securityGitignore, 'utf-8');
     }
   }
 
@@ -138,6 +147,23 @@ export class FsProjectInitializer implements IProjectInitializer {
    */
   getActorPath(actorId: string): string {
     return path.join(this.projectRoot, '.gitgov', 'actors', `${actorId}.json`);
+  }
+
+  /**
+   * [EARS-FPI21] Persists a signed AgentRecord to disk at
+   * `.gitgov/agents/{encodedId}.json`. The record arrives already signed — this
+   * method does NOT sign. `{encodedId}` uses DEFAULT_ID_ENCODER so the file
+   * matches what the record store / indexer expects.
+   */
+  async addAgent(record: GitGovAgentRecord): Promise<void> {
+    const id = record.payload?.id;
+    if (!id) {
+      throw new Error('addAgent requires record.payload.id');
+    }
+    const agentsDir = path.join(this.projectRoot, '.gitgov', 'agents');
+    await fs.mkdir(agentsDir, { recursive: true });
+    const agentPath = path.join(agentsDir, `${DEFAULT_ID_ENCODER.encode(id)}.json`);
+    await fs.writeFile(agentPath, JSON.stringify(record, null, 2), 'utf-8');
   }
 
   /**

--- a/packages/core/src/project_initializer/github/github_project_initializer.test.ts
+++ b/packages/core/src/project_initializer/github/github_project_initializer.test.ts
@@ -14,6 +14,7 @@ import { GitHubProjectInitializer } from './github_project_initializer';
 import type { IGitModule, CommitAuthor } from '../../git';
 import type { ConfigStore } from '../../config_store';
 import type { GitGovConfig } from '../../config_manager';
+import type { GitGovAgentRecord } from '../../record_types';
 import { DEFAULT_STATE_BRANCH } from '../../sync_state/fs_worktree/fs_worktree_sync_state.types';
 
 // ==================== Mock Helpers ====================
@@ -429,6 +430,66 @@ describe('GitHubProjectInitializer', () => {
 
       const sha = await initializer.getHeadSha();
       expect(sha).toBeUndefined();
+    });
+  });
+
+  describe('4.11. Security .gitignore (GPI17)', () => {
+    it('[GPI17] should stage .gitgov/.gitignore with security exclusions in gitModule buffer', async () => {
+      gitModule.branchExists.mockResolvedValue(true);
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.createProjectStructure();
+
+      expect(gitModule.add).toHaveBeenCalledWith(
+        ['.gitgov/.gitignore'],
+        {
+          contentMap: {
+            '.gitgov/.gitignore': expect.stringContaining('*.key'),
+          },
+        },
+      );
+      const gitignoreCall = gitModule.add.mock.calls.find(
+        (call: unknown[]) => (call[0] as string[])[0] === '.gitgov/.gitignore',
+      );
+      const content = (gitignoreCall![1] as { contentMap: Record<string, string> }).contentMap['.gitgov/.gitignore'];
+      expect(content).toContain('.session.json');
+      expect(content).toContain('index.json');
+    });
+  });
+
+  describe('4.12. Agent Persistence (GPI18)', () => {
+    const signedAgent: GitGovAgentRecord = {
+      header: {
+        version: '1.0',
+        type: 'agent',
+        payloadChecksum: 'checksum',
+        signatures: [{ keyId: 'agent:security-audit', role: 'author', notes: '', signature: 'sig', timestamp: 1 }],
+      },
+      payload: {
+        id: 'agent:security-audit',
+        engine: { type: 'local', entrypoint: '@gitgov/agent-security-audit', function: 'runAgent' },
+        status: 'active',
+        triggers: [],
+        knowledge_dependencies: [],
+        prompt_engine_requirements: {},
+      },
+    };
+
+    it('[GPI18] should stage signed agent JSON at basePath/agents/{id}.json via gitModule.add', async () => {
+      const initializer = createInitializer(gitModule, configStore);
+
+      await initializer.addAgent(signedAgent);
+
+      // agent:security-audit → agent_security-audit.json (DEFAULT_ID_ENCODER), staged not committed
+      expect(gitModule.add).toHaveBeenCalledWith(
+        ['.gitgov/agents/agent_security-audit.json'],
+        {
+          contentMap: {
+            '.gitgov/agents/agent_security-audit.json': JSON.stringify(signedAgent, null, 2),
+          },
+        },
+      );
+      expect(gitModule.commit).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/project_initializer/github/github_project_initializer.ts
+++ b/packages/core/src/project_initializer/github/github_project_initializer.ts
@@ -1,6 +1,8 @@
 import type { CommitAuthor, IGitModule } from '../../git';
 import type { ConfigStore } from '../../config_store';
 import type { GitGovConfig } from '../../config_manager';
+import type { GitGovAgentRecord } from '../../record_types';
+import { DEFAULT_ID_ENCODER } from '../../record_store';
 import type {
   IProjectInitializer,
   EnvironmentValidation,
@@ -84,6 +86,13 @@ export class GitHubProjectInitializer implements IProjectInitializer {
     await this.gitModule.add([policyPath], {
       contentMap: { [policyPath]: DEFAULT_POLICY_YML },
     });
+
+    // [GPI17] Stage security .gitignore to prevent keys from being committed
+    const gitignorePath = `${this.basePath}/.gitignore`;
+    const securityGitignore = '# Security: prevent private keys and local files from being committed\n*.key\n.session.json\nindex.json\n';
+    await this.gitModule.add([gitignorePath], {
+      contentMap: { [gitignorePath]: securityGitignore },
+    });
   }
 
   // GPI10 — project is initialized iff branch exists AND config.json is loadable
@@ -104,6 +113,21 @@ export class GitHubProjectInitializer implements IProjectInitializer {
     const content = JSON.stringify(config, null, 2);
     await this.gitModule.add([configPath], {
       contentMap: { [configPath]: content },
+    });
+  }
+
+  // [GPI18] Stage a signed AgentRecord at {basePath}/agents/{encodedId}.json in the
+  // shared gitModule buffer — materialized atomically with actors/cycle/config at
+  // finalize(). The record arrives already signed (no signing, no committed-read).
+  // encodedId uses DEFAULT_ID_ENCODER so the file matches the record store / indexer.
+  async addAgent(record: GitGovAgentRecord): Promise<void> {
+    const id = record.payload?.id;
+    if (!id) {
+      throw new Error('addAgent requires record.payload.id');
+    }
+    const agentPath = `${this.basePath}/agents/${DEFAULT_ID_ENCODER.encode(id)}.json`;
+    await this.gitModule.add([agentPath], {
+      contentMap: { [agentPath]: JSON.stringify(record, null, 2) },
     });
   }
 

--- a/packages/core/src/project_initializer/github/github_project_initializer.ts
+++ b/packages/core/src/project_initializer/github/github_project_initializer.ts
@@ -164,6 +164,7 @@ export class GitHubProjectInitializer implements IProjectInitializer {
     return `${this.basePath}/actors/${actorId}.json`;
   }
 
+
   // GPI13 — IKS-T6: transaction boundary. Materializes all staged writes in 1 commit.
   // Returns the commit SHA for observability (used by RemoteInitService to emit
   // `INIT_COMPLETE` event via `RepoStateMachineService.transition` with commitSha).

--- a/packages/core/src/project_initializer/project_initializer.ts
+++ b/packages/core/src/project_initializer/project_initializer.ts
@@ -1,4 +1,5 @@
 import type { GitGovConfig } from '../config_manager';
+import type { GitGovAgentRecord } from '../record_types';
 import type { EnvironmentValidation } from './project_initializer.types';
 
 /**
@@ -100,6 +101,21 @@ export interface IProjectInitializer {
    * @returns Path or identifier for the actor
    */
   getActorPath(actorId: string): string;
+
+  /**
+   * [EARS-PI14] Persists a signed AgentRecord according to the backend.
+   *
+   * - **Filesystem backend (`FsProjectInitializer`, EARS-FPI21):** writes the
+   *   JSON to `.gitgov/agents/{encodedId}.json` immediately.
+   * - **GitHub backend (`GitHubProjectInitializer`, GPI18):** stages the content
+   *   via `gitModule.add` for the atomic commit at `finalize()`.
+   *
+   * Receives the AgentRecord ALREADY signed (header + payload) — it does NOT sign
+   * nor read committed state. `{encodedId}` uses `DEFAULT_ID_ENCODER` (same as the
+   * record store) so the file is readable by the store/indexer. Throws if
+   * `record.payload.id` is missing.
+   */
+  addAgent(record: GitGovAgentRecord): Promise<void>;
 
   /**
    * Finalize the initialization transaction — Unit of Work pattern

--- a/packages/core/src/project_module/index.ts
+++ b/packages/core/src/project_module/index.ts
@@ -1,4 +1,4 @@
 export { ProjectModule } from './project_module';
 export { DEFAULT_AGENTS } from './default_agents';
-export type { ProjectModuleDeps, ProjectInitOptions, ProjectInitResult, DefaultAgentConfig, EnsureActorInput, EnsureActorResult } from './project_module.types';
-export { EnsureActorError } from './project_module.types';
+export type { ProjectModuleDeps, ProjectInitOptions, ProjectInitResult, DefaultAgentConfig, AddActorInput, AddActorResult } from './project_module.types';
+export { AddActorError } from './project_module.types';

--- a/packages/core/src/project_module/project_module.test.ts
+++ b/packages/core/src/project_module/project_module.test.ts
@@ -637,13 +637,13 @@ describe('ProjectModule', () => {
     });
   });
 
-  describe('4.9. ensureActorInProject (PROJ-H1 to H6)', () => {
+  describe('4.9. addActor (PROJ-H1 to H6)', () => {
     it('[PROJ-H1] should create actor and commit when actor not in store', async () => {
       const { deps, initializer } = createRealDeps();
       initializer.finalize = jest.fn().mockResolvedValue('sha-join-commit');
       const pm = new ProjectModule(deps);
 
-      const result = await pm.ensureActorInProject({
+      const result = await pm.addActor({
         login: 'collab', type: 'human', repoId: 'repo-1', joinedVia: 'cli',
       });
 
@@ -657,11 +657,11 @@ describe('ProjectModule', () => {
       initializer.finalize = jest.fn().mockResolvedValue('sha-first');
       const pm = new ProjectModule(deps);
 
-      await pm.ensureActorInProject({
+      await pm.addActor({
         login: 'collab', type: 'human', repoId: 'repo-1', joinedVia: 'cli',
       });
 
-      const result = await pm.ensureActorInProject({
+      const result = await pm.addActor({
         login: 'collab', type: 'human', repoId: 'repo-1', joinedVia: 'saas-oauth',
       });
 
@@ -676,14 +676,14 @@ describe('ProjectModule', () => {
         .mockResolvedValueOnce('sha-retry-commit');
       const pm = new ProjectModule(deps);
 
-      await expect(pm.ensureActorInProject({
+      await expect(pm.addActor({
         login: 'retry-user', type: 'human', repoId: 'repo-1', joinedVia: 'cli',
       })).rejects.toMatchObject({ code: 'GIT_WRITE_FAILED' });
 
       expect(initializer.finalize).toHaveBeenCalledTimes(1);
 
       // Retry — actor exists in store, finalize is re-called to complete the git write
-      const result = await pm.ensureActorInProject({
+      const result = await pm.addActor({
         login: 'retry-user', type: 'human', repoId: 'repo-1', joinedVia: 'cli',
       });
 
@@ -699,7 +699,7 @@ describe('ProjectModule', () => {
         .mockRejectedValue(new Error('Nothing to commit: staging buffer is empty'));
       const pm = new ProjectModule(deps);
 
-      const result = await pm.ensureActorInProject({
+      const result = await pm.addActor({
         login: 'store-committed', type: 'human', repoId: 'repo-1', joinedVia: 'saas-oauth',
       });
 
@@ -716,7 +716,7 @@ describe('ProjectModule', () => {
       const pm = new ProjectModule(deps);
 
       // First create the actor so it's in the store
-      await expect(pm.ensureActorInProject({
+      await expect(pm.addActor({
         login: 'ghost-actor', type: 'human', repoId: 'repo-1', joinedVia: 'cli',
       })).rejects.toMatchObject({ code: 'GIT_WRITE_FAILED' });
     });
@@ -728,7 +728,7 @@ describe('ProjectModule', () => {
       deps.eventBus = { emit: emitSpy };
       const pm = new ProjectModule(deps);
 
-      await pm.ensureActorInProject({
+      await pm.addActor({
         login: 'event-user', type: 'human', repoId: 'repo-42', joinedVia: 'mcp',
       });
 
@@ -745,7 +745,7 @@ describe('ProjectModule', () => {
       initializer.finalize = jest.fn().mockResolvedValue('sha-lazy');
       const pm = new ProjectModule(deps);
 
-      const result = await pm.ensureActorInProject({
+      const result = await pm.addActor({
         login: 'lazy-user', type: 'human', repoId: 'repo-specific', joinedVia: 'saas-webhook',
       });
 
@@ -757,7 +757,7 @@ describe('ProjectModule', () => {
       const { deps } = createRealDeps();
       const pm = new ProjectModule(deps);
 
-      await expect(pm.ensureActorInProject({
+      await expect(pm.addActor({
         login: 'blocked-user', type: 'agent', repoId: 'repo-1', joinedVia: 'mcp',
         authzCheck: async () => false,
       })).rejects.toMatchObject({

--- a/packages/core/src/project_module/project_module.test.ts
+++ b/packages/core/src/project_module/project_module.test.ts
@@ -37,6 +37,7 @@ function createMockInitializer(): IProjectInitializer {
     validateEnvironment: jest.fn().mockResolvedValue({ isValid: true, isGitRepo: true, hasWritePermissions: true, isAlreadyInitialized: false, warnings: [], suggestions: [] }),
     readFile: jest.fn().mockResolvedValue(''),
     getActorPath: jest.fn().mockReturnValue('.gitgov/actors/test.json'),
+    addAgent: jest.fn().mockResolvedValue(undefined),
     finalize: jest.fn().mockResolvedValue('abc123def456abc123def456abc123def456abc1'),
     getHeadSha: jest.fn().mockResolvedValue('abc123def456abc123def456abc123def456abc1'),
   };
@@ -299,6 +300,10 @@ describe('ProjectModule', () => {
       createAgentRecord: jest.fn().mockResolvedValue({}),
       getAgentRecord: jest.fn().mockResolvedValue(null),
       updateAgentRecord: jest.fn().mockResolvedValue({}),
+      buildSignedAgentRecord: jest.fn().mockImplementation(async (payload: { id?: string }) => ({
+        header: { version: '1.0', type: 'agent', payloadChecksum: 'mock-checksum', signatures: [] },
+        payload,
+      })),
       ...overrides,
     };
   }
@@ -358,8 +363,9 @@ describe('ProjectModule', () => {
       expect(reviewActor!.payload.roles).toEqual(['specialist']);
       expect(reviewActor!.payload.metadata).toEqual(expect.objectContaining({ joinedVia: 'cli' }));
 
-      // AgentRecords created for all 3 (product + 2 specialists)
-      expect(mockAgentAdapter.createAgentRecord).toHaveBeenCalledTimes(3);
+      // AgentRecords built+persisted for all 3 (product + 2 specialists) via the homologated path
+      expect(mockAgentAdapter.buildSignedAgentRecord).toHaveBeenCalledTimes(3);
+      expect(deps.initializer.addAgent as jest.Mock).toHaveBeenCalledTimes(3);
     });
 
     it('[PROJ-E2] should skip failed specialist and continue with remaining agents', async () => {
@@ -382,11 +388,11 @@ describe('ProjectModule', () => {
 
       // Init succeeded despite security-audit specialist failure
       expect(result.actorId).toBe('human:camilo');
-      // Product agent AgentRecord created (createActor skipped for it)
-      // security-audit: createActor failed → entire agent skipped (no createAgentRecord)
-      // review-advisor: createActor succeeded → createAgentRecord called
-      // Total: 2 createAgentRecord calls (product + review-advisor)
-      expect(mockAgentAdapter.createAgentRecord).toHaveBeenCalledTimes(2);
+      // Product agent AgentRecord built (createActor skipped for it)
+      // security-audit: createActor failed → entire agent skipped (no buildSignedAgentRecord)
+      // review-advisor: createActor succeeded → buildSignedAgentRecord called
+      // Total: 2 buildSignedAgentRecord calls (product + review-advisor)
+      expect(mockAgentAdapter.buildSignedAgentRecord).toHaveBeenCalledTimes(2);
     });
 
     it('[PROJ-E3] should not create duplicate ActorRecord for agent:gitgov-audit', async () => {
@@ -420,20 +426,20 @@ describe('ProjectModule', () => {
 
       await pm.initializeProject({ name: 'test-project', login: 'camilo', stateBranch: DEFAULT_STATE_BRANCH });
 
-      const orchestrationCall = mockAgentAdapter.createAgentRecord.mock.calls[0][0];
+      const orchestrationCall = mockAgentAdapter.buildSignedAgentRecord.mock.calls[0][0];
       expect(orchestrationCall.metadata).toEqual(expect.objectContaining({ purpose: 'orchestration' }));
 
-      const auditCall = mockAgentAdapter.createAgentRecord.mock.calls[1][0];
+      const auditCall = mockAgentAdapter.buildSignedAgentRecord.mock.calls[1][0];
       expect(auditCall.metadata).toEqual(expect.objectContaining({ purpose: 'audit' }));
 
-      const reviewCall = mockAgentAdapter.createAgentRecord.mock.calls[2][0];
+      const reviewCall = mockAgentAdapter.buildSignedAgentRecord.mock.calls[2][0];
       expect(reviewCall.metadata).toEqual(expect.objectContaining({ purpose: 'review' }));
     });
   });
 
   // 4.6. Default Agent Registration (PROJ-B4 to B5)
   describe('4.6. Default Agent Registration (PROJ-B4 to B5)', () => {
-    it('[PROJ-B4] should create AgentRecords for each defaultAgent', async () => {
+    it('[PROJ-B4] should build+sign each defaultAgent and persist via initializer.addAgent', async () => {
       const { deps } = createRealDeps();
       const mockAgentAdapter = createMockAgentAdapter();
       deps.agentAdapter = mockAgentAdapter;
@@ -450,23 +456,24 @@ describe('ProjectModule', () => {
 
       await pm.initializeProject({ name: 'test-project', login: 'camilo', stateBranch: DEFAULT_STATE_BRANCH });
 
-      expect(mockAgentAdapter.createAgentRecord).toHaveBeenCalledTimes(1);
-      expect(mockAgentAdapter.createAgentRecord).toHaveBeenCalledWith(
+      expect(mockAgentAdapter.buildSignedAgentRecord).toHaveBeenCalledTimes(1);
+      expect(mockAgentAdapter.buildSignedAgentRecord).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 'agent:gitgov-audit',
           status: 'active',
           engine: expect.objectContaining({ entrypoint: 'packages/core/dist/index.mjs' }),
         }),
-        { defer: true },
       );
+      // Signed record persisted via the initializer (homologated FS/GitHub), not the store
+      expect(deps.initializer.addAgent as jest.Mock).toHaveBeenCalledTimes(1);
     });
 
     it('[PROJ-B5] should continue with remaining agents when one fails', async () => {
       const { deps } = createRealDeps();
       const mockAgentAdapter = createMockAgentAdapter({
-        createAgentRecord: jest.fn()
+        buildSignedAgentRecord: jest.fn()
           .mockRejectedValueOnce(new Error('Agent 1 failed'))
-          .mockResolvedValueOnce({}),
+          .mockResolvedValueOnce({ header: {}, payload: { id: 'agent:second' } }),
       });
       deps.agentAdapter = mockAgentAdapter;
       deps.defaultAgents = [
@@ -480,7 +487,7 @@ describe('ProjectModule', () => {
       // Init succeeded despite first agent failure
       expect(result.actorId).toBe('human:camilo');
       // Both agents were attempted
-      expect(mockAgentAdapter.createAgentRecord).toHaveBeenCalledTimes(2);
+      expect(mockAgentAdapter.buildSignedAgentRecord).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/core/src/project_module/project_module.ts
+++ b/packages/core/src/project_module/project_module.ts
@@ -1,5 +1,5 @@
-import type { ProjectModuleDeps, ProjectInitOptions, ProjectInitResult, EnsureActorInput, EnsureActorResult } from './project_module.types';
-import { EnsureActorError } from './project_module.types';
+import type { ProjectModuleDeps, ProjectInitOptions, ProjectInitResult, AddActorInput, AddActorResult } from './project_module.types';
+import { AddActorError } from './project_module.types';
 
 // [PROJ-C2b] Deterministic root cycle ID. The root cycle is unique per project, so its ID
 // must be stable across inits (not Date.now()). Two inits of the same repo then produce a
@@ -21,14 +21,14 @@ export class ProjectModule {
     if (isInit) {
       const commitSha = await this.deps.initializer.getHeadSha();
       if (options.login) {
-        const ensureInput: EnsureActorInput = {
+        const ensureInput: AddActorInput = {
           login: options.login,
           type: options.type ?? 'human',
           repoId,
           joinedVia,
         };
         if (options.actorName) ensureInput.displayName = options.actorName;
-        const actorResult = await this.ensureActorInProject(ensureInput);
+        const actorResult = await this.addActor(ensureInput);
         return { alreadyInitialized: true, actorId: actorResult.actorId, created: actorResult.created, commitSha: actorResult.commitSha ?? commitSha } as ProjectInitResult;
       }
       return { alreadyInitialized: true, commitSha } as ProjectInitResult;
@@ -38,10 +38,10 @@ export class ProjectModule {
       // [PROJ-C1] Structure (dirs + policy.yml) — before actors
       await this.deps.initializer.createProjectStructure();
 
-      // [PROJ-A1] [PROJ-B1] Human actor — via ensureActorInProject for consistent metadata + events
+      // [PROJ-A1] [PROJ-B1] Human actor — via addActor for consistent metadata + events
       // skipFinalize: true — initializeProject calls finalize() once at the end
       const actorType = options.type ?? 'human';
-      const humanResult = await this.ensureActorInProject({
+      const humanResult = await this.addActor({
         login: options.login || 'owner',
         type: actorType as 'human' | 'agent',
         repoId,
@@ -52,10 +52,10 @@ export class ProjectModule {
         defer: true,
       });
 
-      // [PROJ-B2] Product agent (G21 Two-Tier Actor Model) — via ensureActorInProject
-      let productAgentResult: EnsureActorResult;
+      // [PROJ-B2] Product agent (G21 Two-Tier Actor Model) — via addActor
+      let productAgentResult: AddActorResult;
       try {
-        productAgentResult = await this.ensureActorInProject({
+        productAgentResult = await this.addActor({
           login: 'gitgov-audit',
           type: 'agent',
           skipFinalize: true,
@@ -101,7 +101,7 @@ export class ProjectModule {
             // [PROJ-E3] Product agent already has ActorRecord — skip
             // [PROJ-E1] Specialist agents need their own ActorRecord before AgentRecord
             if (agentConfig.agentId !== productAgentResult.actorId) {
-              await this.ensureActorInProject({
+              await this.addActor({
                 login: agentConfig.agentId.replace('agent:', ''),
                 type: 'agent',
                 repoId,
@@ -167,14 +167,14 @@ export class ProjectModule {
   }
 
   // [PROJ-H1] [PROJ-H2] [PROJ-H3] [PROJ-H4] [PROJ-H5] [PROJ-H6]
-  async ensureActorInProject(input: EnsureActorInput): Promise<EnsureActorResult> {
+  async addActor(input: AddActorInput): Promise<AddActorResult> {
     const actorId = `${input.type}:${input.login}`;
 
     // [PROJ-H6] authzCheck — invoke before any creation
     if (input.authzCheck) {
       const allowed = await input.authzCheck(input);
       if (!allowed) {
-        throw new EnsureActorError('UNAUTHORIZED', { login: input.login, type: input.type, reason: 'authz check denied' });
+        throw new AddActorError('UNAUTHORIZED', { login: input.login, type: input.type, reason: 'authz check denied' });
       }
     }
 
@@ -199,7 +199,7 @@ export class ProjectModule {
         timestamp: new Date().toISOString(),
       });
 
-      const result: EnsureActorResult = { actorId, created: false };
+      const result: AddActorResult = { actorId, created: false };
       if (commitSha) result.commitSha = commitSha;
       return result;
     }
@@ -232,10 +232,10 @@ export class ProjectModule {
         if (message.includes('Nothing to commit')) {
           const verified = await this.deps.identity.getActor(actorId);
           if (!verified) {
-            throw new EnsureActorError('GIT_WRITE_FAILED', { actorId, cause: message });
+            throw new AddActorError('GIT_WRITE_FAILED', { actorId, cause: message });
           }
         } else {
-          throw new EnsureActorError('GIT_WRITE_FAILED', { actorId, cause: message });
+          throw new AddActorError('GIT_WRITE_FAILED', { actorId, cause: message });
         }
       }
     }
@@ -247,7 +247,7 @@ export class ProjectModule {
       timestamp: new Date().toISOString(),
     });
 
-    const result: EnsureActorResult = { actorId, created: true };
+    const result: AddActorResult = { actorId, created: true };
     if (commitSha) result.commitSha = commitSha;
     return result;
   }

--- a/packages/core/src/project_module/project_module.ts
+++ b/packages/core/src/project_module/project_module.ts
@@ -127,14 +127,19 @@ export class ProjectModule {
                 });
               }
             } else {
-              await this.deps.agentAdapter.createAgentRecord({
+              // [PROJ-B4] Build+sign without committed-read, then persist via the initializer
+              // (homologated FS/GitHub). Avoids createAgentRecord's committed-read of the
+              // corresponding ActorRecord, which on the GitHub atomic init is staged-but-not-
+              // committed and invisible to the store's get() → throw → swallowed (Bug A).
+              const signed = await this.deps.agentAdapter.buildSignedAgentRecord({
                 id: agentConfig.agentId,
                 engine: agentConfig.engine,
                 status: 'active',
                 triggers: agentConfig.triggers,
                 // [PROJ-E4] Purpose merged into AgentRecord metadata
                 metadata: mergedMetadata,
-              }, { defer: true });
+              });
+              await this.deps.initializer.addAgent(signed);
             }
           } catch {
             // [PROJ-B5] [PROJ-E2] [GAUD-E3] Non-fatal — agent create/update failure doesn't block init

--- a/packages/core/src/project_module/project_module.types.ts
+++ b/packages/core/src/project_module/project_module.types.ts
@@ -37,7 +37,7 @@ export type ProjectInitOptions = {
   saasUrl?: string;
   stateBranch: string;
   repoId?: string;
-  joinedVia?: EnsureActorInput['joinedVia'];
+  joinedVia?: AddActorInput['joinedVia'];
 };
 
 export type ProjectInitResult = {
@@ -49,32 +49,32 @@ export type ProjectInitResult = {
   created?: boolean;
 };
 
-// --- ensureActorInProject primitive (PROJ-H1..H6) ---
+// --- addActor primitive (PROJ-H1..H6) ---
 
-export type EnsureActorInput = {
+export type AddActorInput = {
   login: string;
   type: 'human' | 'agent';
   repoId: string;
   displayName?: string;
   roles?: string[];
   joinedVia: 'cli' | 'saas-oauth' | 'saas-webhook' | 'mcp';
-  authzCheck?: (input: EnsureActorInput) => Promise<boolean>;
+  authzCheck?: (input: AddActorInput) => Promise<boolean>;
   skipFinalize?: boolean;
   defer?: boolean;
 };
 
-export type EnsureActorResult = {
+export type AddActorResult = {
   actorId: string;
   created: boolean;
   commitSha?: string;
 };
 
-export class EnsureActorError extends Error {
+export class AddActorError extends Error {
   public readonly code: string;
   public readonly context: Record<string, unknown>;
   constructor(code: string, context: Record<string, unknown> = {}) {
-    super(`EnsureActorError(${code})`);
-    this.name = 'EnsureActorError';
+    super(`AddActorError(${code})`);
+    this.name = 'AddActorError';
     this.code = code;
     this.context = context;
   }

--- a/packages/core/src/project_module/project_module.types.ts
+++ b/packages/core/src/project_module/project_module.types.ts
@@ -1,7 +1,7 @@
 import type { IProjectInitializer } from '../project_initializer';
 import type { IdentityModule } from '../identity/identity_module';
 import type { IBacklogAdapter } from '../adapters/backlog_adapter/backlog_adapter.types';
-import type { AgentPayload, AgentRecord } from '../record_types';
+import type { AgentPayload, AgentRecord, GitGovAgentRecord } from '../record_types';
 
 // [PROJ-F1] Trigger type derived from AgentRecord — single source of truth
 export type DefaultAgentConfig = {
@@ -18,6 +18,8 @@ export interface IProjectAgentOps {
   getAgentRecord(agentId: string): Promise<AgentRecord | null>;
   createAgentRecord(payload: Partial<AgentPayload>, options?: { defer?: boolean }): Promise<AgentRecord>;
   updateAgentRecord(agentId: string, updates: Partial<AgentPayload>): Promise<AgentRecord>;
+  // [EARS-G1] Build+sign without committed-read — caller persists via initializer.addAgent (PROJ-B4)
+  buildSignedAgentRecord(payload: Partial<AgentPayload>): Promise<GitGovAgentRecord>;
 }
 
 export type ProjectModuleDeps = {

--- a/packages/core/src/record_projection/prisma/prisma_record_projection.test.ts
+++ b/packages/core/src/record_projection/prisma/prisma_record_projection.test.ts
@@ -3,10 +3,15 @@ import type { IndexData, ProjectionContext, EnrichedTaskRecord } from '../record
 import type { ProjectionClient, GitgovExecutionRow, GitgovAgentRow } from './prisma_record_projection.types';
 
 function createMockDelegate() {
+  let rowCount = 0;
   return {
-    createMany: jest.fn().mockResolvedValue({ count: 0 }),
+    count: jest.fn().mockImplementation(() => Promise.resolve(rowCount)),
+    createMany: jest.fn().mockImplementation((args: { data: unknown[] }) => {
+      rowCount = args.data.length;
+      return Promise.resolve({ count: args.data.length });
+    }),
     findMany: jest.fn().mockResolvedValue([]),
-    deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+    deleteMany: jest.fn().mockImplementation(() => { rowCount = 0; return Promise.resolve({ count: 0 }); }),
   };
 }
 
@@ -873,6 +878,28 @@ describe('PrismaRecordProjection', () => {
       ];
       const orphanedFields = taskFieldNames.filter((f: string) => !knownTaskFields.includes(f));
       expect(orphanedFields).toEqual([]);
+    });
+  });
+
+  describe('4.11. Post-Persist Integrity (PP-C2)', () => {
+    it('[PP-C2] should throw when post-persist count mismatches expected', async () => {
+      const client = createMockClient();
+      // Simulate: createMany succeeds but count returns wrong number (corruption)
+      (client.gitgovActor.count as jest.Mock).mockResolvedValue(999);
+
+      const sink = new PrismaRecordProjection({ client, tenantFields: { repoId: 'repo-1', projectionType: 'index' } });
+      const data = createMockIndexData();
+
+      await expect(sink.persist(data, { lastCommitHash: 'sha-1' }))
+        .rejects.toThrow(/Persist integrity check failed.*repo-1.*actors expected=\d+ actual=999/);
+    });
+
+    it('[PP-C2] should not throw when counts match', async () => {
+      const client = createMockClient();
+      const sink = new PrismaRecordProjection({ client, tenantFields: { repoId: 'repo-1', projectionType: 'index' } });
+      const data = createMockIndexData();
+
+      await expect(sink.persist(data, { lastCommitHash: 'sha-1' })).resolves.not.toThrow();
     });
   });
 });

--- a/packages/core/src/record_projection/prisma/prisma_record_projection.ts
+++ b/packages/core/src/record_projection/prisma/prisma_record_projection.ts
@@ -175,6 +175,21 @@ export class PrismaRecordProjection implements IRecordProjection {
     }
 
     await this.client.$transaction(ops);
+
+    // [PP-C2] Post-persist integrity check: verify counts match what was written.
+    // Only check the 3 most critical tables (actors, tasks, cycles).
+    const actualActors = await this.client.gitgovActor.count({ where });
+    const actualTasks = await this.client.gitgovTask.count({ where });
+    const actualCycles = await this.client.gitgovCycle.count({ where });
+    if (actualActors !== actorRows.length || actualTasks !== taskRows.length || actualCycles !== cycleRows.length) {
+      const id = this.tenantFields['repoId'] ?? 'unknown';
+      throw new Error(
+        `Persist integrity check failed for repo ${id}: ` +
+        `actors expected=${actorRows.length} actual=${actualActors}, ` +
+        `tasks expected=${taskRows.length} actual=${actualTasks}, ` +
+        `cycles expected=${cycleRows.length} actual=${actualCycles}`
+      );
+    }
   }
 
   async read(_context: ProjectionContext): Promise<IndexData | null> {

--- a/packages/core/src/record_projection/prisma/prisma_record_projection.types.ts
+++ b/packages/core/src/record_projection/prisma/prisma_record_projection.types.ts
@@ -153,6 +153,7 @@ export type SingletonDelegate<TRow> = {
 };
 
 export type RecordDelegate<TRow> = {
+  count(args: { where: WhereClause }): PromiseLike<number>;
   createMany(args: {
     data: Array<Omit<TRow, 'id' | 'createdAt' | 'updatedAt'> & Record<string, unknown>>;
   }): PromiseLike<unknown>;

--- a/packages/core/src/shared/fs/fs.ts
+++ b/packages/core/src/shared/fs/fs.ts
@@ -72,3 +72,7 @@ export type { FsAgentRunnerDependencies } from '../../agent_runner/fs';
 // RecordProjection (filesystem-based index.json persistence)
 export { FsRecordProjection } from '../../record_projection/fs';
 export type { FsRecordProjectionOptions } from '../../record_projection/fs';
+
+// AuditFsProjection (filesystem-based audit result persistence)
+export { AuditFsProjection } from '../../audit/fs';
+export type { IAuditFsProjection, AuditFsProjectionOptions } from '../../audit/fs';

--- a/packages/core/src/sync_state/fs_worktree/fs_worktree_sync_state.test.ts
+++ b/packages/core/src/sync_state/fs_worktree/fs_worktree_sync_state.test.ts
@@ -17,7 +17,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { promisify } from 'util';
 import { exec } from 'child_process';
-import { FsWorktreeSyncStateModule } from './fs_worktree_sync_state';
+import { FsWorktreeSyncStateModule, shouldSyncFile } from './fs_worktree_sync_state';
 import { DEFAULT_STATE_BRANCH } from './fs_worktree_sync_state.types';
 import { LocalGitModule } from '../../git/local';
 import type { ExecOptions, ExecResult } from '../../git/types';
@@ -341,7 +341,7 @@ describe('FsWorktreeSyncStateModule', () => {
   // 4.1. Worktree Management (WTSYNC-A1 to A6)
   // ═══════════════════════════════════════════════
 
-  describe('4.1. Worktree Management (WTSYNC-A1 to A7)', () => {
+  describe('4.1. Worktree Management (WTSYNC-A1 to A8)', () => {
     it('[WTSYNC-A1] should create worktree when none exists', async () => {
       const { repoPath, remotePath } = await setupRepoWithRemote();
       cleanupPaths.push(repoPath, remotePath);
@@ -504,58 +504,42 @@ describe('FsWorktreeSyncStateModule', () => {
       expect(branches).toContain('gitgov-state');
     });
 
-    it('[WTSYNC-A7] should NOT create .gitignore on fresh state branch initialization', async () => {
+    it('[WTSYNC-A8] should create security .gitignore excluding keys and local files', async () => {
       const { repoPath, remotePath } = await setupRepoWithRemote();
       cleanupPaths.push(repoPath, remotePath);
 
       const { module } = createModule(repoPath);
       await module.ensureWorktree();
 
-      // Verify the worktree has NO .gitignore at root
       const worktreePath = module.getWorktreePath();
-      expect(fs.existsSync(path.join(worktreePath, '.gitignore'))).toBe(false);
+      const gitignorePath = path.join(worktreePath, '.gitignore');
+      expect(fs.existsSync(gitignorePath)).toBe(true);
 
-      // Verify the state branch tree has NO .gitignore
-      const { stdout: tree } = await execAsync(
-        'git ls-tree -r --name-only gitgov-state',
-        { cwd: repoPath }
-      );
-      expect(tree.trim()).toBe(''); // orphan empty tree — no files at all
+      const content = fs.readFileSync(gitignorePath, 'utf-8');
+      expect(content).toContain('*.key');
+      expect(content).toContain('.session.json');
+      expect(content).toContain('index.json');
     });
 
-    it('[WTSYNC-A7] should remove legacy .gitignore from existing state branch', async () => {
+    it('[WTSYNC-A8] should overwrite .gitignore when content differs from expected', async () => {
       const { repoPath, remotePath } = await setupRepoWithRemote();
       cleanupPaths.push(repoPath, remotePath);
 
-      // Simulate legacy FsSyncState init: create state branch WITH .gitignore
-      await execAsync('git checkout --orphan gitgov-state', { cwd: repoPath });
-      await execAsync('git rm -rf . 2>/dev/null || true', { cwd: repoPath });
-      fs.writeFileSync(path.join(repoPath, '.gitignore'), '# Legacy\nindex.json\n.session.json\n');
-      await execAsync('git add .gitignore', { cwd: repoPath });
-      await execAsync('git commit -m "Initialize state branch with .gitignore"', { cwd: repoPath });
-      await execAsync('git checkout main', { cwd: repoPath });
-
-      // Verify .gitignore exists on state branch before cleanup
-      const { stdout: treeBefore } = await execAsync(
-        'git ls-tree --name-only gitgov-state',
-        { cwd: repoPath }
-      );
-      expect(treeBefore.trim()).toContain('.gitignore');
-
-      // Now create worktree — should clean up legacy .gitignore
       const { module } = createModule(repoPath);
       await module.ensureWorktree();
 
-      // Verify .gitignore is GONE
       const worktreePath = module.getWorktreePath();
-      expect(fs.existsSync(path.join(worktreePath, '.gitignore'))).toBe(false);
+      const gitignorePath = path.join(worktreePath, '.gitignore');
 
-      // Verify the state branch no longer has .gitignore
-      const { stdout: treeAfter } = await execAsync(
-        'git ls-tree --name-only gitgov-state',
-        { cwd: repoPath }
-      );
-      expect(treeAfter.trim()).not.toContain('.gitignore');
+      // Write wrong content
+      fs.writeFileSync(gitignorePath, '# Legacy\nindex.json\n');
+
+      // Re-run ensureWorktree — should overwrite
+      await module.ensureWorktree();
+
+      const content = fs.readFileSync(gitignorePath, 'utf-8');
+      expect(content).toContain('*.key');
+      expect(content).toContain('.session.json');
     });
   });
 
@@ -1085,6 +1069,31 @@ describe('FsWorktreeSyncStateModule', () => {
       expect(result.conflictInfo?.affectedFiles).toContain('.gitgov/tasks/conflict-file.json');
       expect(result.filesSynced).toBe(0);
       expect(result.commitHash).toBeNull();
+    });
+  });
+
+  // ═══════════════════════════════════════════════
+  // 4.2b. Root File Sync Exemption (WTSYNC-B17)
+  // ═══════════════════════════════════════════════
+
+  describe('4.2b. Root File Sync Exemption (WTSYNC-B17)', () => {
+    it('[WTSYNC-B17] should sync policy.yml and .gitignore as root files despite non-json extension', () => {
+      // Root files under .gitgov/ sync by exact name, exempt from the .json filter
+      expect(shouldSyncFile('.gitgov/policy.yml')).toBe(true);
+      expect(shouldSyncFile('.gitgov/.gitignore')).toBe(true);
+      expect(shouldSyncFile('.gitgov/config.json')).toBe(true);
+      // A file under a sync dir still requires the .json extension (B9 unchanged)
+      expect(shouldSyncFile('.gitgov/actors/agent_x.json')).toBe(true);
+      expect(shouldSyncFile('.gitgov/actors/notes.yml')).toBe(false);
+    });
+
+    it('[WTSYNC-B17] should not sync a .gitignore outside .gitgov/', () => {
+      // A worktree-root or repo-root .gitignore is NOT a .gitgov state file
+      expect(shouldSyncFile('.gitignore')).toBe(false);
+      expect(shouldSyncFile('some/repo/.gitignore')).toBe(false);
+      // Local-only and excluded patterns are still rejected despite the root-file exemption
+      expect(shouldSyncFile('.gitgov/index.json')).toBe(false);
+      expect(shouldSyncFile('.gitgov/keys/agent.key')).toBe(false);
     });
   });
 

--- a/packages/core/src/sync_state/fs_worktree/fs_worktree_sync_state.ts
+++ b/packages/core/src/sync_state/fs_worktree/fs_worktree_sync_state.ts
@@ -44,14 +44,12 @@ const logger = createLogger('[WorktreeSyncState] ');
  * Check if a file should be synced to gitgov-state.
  * Returns true only for allowed *.json files in SYNC_DIRECTORIES or SYNC_ROOT_FILES.
  */
-function shouldSyncFile(filePath: string): boolean {
+export function shouldSyncFile(filePath: string): boolean {
   const fileName = path.basename(filePath);
   const ext = path.extname(filePath);
 
-  if (!SYNC_ALLOWED_EXTENSIONS.includes(ext as typeof SYNC_ALLOWED_EXTENSIONS[number])) {
-    return false;
-  }
-
+  // Never sync excluded patterns (private keys, backups, temp) or local-only files.
+  // Checked FIRST so the root-file extension exemption (B17) can never leak a key.
   for (const pattern of SYNC_EXCLUDED_PATTERNS) {
     if (pattern.test(fileName)) {
       return false;
@@ -76,18 +74,22 @@ function shouldSyncFile(filePath: string): boolean {
     );
     if (syncDirIndex !== -1) {
       relativeParts = parts.slice(syncDirIndex);
-    } else if (SYNC_ROOT_FILES.includes(fileName as typeof SYNC_ROOT_FILES[number])) {
-      return true;
     } else {
+      // [WTSYNC-B17] No .gitgov/ context and not under a sync dir → not a .gitgov state
+      // file (e.g. a worktree-root or repo-root .gitignore). Root files only sync under .gitgov/.
       return false;
     }
   }
 
   if (relativeParts.length === 1) {
+    // [WTSYNC-B17] Root files (config.json, policy.yml, .gitignore) sync by exact name,
+    // EXEMPT from SYNC_ALLOWED_EXTENSIONS (policy.yml is .yml, .gitignore has no extension).
     return SYNC_ROOT_FILES.includes(relativeParts[0] as typeof SYNC_ROOT_FILES[number]);
   } else if (relativeParts.length >= 2) {
+    // [WTSYNC-B9] Files inside SYNC_DIRECTORIES must have an allowed extension (.json).
     const dirName = relativeParts[0];
-    return SYNC_DIRECTORIES.includes(dirName as typeof SYNC_DIRECTORIES[number]);
+    return SYNC_DIRECTORIES.includes(dirName as typeof SYNC_DIRECTORIES[number])
+      && SYNC_ALLOWED_EXTENSIONS.includes(ext as typeof SYNC_ALLOWED_EXTENSIONS[number]);
   }
 
   return false;
@@ -144,8 +146,8 @@ export class FsWorktreeSyncStateModule implements ISyncStateModule {
 
     if (health.healthy) {
       logger.debug('Worktree is healthy');
-      // [WTSYNC-A7] Clean up legacy .gitignore even on healthy worktrees
-      await this.removeLegacyGitignore();
+      // [WTSYNC-A8] Ensure security .gitignore exists
+      await this.ensureSecurityGitignore();
       return; // [WTSYNC-A2]
     }
 
@@ -157,7 +159,7 @@ export class FsWorktreeSyncStateModule implements ISyncStateModule {
         await this.ensureStateBranch();
         try {
           await this.execGit(['-C', this.worktreePath, 'checkout', '-B', this.stateBranchName]);
-          await this.removeLegacyGitignore();
+          await this.ensureSecurityGitignore();
           return;
         } catch {
           // If checkout fails, fall through to recreate
@@ -186,30 +188,28 @@ export class FsWorktreeSyncStateModule implements ISyncStateModule {
       );
     }
 
-    // [WTSYNC-A7] Clean up legacy .gitignore after worktree creation
-    await this.removeLegacyGitignore();
+    // [WTSYNC-A8] Ensure security .gitignore after worktree creation
+    await this.ensureSecurityGitignore();
   }
 
   /**
-   * [WTSYNC-A7] Remove .gitignore from state branch if it exists.
-   * The worktree module filters files in code (shouldSyncFile()), not via .gitignore.
-   * Legacy state branches initialized by FsSyncState may have a .gitignore — remove it.
+   * [WTSYNC-A8] Ensure security .gitignore exists in worktree.
+   * Defense-in-depth: shouldSyncFile() filters in code, but .gitignore prevents
+   * accidental `git add .gitgov/` from staging private keys during manual
+   * git operations or conflict resolution.
    */
-  private async removeLegacyGitignore(): Promise<void> {
+  private async ensureSecurityGitignore(): Promise<void> {
     const gitignorePath = path.join(this.worktreePath, '.gitignore');
-    if (!existsSync(gitignorePath)) return;
+    const expectedContent = '# Security: prevent private keys and local files from being committed\n*.key\n.session.json\nindex.json\n';
 
-    logger.info('Removing legacy .gitignore from state branch');
     try {
-      await this.execInWorktree(['rm', '.gitignore']);
-      await this.execInWorktree(['commit', '-m', 'gitgov: remove legacy .gitignore (filtering is in code)']);
-    } catch {
-      // If rm/commit fails (e.g., .gitignore is untracked), just delete the file
-      try {
-        await fsPromises.unlink(gitignorePath);
-      } catch {
-        // Ignore — file may have been removed by git rm
+      if (existsSync(gitignorePath)) {
+        const current = await fsPromises.readFile(gitignorePath, 'utf-8');
+        if (current === expectedContent) return;
       }
+      await fsPromises.writeFile(gitignorePath, expectedContent, 'utf-8');
+    } catch {
+      // Non-fatal — code filtering is the primary protection
     }
   }
 

--- a/packages/core/src/sync_state/sync_state.types.ts
+++ b/packages/core/src/sync_state/sync_state.types.ts
@@ -305,6 +305,8 @@ export const SYNC_DIRECTORIES = [
  */
 export const SYNC_ROOT_FILES = [
   'config.json',
+  'policy.yml',
+  '.gitignore',
 ] as const;
 
 /**

--- a/packages/e2e/prisma/schema/audit.prisma
+++ b/packages/e2e/prisma/schema/audit.prisma
@@ -1,7 +1,7 @@
 // ⚠️ COPIED from core — DO NOT EDIT
 // Source: packages/core/prisma/schema/
 // Re-generate: pnpm prisma:sync (in packages/e2e)
-// Synced at: 2026-05-04T12:22:04.837Z
+// Synced at: 2026-05-31T02:26:50.048Z
 
 // GitGovernance Core — Audit Product Projection Tables
 // Finding, Waiver, Scan — derived from protocol records
@@ -151,7 +151,10 @@ model Scan {
   status               String           @default("pending")
   prNumber             Int?
   prUrl                String?
-  checkRunId           Int?
+  // [SCAN-Q1] GitHub Check Run ID. BIGINT in DB (GitHub IDs can exceed
+  // Int32 range). Migration 20260506042653_index_status_enum_and_scan_updates
+  // set the column type to BIGINT — the schema must match for client codegen.
+  checkRunId           BigInt?
   branch               String?
   commitSha            String?
   commitAuthor         String?

--- a/packages/e2e/prisma/schema/protocol.prisma
+++ b/packages/e2e/prisma/schema/protocol.prisma
@@ -1,7 +1,7 @@
 // ⚠️ COPIED from core — DO NOT EDIT
 // Source: packages/core/prisma/schema/
 // Re-generate: pnpm prisma:sync (in packages/e2e)
-// Synced at: 2026-05-04T12:22:04.837Z
+// Synced at: 2026-05-31T02:26:50.048Z
 
 // GitGovernance Core — Protocol Record Projection Tables
 // Fields match record types from core/src/record_types/generated/

--- a/packages/e2e/tests/helpers/prisma.ts
+++ b/packages/e2e/tests/helpers/prisma.ts
@@ -5,7 +5,7 @@
  */
 import pg from 'pg';
 import { PrismaPg } from '@prisma/adapter-pg';
-import { PrismaClient } from '@gitgov/saas-api/prisma';
+import { PrismaClient } from '../../generated/prisma';
 
 export type { PrismaClient };
 


### PR DESCRIPTION
## Summary

- **Rename `ensureActorInProject` → `addActor`** across core + CLI + types (`EnsureActorInput/Result/Error` → `AddActorInput/Result/Error`). Aligns naming with the explicit initialization model (FV9).
- **CLI `--token` seam** (LOGIN-S1/S2): test-only OAuth bypass — allows convergence/COB E2E isolated without browser. Types in `login-command.types.ts`, wiring in `login.ts`.
- **Private submodule bumps** (session 58): actor refactor pasos 1-7, Connect button (RDV-H1/H2), `addActorToRepo` endpoint (IDS-J1/J2), `resolveActorForUser` no implicit creation (paso 6), KS11 green 11/11, roadmap updated.
- **github_project_initializer**: addActor call updated.

## Context

Part of epic `flow_verification` Cycle 1. The actor initialization refactor (FV9) was unplanned — discovered while debugging OB-H1. `ensureActorInProject` was a misleading name for what is now explicitly "add an actor to a repo." The `--token` seam unblocked headful E2E testing of key_sync and collaborator flows without browser OAuth.

Private side (private#37+#38): 662/662 saas-api tests green, 0 todo. tsc 0 in core/cli/saas-api.

## Test plan

- [ ] `pnpm -F @gitgov/core test` — project_module tests with renamed types
- [ ] `pnpm -F @gitgov/cli test` — login-command tests with addActor + --token types
- [ ] `tsc --noEmit` in core + CLI — zero errors