### PR TITLE
test(core): the PROJ-H3b anti-vacuity control demands a third getActor call

### DIFF
--- a/packages/core/src/project_module/project_module.test.ts
+++ b/packages/core/src/project_module/project_module.test.ts
@@ -969,7 +969,10 @@ describe('ProjectModule', () => {
       expect(result.actorId).toBe('human:late-visible');
       // Anti-vacuity: a green here would be meaningless if the guard had found the actor
       // on the first read — the polling is only exercised when it had to retry.
-      expect(getActorCalls).toBeGreaterThan(1);
+      // Calibration: addActor reads getActor once unconditionally (the existence check at
+      // the top) and the guard reads once more before it ever polls, so a guard WITHOUT a
+      // poll loop already produces 2 calls. Only a third call proves the retry happened.
+      expect(getActorCalls).toBeGreaterThan(2);
     });
 
     it('[PROJ-H3b] should throw GIT_WRITE_FAILED when finalize fails and actor not in store', async () => {


### PR DESCRIPTION
## Summary

The `PROJ-H3b` anti-vacuity control demanded a second `getActor` call, but the behavior it guards only becomes observable on the third call. The test now asserts the third call, so it fails when the guarded behavior is removed and passes when it is present.

## Verification

- `project_module` suite green with the control in place; the assertion goes red when the guarded call is removed.
