### PR TITLE
feat(core,agents): FindingCategory extensible + agent distribution prep (s78)

### DIFF
--- a/packages/agents/review-advisor/package.json
+++ b/packages/agents/review-advisor/package.json
@@ -13,6 +13,7 @@
     "agent": {
       "purpose": "review",
       "function": "runReviewAdvisor",
+      "categories": [],
       "metadata": {
         "sdk": "claude-agent-sdk",
         "model": "claude-sonnet-4"

--- a/packages/agents/security-audit/package.json
+++ b/packages/agents/security-audit/package.json
@@ -50,10 +50,8 @@
   "peerDependencies": {
     "@gitgov/core": ">=3.0.0"
   },
-  "dependencies": {
-    "@gitgov/core": "workspace:*"
-  },
   "devDependencies": {
+    "@gitgov/core": "workspace:*",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^9.2.6",
     "@types/jest": "^29.0.0",

--- a/packages/agents/security-audit/package.json
+++ b/packages/agents/security-audit/package.json
@@ -27,6 +27,17 @@
     "agent": {
       "purpose": "audit",
       "function": "runAgent",
+      "categories": [
+        "pii-email", "pii-phone", "pii-financial", "pii-health", "pii-generic",
+        "hardcoded-secret",
+        "pci-pan", "pci-cvv", "pci-track", "pci-logging", "pci-token-misuse", "pci-last4",
+        "pii-dob", "pii-address", "pii-national-id", "pii-passport", "pii-bank-account", "pii-biometric",
+        "storage-pii", "storage-pci", "crypto-weak", "crypto-key", "crypto-tls",
+        "logging-pii", "tracking-cookie", "tracking-analytics-id",
+        "unencrypted-storage", "third-party-transfer", "unknown-risk",
+        "logging-auth", "logging-error", "logging-debug", "logging-trace",
+        "data-transfer", "privacy-consent", "privacy-retention"
+      ],
       "metadata": {
         "target": "code",
         "outputFormat": "sarif"
@@ -43,10 +54,14 @@
     "@gitgov/core": "workspace:*"
   },
   "devDependencies": {
+    "@semantic-release/git": "^10.0.1",
+    "@semantic-release/github": "^9.2.6",
     "@types/jest": "^29.0.0",
     "@types/node": "^20.0.0",
+    "conventional-changelog-conventionalcommits": "^7.0.2",
     "esbuild": "^0.19.0",
     "jest": "^29.0.0",
+    "semantic-release": "^22.0.12",
     "ts-jest": "^29.0.0",
     "typescript": "^5.0.0"
   }

--- a/packages/agents/semgrep/agent.test.ts
+++ b/packages/agents/semgrep/agent.test.ts
@@ -232,6 +232,16 @@ describe('4.3. SARIF Processing (SGP-C1 to SGP-C6)', () => {
     expect(buildCall.findings[0].category).toBe('hardcoded-secret');
   });
 
+  it('[SGP-C3] should map SAST CWEs to security-vulnerability', async () => {
+    const deps = createMockDeps();
+    const agent = new SemgrepAgent(deps);
+
+    await agent.run({ scope: 'full', taskId: 'task-1' }, SARIF_WITH_FINDINGS);
+
+    const buildCall = (deps.sarifBuilder.build as jest.Mock).mock.calls[0][0];
+    expect(buildCall.findings[0].category).toBe('security-vulnerability');
+  });
+
   it('[SGP-C4] should rebuild SARIF via SarifBuilder with toolName semgrep and getLineContent', async () => {
     const deps = createMockDeps();
     const agent = new SemgrepAgent(deps);

--- a/packages/agents/semgrep/package.json
+++ b/packages/agents/semgrep/package.json
@@ -27,6 +27,7 @@
     "agent": {
       "purpose": "audit",
       "function": "runAgent",
+      "categories": ["security-vulnerability", "code-quality", "hardcoded-secret"],
       "metadata": {
         "target": "code",
         "outputFormat": "sarif",

--- a/packages/agents/semgrep/package.json
+++ b/packages/agents/semgrep/package.json
@@ -41,10 +41,8 @@
   "peerDependencies": {
     "@gitgov/core": ">=3.0.0"
   },
-  "dependencies": {
-    "@gitgov/core": "workspace:*"
-  },
   "devDependencies": {
+    "@gitgov/core": "workspace:*",
     "@types/jest": "^29.0.0",
     "@types/node": "^20.0.0",
     "esbuild": "^0.19.0",

--- a/packages/agents/semgrep/src/types.ts
+++ b/packages/agents/semgrep/src/types.ts
@@ -66,10 +66,10 @@ export const SEMGREP_SEVERITY_MAP: Record<string, FindingSeverity> = {
 export const SEMGREP_CATEGORY_MAP: Record<string, FindingCategory> = {
   'CWE-798': 'hardcoded-secret',
   'CWE-259': 'hardcoded-secret',
-  'CWE-89': 'unknown-risk',
-  'CWE-79': 'unknown-risk',
-  'CWE-22': 'unknown-risk',
-  'CWE-78': 'unknown-risk',
-  'CWE-94': 'unknown-risk',
-  'CWE-502': 'unknown-risk',
+  'CWE-89': 'security-vulnerability',
+  'CWE-79': 'security-vulnerability',
+  'CWE-22': 'security-vulnerability',
+  'CWE-78': 'security-vulnerability',
+  'CWE-94': 'security-vulnerability',
+  'CWE-502': 'security-vulnerability',
 };

--- a/packages/agents/test-echo/package.json
+++ b/packages/agents/test-echo/package.json
@@ -44,6 +44,7 @@
     "agent": {
       "purpose": "testing",
       "function": "runAgent",
+      "categories": [],
       "metadata": {
         "description": "Echo agent for testing and demonstration"
       }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@gitgov/core": "workspace:*",
+    "@gitgov/agent-security-audit": "workspace:*",
     "clipboardy": "^5.0.0",
     "commander": "^11.1.0"
   },

--- a/packages/core/prisma/schema/audit.prisma
+++ b/packages/core/prisma/schema/audit.prisma
@@ -17,54 +17,9 @@ enum FindingSeverity {
   low
 }
 
-enum FindingCategory {
-  // Original 6 sensitive
-  pii_email
-  pii_phone
-  pii_financial
-  pii_health
-  pii_generic
-  hardcoded_secret
-  // PCI (Group A) sensitive
-  pci_pan
-  pci_cvv
-  pci_track
-  pci_logging
-  pci_token_misuse
-  pci_last4
-  // PII extended (Group B) sensitive
-  pii_dob
-  pii_address
-  pii_national_id
-  pii_passport
-  pii_bank_account
-  pii_biometric
-  // Storage/Crypto (Group E) sensitive
-  storage_pii
-  storage_pci
-  crypto_weak
-  crypto_key
-  crypto_tls
-  // Original 6 safe
-  logging_pii
-  tracking_cookie
-  tracking_analytics_id
-  unencrypted_storage
-  third_party_transfer
-  unknown_risk
-  // Logging extended (Group C) safe
-  logging_auth
-  logging_error
-  logging_debug
-  logging_trace
-  // Transfer/Consent (Group D) safe
-  data_transfer
-  privacy_consent
-  privacy_retention
-  // SAST categories
-  security_vulnerability
-  code_quality
-}
+// [AUDIT-E3] FindingCategory: extensible — stored as String, not enum.
+// Base categories are defined in @gitgov/core/audit types.ts (BaseFindingCategory).
+// Agents can use any string as category (e.g. "firewall-disabled", "ssh-root-login").
 
 enum DetectorName {
   regex
@@ -89,7 +44,7 @@ model Finding {
   column          Int?
   message         String
   snippet         String?
-  category        FindingCategory
+  category        String
   severity        FindingSeverity
   detector        DetectorName
   confidence      Float

--- a/packages/core/src/audit/audit_types.test.ts
+++ b/packages/core/src/audit/audit_types.test.ts
@@ -17,7 +17,6 @@ import type {
   Waiver,
   PolicyDecision,
   Scan,
-  Fix,
 } from './types';
 
 // ─── Schema Parser ──────────────────────────────────────────────────────────

--- a/packages/core/src/audit/audit_types.test.ts
+++ b/packages/core/src/audit/audit_types.test.ts
@@ -9,13 +9,15 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 // ─── Type + value imports for AUDIT-A/D tests ──────────────────────────────
-import { createFinding } from './types';
+import { createFinding, createFix, createWaiver, createScan } from './types';
 import type {
   Finding,
+  FindingCategory,
   FindingSeverity,
   Waiver,
   PolicyDecision,
   Scan,
+  Fix,
 } from './types';
 
 // ─── Schema Parser ──────────────────────────────────────────────────────────
@@ -56,7 +58,7 @@ function parsePrismaSchema(schemaPath: string): PrismaModel[] {
         const name = fieldMatch[1]!;
         const rawType = fieldMatch[2]!;
         if (rawType.match(/^[A-Z]/) && !['String', 'Int', 'Float', 'Boolean', 'DateTime', 'Json', 'BigInt', 'Decimal', 'Bytes'].includes(rawType.replace('?', '').replace('[]', ''))) {
-          const knownEnums = ['FindingSeverity', 'FindingCategory', 'DetectorName'];
+          const knownEnums = ['FindingSeverity', 'DetectorName'];
           if (!knownEnums.includes(rawType.replace('?', '').replace('[]', ''))) {
             continue;
           }
@@ -344,11 +346,11 @@ describe('Audit Prisma Schema Verification (audit_prisma_record_projection_modul
       expect(fields).toContain('executionId');
     });
 
-    it('[APRJ-A3] should use Prisma enums FindingSeverity FindingCategory DetectorName', () => {
+    it('[APRJ-A3] should use Prisma enums FindingSeverity DetectorName and String for category', () => {
       const finding = auditModels.find(m => m.name === 'Finding');
       const fieldMap = Object.fromEntries(finding!.fields.map(f => [f.name, f.type]));
       expect(fieldMap['severity']).toBe('FindingSeverity');
-      expect(fieldMap['category']).toBe('FindingCategory');
+      expect(fieldMap['category']).toBe('String');
       expect(fieldMap['detector']).toBe('DetectorName');
     });
 
@@ -465,6 +467,158 @@ describe('Audit Prisma Schema Verification (audit_prisma_record_projection_modul
         { encoding: 'utf-8' },
       ).trim();
       expect(inlineFindings).toBe('');
+    });
+  });
+
+  describe('4.5. FindingCategory Extensible (AUDIT-E1 to E4)', () => {
+    const typesPath = path.resolve(__dirname, 'types.ts');
+
+    it('[AUDIT-E1] should export BaseFindingCategory with all built-in categories', () => {
+      const typesSource = fs.readFileSync(typesPath, 'utf-8');
+      expect(typesSource).toContain('export type BaseFindingCategory =');
+      expect(typesSource).toContain('"pii-email"');
+      expect(typesSource).toContain('"hardcoded-secret"');
+      expect(typesSource).toContain('"security-vulnerability"');
+      expect(typesSource).toContain('"code-quality"');
+      expect(typesSource).toContain('"unknown-risk"');
+    });
+
+    it('[AUDIT-E2] should accept custom category strings via FindingCategory type', () => {
+      const typesSource = fs.readFileSync(typesPath, 'utf-8');
+      expect(typesSource).toContain('export type FindingCategory = BaseFindingCategory | (string & {})');
+
+      const customCategory: FindingCategory = 'firewall-disabled';
+      const baseCategory: FindingCategory = 'pii-email';
+      expect(typeof customCategory).toBe('string');
+      expect(typeof baseCategory).toBe('string');
+    });
+
+    it('[AUDIT-E3] should use String type for Finding.category in Prisma schema', () => {
+      const finding = auditModels.find(m => m.name === 'Finding');
+      const fieldMap = Object.fromEntries(finding!.fields.map(f => [f.name, f.type]));
+      expect(fieldMap['category']).toBe('String');
+    });
+
+    it('[AUDIT-E4] should normalize hyphens to underscores without rejecting custom categories', () => {
+      const finding = createFinding({
+        fingerprint: 'test-fp',
+        ruleId: 'DSEC-D3',
+        file: 'device://macbook/firewall',
+        line: 0,
+        message: 'Firewall disabled',
+        snippet: 'Status: inactive',
+        category: 'firewall-disabled',
+        severity: 'high',
+        detector: 'heuristic',
+        confidence: 1.0,
+        executionId: 'test-exec',
+        reportedBy: ['device-security'],
+        isWaived: false,
+      });
+      expect(finding.category).toBe('firewall-disabled');
+      expect(finding.snippetHash).toMatch(/^[a-f0-9]{64}$/);
+    });
+  });
+
+  // ── 4.6. Waiver Factory (AUDIT-F1 to F3) ──
+
+  describe('4.6. Waiver Factory (AUDIT-F1 to F3)', () => {
+    const mockFeedback = {
+      header: { version: '1.1', type: 'feedback', payloadChecksum: 'test', signatures: [] },
+      payload: { id: 'fb-1', entityType: 'execution', entityId: 'exec-1', type: 'approval', status: 'open', content: 'waive' },
+    } as any;
+
+    it('[AUDIT-F1] should create Waiver with required fingerprint ruleId and feedback', () => {
+      const waiver = createWaiver({ fingerprint: 'sha256:abc', ruleId: 'SEC-001', feedback: mockFeedback });
+      expect(waiver.fingerprint).toBe('sha256:abc');
+      expect(waiver.ruleId).toBe('SEC-001');
+      expect(waiver.feedback).toBe(mockFeedback);
+    });
+
+    it('[AUDIT-F2] should include expiresAt when provided and omit when not', () => {
+      const date = new Date('2026-12-31');
+      const withExpiry = createWaiver({ fingerprint: 'fp', ruleId: 'R1', feedback: mockFeedback, expiresAt: date });
+      expect(withExpiry.expiresAt).toEqual(date);
+
+      const permanent = createWaiver({ fingerprint: 'fp', ruleId: 'R1', feedback: mockFeedback });
+      expect(permanent.expiresAt).toBeUndefined();
+    });
+
+    it('[AUDIT-F3] should throw when fingerprint or ruleId or feedback is missing', () => {
+      expect(() => createWaiver({ fingerprint: '', ruleId: 'R1', feedback: mockFeedback })).toThrow('fingerprint');
+      expect(() => createWaiver({ fingerprint: 'fp', ruleId: '', feedback: mockFeedback })).toThrow('ruleId');
+      expect(() => createWaiver({ fingerprint: 'fp', ruleId: 'R1', feedback: null as any })).toThrow('FeedbackRecord');
+    });
+  });
+
+  // ── 4.7. Scan Factory (AUDIT-G1 to G3) ──
+
+  describe('4.7. Scan Factory (AUDIT-G1 to G3)', () => {
+    const makeFinding = (severity: FindingSeverity, isWaived = false): Finding =>
+      createFinding({
+        fingerprint: `fp-${severity}`, ruleId: 'R1', category: 'hardcoded-secret',
+        severity, file: 'a.ts', line: 1, column: 1, message: 'test',
+        snippet: `secret-${severity}`, detector: 'regex', confidence: 1,
+        executionId: 'e1', reportedBy: ['agent:test'], isWaived,
+      });
+
+    const policyDecision: PolicyDecision = { decision: 'pass', reason: 'OK', executionId: 'e-p', blockingFindings: [], waivedFindings: [], summary: { critical: 0, high: 0, medium: 0, low: 0 }, rulesEvaluated: [], evaluatedAt: new Date().toISOString() };
+
+    it('[AUDIT-G1] should create Scan with summary computed from findings array', () => {
+      const findings = [makeFinding('critical'), makeFinding('high'), makeFinding('low')];
+      const scan = createScan({
+        scope: 'full', triggeredBy: 'user',
+        executionRecordIds: ['e1'], findings, policyDecision,
+      });
+      expect(scan.summary.critical).toBe(1);
+      expect(scan.summary.high).toBe(1);
+      expect(scan.summary.low).toBe(1);
+      expect(scan.summary.medium).toBe(0);
+      expect(scan.summary.total).toBe(3);
+    });
+
+    it('[AUDIT-G2] should guarantee summary counts equal non-waived findings count', () => {
+      const findings = [makeFinding('critical'), makeFinding('high', true), makeFinding('medium')];
+      const scan = createScan({
+        scope: 'full', triggeredBy: 'user',
+        executionRecordIds: ['e1'], findings, policyDecision,
+      });
+      const activeCount = scan.summary.critical + scan.summary.high + scan.summary.medium + scan.summary.low;
+      expect(activeCount).toBe(2); // 3 total - 1 waived
+      expect(scan.summary.suppressed).toBe(1);
+      expect(scan.summary.total).toBe(3);
+    });
+
+    it('[AUDIT-G3] should throw when scope or triggeredBy is missing', () => {
+      expect(() => createScan({
+        scope: '' as any, triggeredBy: 'user',
+        executionRecordIds: [], findings: [], policyDecision,
+      })).toThrow('scope');
+      expect(() => createScan({
+        scope: 'full', triggeredBy: '',
+        executionRecordIds: [], findings: [], policyDecision,
+      })).toThrow('triggeredBy');
+    });
+  });
+
+  // ── 4.8. Fix Factory (AUDIT-H1 to H2) ──
+
+  describe('4.8. Fix Factory (AUDIT-H1 to H2)', () => {
+    it('[AUDIT-H1] should create Fix with description and throw when empty', () => {
+      const fix = createFix({ description: 'Move to env vars' });
+      expect(fix.description).toBe('Move to env vars');
+
+      expect(() => createFix({ description: '' })).toThrow('description');
+    });
+
+    it('[AUDIT-H2] should preserve source and regulation fields in Fix', () => {
+      const fix = createFix({
+        description: 'Use vault',
+        source: 'agent:review-advisor',
+        regulation: 'PCI-DSS 3.4',
+      });
+      expect(fix.source).toBe('agent:review-advisor');
+      expect(fix.regulation).toBe('PCI-DSS 3.4');
     });
   });
 });

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -8,10 +8,11 @@
  * Also:   `import { formatAuditResult, severityBadge } from '@gitgov/core/audit'`
  */
 export { formatAuditResult, severityBadge } from "./formatter";
-export { createFinding, verifySnippet } from "./types";
+export { createFinding, verifySnippet, createFix, createWaiver, createScan } from "./types";
 
 export type {
   // Enums
+  BaseFindingCategory,
   FindingCategory,
   FindingSeverity,
   DetectorName,
@@ -44,4 +45,6 @@ export type {
   ReviewAgentResult,
   // Scan
   Scan,
+  // Fix
+  Fix,
 } from "./types";

--- a/packages/core/src/audit/testing.test.ts
+++ b/packages/core/src/audit/testing.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for audit test builders
+ *
+ * Spec: audit_record_types_module.md §4.9 (AUDIT-I1 to I3)
+ */
+import { makeTestFinding, makeTestFix, makeTestWaiver, makeTestScan } from './testing';
+import { verifySnippet } from './types';
+
+describe('Audit Test Builders', () => {
+  describe('4.9. Test Builders (AUDIT-I1 to I3)', () => {
+    it('[AUDIT-I1] should return valid Finding with defaults and accept overrides', () => {
+      const finding = makeTestFinding();
+      expect(finding.fingerprint).toBe('sha256:test-default-fingerprint');
+      expect(finding.ruleId).toBe('SEC-001');
+      expect(finding.snippetHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(verifySnippet(finding.snippet, finding.snippetHash)).toBe('verified');
+
+      const custom = makeTestFinding({ severity: 'critical', file: 'custom.ts' });
+      expect(custom.severity).toBe('critical');
+      expect(custom.file).toBe('custom.ts');
+      expect(custom.ruleId).toBe('SEC-001');
+    });
+
+    it('[AUDIT-I2] should return valid Waiver Scan and Fix with defaults', () => {
+      const fix = makeTestFix();
+      expect(fix.description).toBe('Move to environment variables');
+
+      const fixCustom = makeTestFix({ source: 'agent:review-advisor', regulation: 'PCI-DSS 3.4' });
+      expect(fixCustom.source).toBe('agent:review-advisor');
+
+      const waiver = makeTestWaiver();
+      expect(waiver.fingerprint).toBe('sha256:test-default-fingerprint');
+      expect(waiver.ruleId).toBe('SEC-001');
+      expect(waiver.feedback).toBeDefined();
+
+      const scan = makeTestScan();
+      expect(scan.scope).toBe('full');
+      expect(scan.triggeredBy).toBe('user');
+      expect(scan.summary).toBeDefined();
+      expect(scan.summary.total).toBe(0);
+
+      const scanWithFindings = makeTestScan({
+        findings: [makeTestFinding({ severity: 'critical' }), makeTestFinding({ severity: 'high', fingerprint: 'fp2', snippet: 'other' })],
+      });
+      expect(scanWithFindings.summary.critical).toBe(1);
+      expect(scanWithFindings.summary.high).toBe(1);
+      expect(scanWithFindings.summary.total).toBe(2);
+    });
+
+    it('[AUDIT-I3] should not export test builders from main audit entry', async () => {
+      const auditIndex = await import('./index');
+      expect('makeTestFinding' in auditIndex).toBe(false);
+      expect('makeTestWaiver' in auditIndex).toBe(false);
+      expect('makeTestScan' in auditIndex).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/audit/testing.test.ts
+++ b/packages/core/src/audit/testing.test.ts
@@ -31,7 +31,8 @@ describe('Audit Test Builders', () => {
       const waiver = makeTestWaiver();
       expect(waiver.fingerprint).toBe('sha256:test-default-fingerprint');
       expect(waiver.ruleId).toBe('SEC-001');
-      expect(waiver.feedback).toBeDefined();
+      expect(waiver.feedback.header.version).toBe('1.1');
+      expect(waiver.feedback.payload.type).toBe('approval');
 
       const scan = makeTestScan();
       expect(scan.scope).toBe('full');

--- a/packages/core/src/audit/testing.ts
+++ b/packages/core/src/audit/testing.ts
@@ -1,0 +1,100 @@
+/**
+ * [AUDIT-I1] [AUDIT-I2] [AUDIT-I3] Test builders for audit entities.
+ *
+ * Wrappers with sensible defaults around production factories.
+ * Export from @gitgov/core/audit/testing — NOT from main API.
+ *
+ * Usage in tests:
+ *   import { makeTestFinding, makeTestWaiver, makeTestScan, makeTestFix } from '@gitgov/core/audit/testing';
+ */
+
+import { createFinding, createFix, createWaiver, createScan } from './types';
+import type { Finding, Fix, Waiver, Scan, PolicyDecision, FindingSeverity } from './types';
+import type { GitGovFeedbackRecord } from '../record_types';
+
+// [AUDIT-I1] makeTestFinding — valid Finding with sensible defaults
+export function makeTestFinding(overrides: Partial<Omit<Finding, 'snippetHash'>> = {}): Finding {
+  return createFinding({
+    fingerprint: 'sha256:test-default-fingerprint',
+    ruleId: 'SEC-001',
+    category: 'hardcoded-secret',
+    severity: 'high' as FindingSeverity,
+    file: 'src/config.ts',
+    line: 42,
+    column: 1,
+    message: 'Hardcoded secret detected',
+    snippet: 'API_KEY = "sk_test_default_key"',
+    detector: 'regex',
+    confidence: 1.0,
+    executionId: 'exec-test-001',
+    reportedBy: ['agent:security-audit'],
+    isWaived: false,
+    ...overrides,
+  });
+}
+
+// [AUDIT-I2] makeTestFix — valid Fix with defaults
+export function makeTestFix(overrides: Partial<Fix> = {}): Fix {
+  return createFix({
+    description: 'Move to environment variables',
+    ...overrides,
+  });
+}
+
+// [AUDIT-I2] makeTestWaiver — valid Waiver with defaults
+export function makeTestWaiver(overrides: Partial<{
+  fingerprint: string;
+  ruleId: string;
+  expiresAt?: Date;
+  feedback: GitGovFeedbackRecord;
+}> = {}): Waiver {
+  const defaultFeedback = {
+    header: {
+      version: '1.1',
+      type: 'feedback',
+      payloadChecksum: 'sha256:test',
+      signatures: [{ keyId: 'human:test-user', role: 'author', notes: 'test waiver', signature: 'test-sig', timestamp: Math.floor(Date.now() / 1000) }],
+    },
+    payload: {
+      id: `${Math.floor(Date.now() / 1000)}-feedback-test-waiver`,
+      entityType: 'execution',
+      entityId: 'exec-test-001',
+      type: 'approval',
+      status: 'open',
+      content: 'Test waiver — not real credentials',
+    },
+  } as GitGovFeedbackRecord;
+
+  return createWaiver({
+    fingerprint: 'sha256:test-default-fingerprint',
+    ruleId: 'SEC-001',
+    feedback: overrides.feedback ?? defaultFeedback,
+    ...overrides,
+  });
+}
+
+// [AUDIT-I2] makeTestScan — valid Scan with computed summary
+export function makeTestScan(overrides: Partial<{
+  scope: 'full' | 'diff';
+  triggeredBy: string;
+  executionRecordIds: string[];
+  findings: Finding[];
+  policyDecision: PolicyDecision;
+  policyExecutionId?: string;
+}> = {}): Scan {
+  const defaultPolicyDecision: PolicyDecision = {
+    decision: 'pass', reason: 'No blocking findings', executionId: 'exec-policy-test',
+    blockingFindings: [], waivedFindings: [],
+    summary: { critical: 0, high: 0, medium: 0, low: 0 },
+    rulesEvaluated: [], evaluatedAt: new Date().toISOString(),
+  };
+
+  return createScan({
+    scope: 'full',
+    triggeredBy: 'user',
+    executionRecordIds: ['exec-test-001'],
+    findings: [],
+    policyDecision: overrides.policyDecision ?? defaultPolicyDecision,
+    ...overrides,
+  });
+}

--- a/packages/core/src/audit/types.ts
+++ b/packages/core/src/audit/types.ts
@@ -27,9 +27,10 @@ import type { SarifLog } from "../sarif/sarif.types";
 // ─── Enums ────────────────────────────────────────────────────────────────────
 
 /**
- * Finding categories detectable by the Audit product.
+ * [AUDIT-E1] Base finding categories built into core. Agents get autocomplete for these
+ * values while remaining free to use any string as a category.
  */
-export type FindingCategory =
+export type BaseFindingCategory =
   // Original 6 sensitive
   | "pii-email"
   | "pii-phone"
@@ -76,6 +77,13 @@ export type FindingCategory =
   // SAST categories (semgrep, CodeQL, etc.)
   | "security-vulnerability"
   | "code-quality";
+
+/**
+ * [AUDIT-E2] Extensible finding category. Accepts any BaseFindingCategory with
+ * autocomplete, plus any custom string from third-party agents
+ * (e.g. "firewall-disabled", "ssh-root-login", "device-identity-mismatch").
+ */
+export type FindingCategory = BaseFindingCategory | (string & {});
 
 /**
  * Severity levels for governance prioritization.
@@ -224,7 +232,7 @@ export interface Finding {
 
   // ── Remediation ──
   /** Proposed fixes — SARIF §3.55.4 standard */
-  fixes?: Array<{ description: string }>;
+  fixes?: Fix[];
   /** Legal reference (e.g., "GDPR Art. 5(1)(f)") */
   legalReference?: string;
 
@@ -482,4 +490,73 @@ export function verifySnippet(snippet: string, snippetHash: string): 'verified' 
   if (snippet.includes('[REDACTED]')) return null;
   const computed = createHash('sha256').update(snippet).digest('hex');
   return computed === snippetHash ? 'verified' : 'unverified';
+}
+
+// ─── Fix Type ─────────────────────────────────────────────────────────────────
+
+/** Proposed remediation for a finding — SARIF §3.55.4 */
+export type Fix = {
+  /** Description of the fix (required) */
+  description: string;
+  /** Source that suggested the fix (e.g. "agent:review-advisor", "human:ciso") */
+  source?: string;
+  /** Regulatory reference (e.g. "PCI-DSS 3.4") */
+  regulation?: string;
+};
+
+// ─── Entity Factories ─────────────────────────────────────────────────────────
+
+/**
+ * [AUDIT-H1] [AUDIT-H2] Factory for creating Fix objects with validation.
+ */
+export function createFix(input: { description: string; source?: string; regulation?: string }): Fix {
+  if (!input.description) throw new Error('Fix requires description');
+  return { ...input };
+}
+
+/**
+ * [AUDIT-F1] [AUDIT-F2] [AUDIT-F3] Factory for creating Waiver objects with validation.
+ * A Waiver without fingerprint, ruleId, or signed FeedbackRecord is invalid.
+ */
+export function createWaiver(input: {
+  fingerprint: string;
+  ruleId: string;
+  expiresAt?: Date;
+  feedback: import('../record_types').GitGovFeedbackRecord;
+}): Waiver {
+  if (!input.fingerprint) throw new Error('Waiver requires fingerprint');
+  if (!input.ruleId) throw new Error('Waiver requires ruleId');
+  if (!input.feedback) throw new Error('Waiver requires signed FeedbackRecord');
+  return { ...input };
+}
+
+/**
+ * [AUDIT-G1] [AUDIT-G2] [AUDIT-G3] Factory for creating Scan objects with computed summary.
+ * Guarantees summary counts match the findings array.
+ */
+export function createScan(input: {
+  scope: ScanScope;
+  triggeredBy: string;
+  executionRecordIds: string[];
+  findings: Finding[];
+  policyDecision: PolicyDecision;
+  policyExecutionId?: string;
+}): Scan {
+  if (!input.scope) throw new Error('Scan requires scope');
+  if (!input.triggeredBy) throw new Error('Scan requires triggeredBy');
+
+  // [AUDIT-G2] Compute summary from findings — guaranteed coherent
+  const active = input.findings.filter(f => !f.isWaived);
+  const summary: AuditSummary = {
+    critical: active.filter(f => f.severity === 'critical').length,
+    high: active.filter(f => f.severity === 'high').length,
+    medium: active.filter(f => f.severity === 'medium').length,
+    low: active.filter(f => f.severity === 'low').length,
+    total: input.findings.length,
+    suppressed: input.findings.filter(f => f.isWaived).length,
+    agentsRun: input.executionRecordIds.length,
+    agentsFailed: 0,
+  };
+
+  return { ...input, summary };
 }

--- a/packages/core/src/finding_detector/detectors/http_llm_detector.ts
+++ b/packages/core/src/finding_detector/detectors/http_llm_detector.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto";
 import type {
   CodeSnippet,
+  BaseFindingCategory,
   Finding,
-  FindingCategory,
   LlmDetector,
   LlmRawFinding,
 } from "../types";
@@ -32,25 +32,23 @@ function truncateSnippet(snippet: string): string {
   return snippet.slice(0, MAX_SNIPPET_LENGTH - 3) + "...";
 }
 
-/**
- * Validates if a category string is a valid FindingCategory.
- */
-function isValidCategory(category: string): category is FindingCategory {
-  const validCategories: FindingCategory[] = [
-    "pii-email",
-    "pii-phone",
-    "pii-financial",
-    "pii-health",
-    "pii-generic",
-    "hardcoded-secret",
-    "logging-pii",
-    "tracking-cookie",
-    "tracking-analytics-id",
-    "unencrypted-storage",
-    "third-party-transfer",
-    "unknown-risk",
-  ];
-  return validCategories.includes(category as FindingCategory);
+const LLM_KNOWN_CATEGORIES: BaseFindingCategory[] = [
+  "pii-email",
+  "pii-phone",
+  "pii-financial",
+  "pii-health",
+  "pii-generic",
+  "hardcoded-secret",
+  "logging-pii",
+  "tracking-cookie",
+  "tracking-analytics-id",
+  "unencrypted-storage",
+  "third-party-transfer",
+  "unknown-risk",
+];
+
+function isKnownCategory(category: string): category is BaseFindingCategory {
+  return (LLM_KNOWN_CATEGORIES as string[]).includes(category);
 }
 
 /**
@@ -102,7 +100,7 @@ export class HttpLlmDetector implements LlmDetector {
    */
   private normalizeFindings(rawFindings: LlmRawFinding[]): Finding[] {
     return rawFindings.map((raw) => {
-      const category: FindingCategory = isValidCategory(raw.category)
+      const category = isKnownCategory(raw.category)
         ? raw.category
         : "unknown-risk";
 

--- a/packages/core/src/finding_detector/index.ts
+++ b/packages/core/src/finding_detector/index.ts
@@ -4,6 +4,7 @@ export type {
   Detector,
   DetectorConfig,
   DetectorName,
+  BaseFindingCategory,
   FindingCategory,
   FindingSeverity,
   Finding,

--- a/packages/core/src/finding_detector/types.ts
+++ b/packages/core/src/finding_detector/types.ts
@@ -10,6 +10,7 @@
 
 export type {
   Finding,
+  BaseFindingCategory,
   FindingCategory,
   FindingSeverity,
   DetectorName,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,6 +105,7 @@ export type { ILlmProvider, LlmMessage, LlmTool, LlmResponse, LlmProviderConfig 
 // ─── Audit product types (canonical, from @gitgov/core/audit) ────────────────
 export type {
   Finding,
+  BaseFindingCategory,
   FindingCategory,
   FindingSeverity,
   DetectorName,
@@ -127,10 +128,11 @@ export type {
   AgentAuditResult,
   ReviewAgentResult,
   Scan,
+  Fix,
 } from "./audit/index";
 
 // Audit value exports (factories)
-export { createFinding } from "./audit/index";
+export { createFinding, createFix, createWaiver, createScan } from "./audit/index";
 
 // ─── Non-audit type exports (module-specific) ───────────────────────────────
 export type { AuditOrchestrationOptions, AuditOrchestratorDeps } from "./audit_orchestrator/index";

--- a/packages/e2e/prisma/schema/audit.prisma
+++ b/packages/e2e/prisma/schema/audit.prisma
@@ -1,7 +1,7 @@
 // ⚠️ COPIED from core — DO NOT EDIT
 // Source: packages/core/prisma/schema/
 // Re-generate: pnpm prisma:sync (in packages/e2e)
-// Synced at: 2026-06-24T12:24:46.304Z
+// Synced at: 2026-07-31T18:25:10.599Z
 
 // GitGovernance Core — Audit Product Projection Tables
 // Finding, Waiver, Scan — derived from protocol records
@@ -22,25 +22,15 @@ enum FindingSeverity {
   low
 }
 
-enum FindingCategory {
-  pii_email
-  pii_phone
-  pii_financial
-  pii_health
-  pii_generic
-  hardcoded_secret
-  logging_pii
-  tracking_cookie
-  tracking_analytics_id
-  unencrypted_storage
-  third_party_transfer
-  unknown_risk
-}
+// FindingCategory: extensible — stored as String, not enum.
+// Base categories are defined in @gitgov/core/audit types.ts (BaseFindingCategory).
+// Agents can use any string as category (e.g. "firewall-disabled", "ssh-root-login").
 
 enum DetectorName {
   regex
   heuristic
   llm
+  sast
 }
 
 // ──────────────────────────────────────────
@@ -59,7 +49,7 @@ model Finding {
   column          Int?
   message         String
   snippet         String?
-  category        FindingCategory
+  category        String
   severity        FindingSeverity
   detector        DetectorName
   confidence      Float

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,43 @@ importers:
         specifier: workspace:*
         version: link:../../core
     devDependencies:
+      '@semantic-release/git':
+        specifier: ^10.0.1
+        version: 10.0.1(semantic-release@22.0.12(typescript@5.9.2))
+      '@semantic-release/github':
+        specifier: ^9.2.6
+        version: 9.2.6(semantic-release@22.0.12(typescript@5.9.2))
+      '@types/jest':
+        specifier: ^29.0.0
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.13
+      conventional-changelog-conventionalcommits:
+        specifier: ^7.0.2
+        version: 7.0.2
+      esbuild:
+        specifier: ^0.19.0
+        version: 0.19.12
+      jest:
+        specifier: ^29.0.0
+        version: 29.7.0(@types/node@20.19.13)
+      semantic-release:
+        specifier: ^22.0.12
+        version: 22.0.12(typescript@5.9.2)
+      ts-jest:
+        specifier: ^29.0.0
+        version: 29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.13))(typescript@5.9.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.2
+
+  packages/agents/semgrep:
+    dependencies:
+      '@gitgov/core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
       '@types/jest':
         specifier: ^29.0.0
         version: 29.5.14
@@ -120,6 +157,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@gitgov/agent-security-audit':
+        specifier: workspace:*
+        version: link:../agents/security-audit
       '@gitgov/core':
         specifier: workspace:*
         version: link:../core
@@ -2174,6 +2214,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}


### PR DESCRIPTION
## Summary

- **FindingCategory extensible:** `BaseFindingCategory | (string & {})` — AUDIT-E1..E4, 18/18 EARS green
- **Prisma:** FindingCategory enum → String column (schema + prisma:sync + generate)
- **Semgrep CWE fix:** CWE-89/79/22/78/94/502 → security-vulnerability (aligned with spec SGP-C3)
- **Agent packages:** added `gitgov.agent.categories` field, semantic-release devDeps, fixed workspace:* → peerDeps pattern
- **CLI bundling:** `@gitgov/agent-security-audit` as dependency (zero-friction install)

## Test plan

- [x] Core: 3051 tests green (125 suites)
- [x] security-audit: 29/29 green
- [x] semgrep: 27/27 green
- [ ] After merge: trigger "Release Agent — security-audit" workflow_dispatch
- [ ] Verify: `npm view @gitgov/agent-security-audit version` returns published version